### PR TITLE
Premake

### DIFF
--- a/source/angelwrap/angelwrap.premake
+++ b/source/angelwrap/angelwrap.premake
@@ -1,0 +1,19 @@
+project "angelwrap"
+
+    kind         "SharedLib"
+    language     "C++"
+    qf_targetdir "libs"
+    
+    files    { 
+        "*.h",
+        "addon/*.h",
+        "../gameshared/q_angeliface.h",
+        "../gameshared/q_math.h",
+        "../gameshared/q_shared.h",
+        "*.cpp",
+        "addon/*.cpp",
+        "../gameshared/q_math.c",
+        "../gameshared/q_shared.c",
+    }
+
+    qf_links { "angelscript" }

--- a/source/cgame/cgame.premake
+++ b/source/cgame/cgame.premake
@@ -1,0 +1,30 @@
+project "cgame"
+
+    kind         "SharedLib"
+    language     "C++"
+    qf_targetdir "base"
+    
+    files    { 
+        "*.h",
+        "../gameshared/config.h",
+        "../gameshared/gs_public.h",
+        "../gameshared/gs_qrespath.h",
+        "../gameshared/q_arch.h",
+        "../gameshared/q_collision.h",
+        "../gameshared/q_comref.h",
+        "../gameshared/q_cvar.h",
+        "../gameshared/q_dynvar.h",
+        "../gameshared/q_math.h",
+        "../gameshared/q_shared.h",
+        "*.cpp",
+        "../gameshared/gs_gameteams.c",
+        "../gameshared/gs_items.c",
+        "../gameshared/gs_misc.c",
+        "../gameshared/gs_players.c",
+        "../gameshared/gs_pmove.c",
+        "../gameshared/gs_slidebox.c",
+        "../gameshared/gs_weapondefs.c",
+        "../gameshared/gs_weapons.c",
+        "../gameshared/q_math.c",
+        "../gameshared/q_shared.c",
+    }

--- a/source/cin/cin.premake
+++ b/source/cin/cin.premake
@@ -1,0 +1,17 @@
+project "cin"
+
+    kind         "SharedLib"
+    language     "C"
+    qf_targetdir "libs"
+    
+    files    { 
+        "*.h",
+        "../gameshared/q_math.h",
+        "../gameshared/q_shared.h",
+        "*.c",
+        "../gameshared/q_math.c",
+        "../gameshared/q_shared.c",
+    }
+
+    qf_links { "ogg", "vorbis", "theora" }
+

--- a/source/ftlib/ftlib.premake
+++ b/source/ftlib/ftlib.premake
@@ -1,0 +1,17 @@
+project "ftlib"
+
+    kind         "SharedLib"
+    language     "C"
+    qf_targetdir "libs"
+    
+    files    { 
+        "*.h",
+        "../gameshared/q_math.h",
+        "../gameshared/q_shared.h",
+        "*.c",
+        "../gameshared/q_math.c",
+        "../gameshared/q_shared.c",
+    }
+
+    qf_links { "freetype" }
+            

--- a/source/game/game.premake
+++ b/source/game/game.premake
@@ -1,0 +1,37 @@
+project "game"
+
+    kind         "SharedLib"
+    language     "C++"
+    qf_targetdir "base"
+    
+    files    { 
+        "*.h",
+        "ai/*.h",
+        "../gameshared/anorms.h",
+        "../gameshared/config.h",
+        "../gameshared/gs_public.h",
+        "../gameshared/gs_qrespath.h",
+        "../gameshared/gs_ref.h",
+        "../matchmaker/mm_rating.h",
+        "../gameshared/q_angeliface.h",
+        "../gameshared/q_arch.h",
+        "../gameshared/q_collision.h",
+        "../gameshared/q_comref.h",
+        "../gameshared/q_cvar.h",
+        "../gameshared/q_dynvar.h",
+        "../gameshared/q_math.h",
+        "../gameshared/q_shared.h",
+        "*.cpp",
+        "ai/*.cpp",
+        "../gameshared/gs_gameteams.c",
+        "../gameshared/gs_items.c",
+        "../gameshared/gs_misc.c",
+        "../gameshared/gs_players.c",
+        "../gameshared/gs_pmove.c",
+        "../gameshared/gs_slidebox.c",
+        "../gameshared/gs_weapondefs.c",
+        "../gameshared/gs_weapons.c",
+        "../matchmaker/mm_rating.c",
+        "../gameshared/q_math.c",
+        "../gameshared/q_shared.c",
+    }   

