### PR TITLE
Feature request: cvaradd command

### DIFF
--- a/source/qcommon/cvar.c
+++ b/source/qcommon/cvar.c
@@ -684,7 +684,7 @@ static void Cvar_Add_f( void )
 	if( !v )
 		return;
 
-	Cvar_Set( v->name, v->value + atof( Cmd_Argv(2) ) );
+	Cvar_SetValue( v->name, v->value + atof( Cmd_Argv(2) ) );
 }
 
 #ifndef PUBLIC_BUILD

--- a/source/qcommon/cvar.c
+++ b/source/qcommon/cvar.c
@@ -682,7 +682,10 @@ static void Cvar_Add_f( void )
 
 	v = Cvar_Find( Cmd_Argv( 1 ) );
 	if( !v )
+	{
+		Com_Printf( "No such variable: \"%s\"\n", Cmd_Argv( 1 ) );
 		return;
+	}
 
 	Cvar_SetValue( v->name, v->value + atof( Cmd_Argv(2) ) );
 }

--- a/source/qcommon/cvar.c
+++ b/source/qcommon/cvar.c
@@ -667,6 +667,26 @@ static void Cvar_List_f( void )
 	Trie_FreeDump( dump );
 }
 
+/*
+* Cvar_Add_f
+*/
+static void Cvar_Add_f( void )
+{
+	cvar_t *v;
+
+	if( Cmd_Argc() != 3 )
+	{
+		Com_Printf( "usage: cvaradd <variable> <value>\n" );
+		return;
+	}
+
+	v = Cvar_Find( Cmd_Argv( 1 ) );
+	if( !v )
+		return;
+
+	Cvar_Set( v->name, v->value + atof( Cmd_Argv(2) ) );
+}
+
 #ifndef PUBLIC_BUILD
 /*
 * Cvar_ArchiveList_f
@@ -867,6 +887,7 @@ void Cvar_Init( void )
 	Cmd_AddCommand( "sets", Cvar_Sets_f );
 	Cmd_AddCommand( "reset", Cvar_Reset_f );
 	Cmd_AddCommand( "toggle", Cvar_Toggle_f );
+	Cmd_AddCommand( "cvaradd", Cvar_Add_f );
 	Cmd_AddCommand( "cvarlist", Cvar_List_f );
 
 	Cmd_SetCompletionFunc( "set", Cvar_CompleteBuildList );
@@ -877,6 +898,7 @@ void Cvar_Init( void )
 	Cmd_SetCompletionFunc( "setas", Cvar_CompleteBuildListServer );
 	Cmd_SetCompletionFunc( "setu", Cvar_CompleteBuildListUser );
 	Cmd_SetCompletionFunc( "sets", Cvar_CompleteBuildListServer );
+	Cmd_SetCompletionFunc( "cvaradd", Cvar_CompleteBuildList );
 
 #ifndef PUBLIC_BUILD
 	Cmd_AddCommand( "cvararchivelist", Cvar_ArchiveList_f );
@@ -921,6 +943,7 @@ void Cvar_Shutdown( void )
 		Cmd_RemoveCommand( "sets" );
 		Cmd_RemoveCommand( "reset" );
 		Cmd_RemoveCommand( "toggle" );
+		Cmd_RemoveCommand( "cvaradd" );
 		Cmd_RemoveCommand( "cvarlist" );
 #ifndef PUBLIC_BUILD
 		Cmd_RemoveCommand( "cvararchivelist" );


### PR DESCRIPTION
Adds a command `cvaradd <variable> <value>` which adjusts variable by the given value. Quite handy for binds like `bind x cvaradd s_volume 0.1; bind y cvaradd s_volume -0.1`. I don't think it adds anything that can't currently be done without infinity alias;bind lines in a cfg.

If variable is undefined, no action is taken.
If variable is non-numeric, it is treated as 0
If value cannot be parsed, it is treated as 0

Thoughts?
