### PR TITLE
FreeType inclusion

### DIFF
--- a/source/ftlib/ftlib.c
+++ b/source/ftlib/ftlib.c
@@ -30,10 +30,10 @@ static qfontface_t fontFaces[FTLIB_MAX_FONT_FACES];
 // ============================================================================
 
 #include <ft2build.h>
+#include FT_FREETYPE_H
 #include FT_ERRORS_H
 #include FT_SYSTEM_H
 #include FT_IMAGE_H
-#include FT_FREETYPE_H
 #include FT_OUTLINE_H
 
 #define QFT_DIR						"fonts"


### PR DESCRIPTION
Compiling the ftlib module failed with errors inside the FT_ERRORS_H inclusion for me.
At first I thought this was a problem with my version of the library, but some page said the main header file should be included first.
I don't know why others do not seem to have that issue, but this fixes it for me.