--- a/source/irc/irc.premake
+++ b/source/irc/irc.premake
@@ -1,0 +1,16 @@
+project "irc"
+
+    kind     "SharedLib"
+    language "C"
+    
+    files    { 
+        "*.h",
+        "../gameshared/q_shared.h",
+        "*.c",
+        "../gameshared/q_shared.c",
+    }
+
+    configuration "windows"
+        links { "ws2_32" }
+
+    configuration "macosx"

--- a/source/irc/irc.premake
+++ b/source/irc/irc.premake
@@ -12,5 +12,3 @@ project "irc"
 
     configuration "windows"
         links { "ws2_32" }
-
-    configuration "macosx"

--- a/source/premake4.lua
+++ b/source/premake4.lua
@@ -31,6 +31,14 @@ solution "qfusion"
             windows = { "libjpegstat" },
             linux   = { "jpeg" } 
         },
+        curl = {
+            windows = { "libcurlstat" },
+            linux   = { "curl" }
+        },
+        z = {
+            windows = { "zlibstat" },
+            linux   = { "z" }
+        }
     }
 
     function qf_links(libs) 

--- a/source/premake4.lua
+++ b/source/premake4.lua
@@ -133,3 +133,14 @@ solution "qfusion"
     dofile "ui/ui.premake"
     dofile "qfusion.premake"
     dofile "qfusion_server.premake"
+
+    function prebuild_linux_deps()
+        os.execute("cd ../libsrcs/angelscript/sdk/angelscript/projects/gnuc && make")
+        os.execute("cd ../libsrcs/libRocket/libRocket/Build && make -f Makefile.qfusion")
+    end
+
+    newaction {
+        trigger     = "linux_deps",
+        description = "Build linux dependecies",
+        execute     = prebuild_linux_deps
+    }

--- a/source/premake4.lua
+++ b/source/premake4.lua
@@ -1,0 +1,127 @@
+solution "qfusion"
+    configurations { "Debug", "Release" }
+    platforms { "x32", "x64" }
+    
+    qf_libs = {
+        angelscript = {
+            windows = { "angelscript" },
+            linux   = { "angelscript" }
+        },
+        ogg = {
+            windows = { "libogg_static" },
+            linux   = { "ogg" }
+        },
+        vorbis = {
+            windows = { "libvorbis_static", "libvorbisfile_static" },
+            linux   = { "vorbis" }
+        },
+        theora = {
+            windows = { "libtheora_static" },
+            linux   = { "theora" } 
+        },
+        freetype = {
+            windows = { "libfreetypestat" },
+            linux   = { "freetype" } 
+        },
+        png = {
+            windows = { "libpngstat", "zlibstat" },
+            linux   = { "png", "z" } 
+        },
+        jpeg = {
+            windows = { "libjpegstat" },
+            linux   = { "jpeg" } 
+        },
+    }
+
+    function qf_links(libs) 
+        local platform_libs = {}
+
+        for i, lib in ipairs(libs) do
+            if qf_libs[lib] then
+                for j, platform_lib in ipairs(qf_libs[lib][os.get()]) do
+                    table.insert(platform_libs, platform_lib)
+                end
+            else
+                table.insert(platform_libs, lib)
+            end
+        end
+
+        links(platform_libs)
+    end
+
+    function qf_targetdir(dir)
+        cfg = configuration()
+        
+        configuration { cfg.terms, "Debug" }
+        targetdir ("../build/debug/" .. dir)
+
+        configuration { cfg.terms, "Release" }
+        targetdir ("../build/release/" .. dir)
+
+        configuration(cfg.terms)
+    end
+
+    configuration "Debug"
+        targetdir "build/debug"
+        objdir    "build/debug/obj"
+        defines   { "_DEBUG", "DEBUG" }
+        flags     { "Symbols" }
+        
+    configuration "Release"
+        targetdir "build/release"
+        objdir    "build/release/obj"
+        defines   { "NDEBUG" }
+        flags     { "Optimize" }
+
+    configuration "vs*"
+        flags        { "StaticRuntime" }
+        targetsuffix "_$(PlatformShortName)"
+        defines      { "WIN32", "_WINDOWS", "_CRT_SECURE_NO_WARNINGS", "_SECURE_SCL=0", "CURL_STATICLIB" }
+
+        includedirs {
+            "../libsrcs/libogg/include",
+            "../libsrcs/libvorbis/include",
+            "../libsrcs/libtheora/include",
+            "../libsrcs/libcurl/include",
+            "../libsrcs/angelscript/sdk/angelscript/include",
+            "../libsrcs/zlib",
+            "../libsrcs/libfreetype/include",
+            "../libsrcs/libpng",
+            "../libsrcs/libjpeg",
+            "win32/include/msvc",
+            "win32/include",
+        }
+
+    configuration {"vs*", "Debug"}
+        libdirs { "win32/x86/lib/debug" }
+
+    configuration {"vs*", "Release"}
+        libdirs { "win32/x86/lib/release" }
+
+    configuration "linux"
+        targetprefix ""
+        targetsuffix "_x86_64"
+        
+        includedirs {
+            "/usr/include/SDL", -- #include "SDL.h" instead of #include "SDL/SDL.h" in unix_snd.c
+            "/usr/include/freetype2",
+            "../libsrcs/angelscript/sdk/angelscript/include",
+        }
+
+        libdirs {
+            "../libsrcs/angelscript/sdk/angelscript/lib" 
+        }
+
+    dofile "angelwrap/angelwrap.premake"
+    dofile "cgame/cgame.premake"
+    dofile "cin/cin.premake"
+    dofile "ftlib/ftlib.premake"
+    dofile "game/game.premake"
+    dofile "irc/irc.premake"
+    dofile "ref_gl/ref_gl.premake"
+    dofile "snd_openal/snd_openal.premake"
+    dofile "snd_qf/snd_qf.premake"
+    dofile "tv_server/tv_server.premake"
+    dofile "ui/ui.premake"
+    dofile "qfusion.premake"
+    dofile "qfusion_server.premake"

