### PR TITLE
Map caching

### DIFF
--- a/source/qcommon/mlist.c
+++ b/source/qcommon/mlist.c
@@ -396,9 +396,10 @@ void ML_Init( void )
 	else
 		ML_InitFromMaps();
 
+	ml_initialized = qtrue;
+
 	ML_BuildCache();
 
-	ml_initialized = qtrue;
 	ml_flush = qtrue;
 }
 
@@ -413,11 +414,11 @@ void ML_Shutdown( void )
 	if( !ml_initialized )
 		return;
 
+	ML_BuildCache();
+
 	ml_initialized = qfalse;
 
 	Cmd_RemoveCommand( "maplist" );
-
-	ML_BuildCache();
 
 	Trie_Destroy( mlist_filenames_trie );
 	Trie_Destroy( mlist_fullnames_trie );

--- a/source/qcommon/mlist.c
+++ b/source/qcommon/mlist.c
@@ -571,19 +571,20 @@ qboolean ML_FilenameExists( const char *filename )
 const char *ML_GetFullname( const char *filename )
 {
 	mapinfo_t *map;
-	char *filepath;
+	//char *filepath;
 
 	if( !ml_initialized )
 		return MLIST_NULL;
 
+	if( !ML_ValidateFilename( filename ) )
+		return MLIST_NULL;
+
+	/*
 	filepath = va( "maps/%s.bsp", filename );
 	COM_SanitizeFilePath( filepath );
 
-	if( !ML_ValidateFilename( filename ) )
-		return MLIST_NULL;
-	/*
 	if( FS_FOpenFile( filepath, NULL, FS_READ ) == -1 )
-	return MLIST_NULL;
+		return MLIST_NULL;
 	*/
 
 	if( Trie_Find( mlist_filenames_trie, filename, TRIE_EXACT_MATCH, (void **)&map ) == TRIE_OK )

--- a/source/qcommon/mlist.c
+++ b/source/qcommon/mlist.c
@@ -582,7 +582,7 @@ const char *ML_GetFullname( const char *filename )
 	filepath = va( "maps/%s.bsp", filename );
 	COM_SanitizeFilePath( filepath );
 
-	if( !ML_ValidateFilename( filepath ) )
+	if( !ML_ValidateFilename( filename ) )
 		return MLIST_NULL;
 	/*
 	if( FS_FOpenFile( filepath, NULL, FS_READ ) == -1 )

--- a/source/qcommon/mlist.c
+++ b/source/qcommon/mlist.c
@@ -397,9 +397,6 @@ void ML_Init( void )
 		ML_InitFromMaps();
 
 	ml_initialized = qtrue;
-
-	ML_BuildCache();
-
 	ml_flush = qtrue;
 }
 


### PR DESCRIPTION
In the first Warsow 0.7 beta, the "ml_initialized = qfalse" was moved up in ML_Shutdown, causing the ML_BuildCache call to do nothing.
The same already held for the ML_BuildCache call in ML_Init, but that was useless anyway.

Also fixed a bug in ML_GetFullname which made it return an empty string all the time. This function wasn't actually used at all until G_VoteMapWebRequest was added.

On a related note, the Warsow ui code for the local game tab uses the long map name to start the server, but this name is not guaranteed to be unique (there are over 40 "Made By Pornstar" racemaps).
To fix this, line 85 of ui/porkui/game_local.rml should read "map = data.getField( 'list', selectedRow, 'name' );".
