### PR TITLE
Round normal FPS display

### DIFF
--- a/source/cgame/cg_hud.cpp
+++ b/source/cgame/cg_hud.cpp
@@ -174,7 +174,7 @@ static int CG_GetFPS( const void *parameter )
 			avFrameTime += frameTimes[( cg.frameCount-i ) & FPSSAMPLESMASK];
 		}
 		avFrameTime /= FPSSAMPLESCOUNT;
-		fps = (int)( 1.0f/avFrameTime );
+		fps = (int)( 1.0f/avFrameTime + 0.5f );
 	}
 	else
 	{


### PR DESCRIPTION
For cg_showFPS > 0 and not 2, the value displayed is not rounded.
It just looks silly to have 124 shown all the time while the value is probably very close to 125.
cg_showFPS = 2 also has its output rounded.