--- a/source/qfusion.premake
+++ b/source/qfusion.premake
@@ -31,7 +31,7 @@ project "qfusion"
             "gameshared/q_shared.c",
         }
 
-        qf_links { "cin", "curl", "z" }
+        qf_links { "curl", "z" }
 
         configuration "windows"
             files {

--- a/source/qfusion.premake
+++ b/source/qfusion.premake
@@ -29,7 +29,9 @@ project "qfusion"
             "matchmaker/*.c",
             "gameshared/q_math.c",
             "gameshared/q_shared.c",
-          }
+        }
+
+        qf_links { "cin", "curl", "z" }
 
         configuration "windows"
             files {
@@ -47,7 +49,7 @@ project "qfusion"
                 "win32/qfusion.rc",
             }
 
-            links { "cin", "libcurlstat", "zlibstat", "winmm", "ws2_32", "dxguid" }
+            links { "winmm", "ws2_32", "dxguid" }
 
         configuration "linux"
             files {
@@ -60,4 +62,4 @@ project "qfusion"
                 "unix/unix_input.c",
             }
 
-            links { "curl", "z", "pthread", "dl", "rt", "X11", "Xext", "Xxf86dga"}
+            links { "pthread", "dl", "rt", "X11", "Xext", "Xxf86dga"}

--- a/source/qfusion.premake
+++ b/source/qfusion.premake
@@ -1,0 +1,63 @@
+project "qfusion"
+
+        kind     "WindowedApp"
+        language "C++"
+        flags    { "WinMain" }
+
+        configuration "vs*"
+            libdirs { "$(DXSDK_DIR)/Lib/x86" }
+        configuration {}
+        
+        files {
+            "cin/cin_public.h",
+            "ftlib/ftlib_public.h",
+            "cgame/cg_public.h",
+            "ref_gl/r_public.h",
+            "ref_gl/iqm.h",
+            "ui/ui_public.h",
+            "server/server.h",
+            "cgame/ref.h",
+            "matchmaker/*.h",
+            "gameshared/*.h",
+            "qalgo/*.h",
+            "qcommon/*.h",
+            "client/*.h",
+            "qalgo/*.c",
+            "qcommon/*.c",
+            "client/*.c",
+            "server/*.c",
+            "matchmaker/*.c",
+            "gameshared/q_math.c",
+            "gameshared/q_shared.c",
+          }
+
+        configuration "windows"
+            files {
+                "win32/winquake.h",
+                "win32/resource.h",
+                "win32/conproc.h",
+                "win32/conproc.c",
+                "win32/win_fs.c",
+                "win32/win_input.c",
+                "win32/win_lib.c",
+                "win32/win_net.c",
+                "win32/win_sys.c",
+                "win32/win_threads.c",
+                "win32/win_vid.c",
+                "win32/qfusion.rc",
+            }
+
+            links { "cin", "libcurlstat", "zlibstat", "winmm", "ws2_32", "dxguid" }
+
+        configuration "linux"
+            files {
+                "unix/unix_fs.c",
+                "unix/unix_net.c",
+                "unix/unix_sys.c",
+                "unix/unix_lib.c",
+                "unix/unix_threads.c",
+                "unix/unix_vid.c",
+                "unix/unix_input.c",
+            }
+
+            links { "curl", "z", "pthread", "dl", "rt", "X11", "Xext", "Xxf86dga"}

