### PR TITLE
Screenshot formatstring formatting mixup

### DIFF
--- a/source/ref_gl/r_register.c
+++ b/source/ref_gl/r_register.c
@@ -713,7 +713,7 @@ static void R_Register( const char *screenshotsPrefix )
 
 	r_screenshot_jpeg = ri.Cvar_Get( "r_screenshot_jpeg", "1", CVAR_ARCHIVE );
 	r_screenshot_jpeg_quality = ri.Cvar_Get( "r_screenshot_jpeg_quality", "90", CVAR_ARCHIVE );
-	r_screenshot_fmtstr = ri.Cvar_Get( "r_screenshot_fmtstr", va( "%s%y%m%d_%H%M%S", screenshotsPrefix ), CVAR_ARCHIVE );
+	r_screenshot_fmtstr = ri.Cvar_Get( "r_screenshot_fmtstr", va( "%s%y%%m%%d_%H%M%%S", screenshotsPrefix ), CVAR_ARCHIVE );
 
 #ifdef GLX_VERSION
 	r_swapinterval = ri.Cvar_Get( "r_swapinterval", "0", CVAR_ARCHIVE|CVAR_LATCH_VIDEO );


### PR DESCRIPTION
The default screenshot format string conflicts with its own formatting.
Unintended format specifiers interpreted by the va function need to be escaped.

Somehow I start getting segfaults from this two weeks after its introduction.