--- a/source/qfusion_server.premake
+++ b/source/qfusion_server.premake
@@ -1,0 +1,47 @@
+ project "qfusion_server"
+
+    kind     "WindowedApp"
+    language "C++"
+
+    flags   { "WinMain"}
+    defines { "DEDICATED_ONLY" }
+
+    files {
+        "matchmaker/*.h",
+        "gameshared/*.h",
+        "qalgo/*.h",
+        "qcommon/*.h",
+        "server/server.h",
+        "qalgo/*.c",
+        "qcommon/*.c",
+        "matchmaker/*.c",
+        "server/*.c",
+        "null/cl_null.c",
+        "gameshared/q_math.c",
+        "gameshared/q_shared.c",
+    }
+
+    configuration "windows"
+        files {
+            "win32/conproc.h",
+            "win32/winquake.h",
+            "win32/win_fs.c",
+            "win32/win_net.c",
+            "win32/win_sys.c",
+            "win32/win_lib.c",
+            "win32/win_threads.c",       
+            "win32/conproc.c",
+        }
+
+        links { "libcurlstat", "zlibstat", "winmm", "ws2_32" }
+
+    configuration "linux"
+        files {
+            "unix/unix_fs.c",
+            "unix/unix_net.c",
+            "unix/unix_lib.c",
+            "unix/unix_sys.c",
+            "unix/unix_threads.c",
+        }
+
+        links { "curl", "z", "pthread", "dl" }

--- a/source/qfusion_server.premake
+++ b/source/qfusion_server.premake
@@ -21,6 +21,8 @@
         "gameshared/q_shared.c",
     }
 
+    qf_links { "curl", "z" }
+
     configuration "windows"
         files {
             "win32/conproc.h",
@@ -33,7 +35,7 @@
             "win32/conproc.c",
         }
 
-        links { "libcurlstat", "zlibstat", "winmm", "ws2_32" }
+        links { "winmm", "ws2_32" }
 
     configuration "linux"
         files {
@@ -44,4 +46,4 @@
             "unix/unix_threads.c",
         }
 
-        links { "curl", "z", "pthread", "dl" }
+        links { "pthread", "dl" }

--- a/source/ref_gl/ref_gl.premake
+++ b/source/ref_gl/ref_gl.premake
@@ -1,0 +1,42 @@
+project "ref_gl"
+
+    kind         "SharedLib"
+    language     "C"
+    qf_targetdir "libs"
+    
+    files    { 
+        "*.h",
+        "../cgame/ref.h",
+        "../gameshared/anorms.h",
+        "../gameshared/config.h",
+        "../gameshared/q_arch.h",
+        "../gameshared/q_cvar.h",
+        "../gameshared/q_math.h",
+        "../gameshared/q_shared.h",
+        "../qcommon/patch.h",
+        "../gameshared/q_trie.h",
+        "*.c",
+        "../gameshared/q_math.c",
+        "../gameshared/q_shared.c",
+        "../qalgo/hash.c",
+        "../qcommon/bsp.c",
+        "../qcommon/patch.c",
+        "../qalgo/q_trie.c",
+    }
+
+    qf_links { "png", "jpeg" }
+
+    configuration "windows"
+        files {
+            "../win32/win_glw.c",
+            "../win32/win_qgl.c",
+        }
+
+    configuration "linux"
+        files {
+            "../unix/unix_glw.c",
+            "../unix/unix_qgl.c",
+            "../unix/unix_xpm.c",
+        }
+
+        links { "X11", "Xext", "Xinerama", "Xrandr", "Xxf86vm" }

--- a/source/snd_openal/snd_openal.premake
+++ b/source/snd_openal/snd_openal.premake
@@ -1,7 +1,7 @@
 project "snd_openal"
 
-    kind      "SharedLib"
-    language  "C"
+    kind         "SharedLib"
+    language     "C"
     qf_targetdir "libs"
 
     files    { 
@@ -14,9 +14,4 @@ project "snd_openal"
         "../gameshared/q_shared.c",
     }
 
-    configuration "windows"
-        links { "libogg_static", "libvorbis_static", "libvorbisfile_static" }
-
-    configuration "macosx"
-        links { "Ogg.framework", "Vorbis.framework" }
-        
+    qf_links { "ogg", "vorbis" }      

--- a/source/snd_openal/snd_openal.premake
+++ b/source/snd_openal/snd_openal.premake
@@ -1,0 +1,22 @@
+project "snd_openal"
+
+    kind      "SharedLib"
+    language  "C"
+    qf_targetdir "libs"
+
+    files    { 
+        "*.h",
+        "../gameshared/q_math.h",
+        "../gameshared/q_shared.h",
+        "../client/snd_public.h",
+        "*.c",
+        "../gameshared/q_math.c",
+        "../gameshared/q_shared.c",
+    }
+
+    configuration "windows"
+        links { "libogg_static", "libvorbis_static", "libvorbisfile_static" }
+
+    configuration "macosx"
+        links { "Ogg.framework", "Vorbis.framework" }
+        

--- a/source/snd_qf/snd_qf.premake
+++ b/source/snd_qf/snd_qf.premake
@@ -1,0 +1,24 @@
+project "snd_qf"
+
+    kind      "SharedLib"
+    language  "C"
+    qf_targetdir "libs"
+    
+    files    { 
+        "*.h",
+        "../gameshared/q_math.h",
+        "../gameshared/q_shared.h",
+        "../client/snd_public.h",
+        "*.c",
+        "../gameshared/q_math.c",
+        "../gameshared/q_shared.c",
+    }
+
+    qf_links { "ogg", "vorbis" }
+
+    configuration "windows"
+        files { "../win32/win_snd.c" }
+        links { "winmm" }
+
+    configuration "linux"
+        files { "../unix/unix_snd.c"}

--- a/source/tv_server/tv_server.premake
+++ b/source/tv_server/tv_server.premake
@@ -1,0 +1,74 @@
+project "tv_server"
+
+    kind     "WindowedApp"
+    language "C++"
+
+    defines { "DEDICATED_ONLY", "TV_SERVER_ONLY", "TV_MODULE_HARD_LINKED" }
+    flags   { "WinMain"}
+    
+    files   { 
+        "*.h",
+        "tv_module/*.h",
+        "../qalgo/md5.h",
+        "../qalgo/glob.h",
+        "../gameshared/q_arch.h",
+        "../gameshared/q_collision.h",
+        "../gameshared/q_comref.h",
+        "../gameshared/q_cvar.h",
+        "../gameshared/q_dynvar.h",
+        "../gameshared/q_math.h",
+        "../gameshared/q_shared.h",
+        "../gameshared/q_trie.h",
+        "../gameshared/config.h",
+        "../qcommon/bsp.h",
+        "../qcommon/qcommon.h",
+        "../qcommon/qthreads.h",
+        "../qcommon/snap_read.h",
+        "../qcommon/snap_write.h",
+        "../qcommon/svnrev.h",
+        "../qcommon/sys_fs.h",
+        "../qcommon/sys_library.h",
+        "../qcommon/sys_net.h",
+        "../qcommon/sys_threads.h",
+        "../qcommon/version.h",
+        "*.c",
+        "tv_module/*.c",
+        "../qcommon/*.c",
+        "../qalgo/*.c",
+        "../null/irc_null.c",
+        "../null/ascript_null.c",
+        "../null/cl_null.c",
+        "../null/mm_null.c",
+        "../gameshared/q_math.c",
+        "../gameshared/q_shared.c",        
+    }
+
+    excludes {
+        "../qcommon/irc.c",
+        "../qcommon/ascript.c",
+    }
+
+    configuration "windows"
+        files {
+            "../win32/conproc.h",
+            "../win32/winquake.h",
+            "../win32/win_fs.c",
+            "../win32/win_net.c",
+            "../win32/win_sys.c",
+            "../win32/win_lib.c",
+            "../win32/win_threads.c",       
+            "../win32/conproc.c",
+        }
+
+        links { "libcurlstat", "zlibstat", "winmm", "ws2_32" }
+
+    configuration "linux"
+        files {
+            "../unix/unix_fs.c",
+            "../unix/unix_net.c",
+            "../unix/unix_sys.c",
+            "../unix/unix_lib.c",
+            "../unix/unix_threads.c",
+        }
+
+        links { "curl", "z", "pthread", "dl" }

--- a/source/tv_server/tv_server.premake
+++ b/source/tv_server/tv_server.premake
@@ -48,6 +48,8 @@ project "tv_server"
         "../qcommon/ascript.c",
     }
 
+    qf_links { "curl", "z" }
+
     configuration "windows"
         files {
             "../win32/conproc.h",
@@ -60,7 +62,7 @@ project "tv_server"
             "../win32/conproc.c",
         }
 
-        links { "libcurlstat", "zlibstat", "winmm", "ws2_32" }
+        links { "winmm", "ws2_32" }
 
     configuration "linux"
         files {
@@ -71,4 +73,4 @@ project "tv_server"
             "../unix/unix_threads.c",
         }
 
-        links { "curl", "z", "pthread", "dl" }
+        links { "pthread", "dl" }

--- a/source/ui/ui.premake
+++ b/source/ui/ui.premake
@@ -1,0 +1,57 @@
+project "ui"
+
+    kind      "SharedLib"
+    language  "C++"
+    
+    qf_targetdir "base"
+
+    -- pchheader "ui_precompiled.h"
+    -- pchsource "ui_precompiled.cpp"
+
+    includedirs { ".", "../../libsrcs/libRocket/libRocket/Include" }
+    defines     { "STATIC_LIB" }
+
+    files { 
+        "*.h",
+        "as/*.h",
+        "datasources/*.h",
+        "decorators/*.h",
+        "formatters/*.h",
+        "kernel/*.h",
+        "widgets/*.h",
+        "../qalgo/hash.h",
+        "../qalgo/md5.h",
+        "../gameshared/config.h",
+        "../gameshared/gs_qrespath.h",
+        "../gameshared/gs_ref.h",
+        "../gameshared/q_arch.h",
+        "../gameshared/q_cvar.h",
+        "../gameshared/q_dynvar.h",
+        "../gameshared/q_keycodes.h",
+        "../gameshared/q_math.h",
+        "../gameshared/q_shared.h",
+        "ui_public.cpp",
+        "ui_precompiled.cpp",
+        "as/*.cpp",
+        "datasources/*.cpp",
+        "decorators/*.cpp",
+        "formatters/*.cpp",
+        "kernel/*.cpp",
+        "widgets/*.cpp",
+        "parsers/*.cpp",
+        "../qalgo/hash.c",
+        "../qalgo/md5.c",
+        "../gameshared/q_math.c",
+        "../gameshared/q_shared.c",
+    }
+
+    configuration "windows"
+        links { "RocketCore", "RocketControls" }
+
+    configuration "linux"
+        libdirs {
+            "../../libsrcs/libRocket/libRocket/Build/lib",
+            "../../libsrcs/libRocket/libRocket/lib",
+        }
+        
+        links { "RocketWSW", "freetype" }


### PR DESCRIPTION
I've already made a proposal to use cmake as a crossplatform built tool to make maintenance much easier. After making some tests with cmake I once again realized how horrible it is. So I decided to use premake instead (http://industriousone.com/premake). It has nice declarative lua-based scripting and is very simple overall.

This branch is still work in progress but it would be great if you have time to take a look through the code and give some feedback and your overall impressions about this idea.

I've tested this on Windows 7 x64 (I used premake4.4-beta5 from http://industriousone.com/premake/download) and Ubuntu 13.10 x64 (premake4 from apt-get). On windows you need to run

```
 premake4 vs2010
```

in qfusion/source directory to generate visual studio projects (old project files are not removed yet). On linux

```
 premake4 gmake && make config=debug64
```

Known issues:
- no precompiled headers support in a way we need. There is no option in premake to ignore precompiled headers for specific files in project. It can be fixed with some refactoring.
- for now angelscript and librocket on linux should be prebuilt manually by calling make.
- currently no OS X support. But it seems to broken in master anyway
