### PR TITLE
Fix Numpad input in console/chat to input numbers (not navigation)

### DIFF
--- a/source/client/console.c
+++ b/source/client/console.c
@@ -68,6 +68,59 @@ static int chat_prestep = 0;
 static unsigned int chat_linepos = 0;
 static unsigned int chat_bufferlen = 0;
 
+static int Con_NumPadValue( int key )
+{
+	switch( key )
+	{
+	case KP_SLASH:
+		return '/';
+
+	case KP_STAR:
+		return '*';
+
+	case KP_MINUS:
+		return '-';
+
+	case KP_PLUS:
+		return '+';
+
+	case KP_HOME:
+		return '7';
+
+	case KP_UPARROW:
+		return '8';
+
+	case KP_PGUP:
+		return '9';
+
+	case KP_LEFTARROW:
+		return '4';
+
+	case KP_5:
+		return '5';
+
+	case KP_RIGHTARROW:
+		return '6';
+
+	case KP_END:
+		return '1';
+
+	case KP_DOWNARROW:
+		return '2';
+
+	case KP_PGDN:
+		return '3';
+
+	case KP_INS:
+		return '0';
+
+	case KP_DEL:
+		return '.';
+	}
+
+	return key;
+}
+
 static void Con_ClearTyping( void )
 {
 	key_lines[edit_line][1] = 0; // clear any typing
@@ -1121,6 +1174,8 @@ void Con_CharEvent( qwchar key )
 	if( !con_initialized )
 		return;
 
+	key = Con_NumPadValue( key );
+
 	if( cls.state == CA_GETTING_TICKET || cls.state == CA_CONNECTING || cls.state == CA_CONNECTED )
 		return;
 
@@ -1342,51 +1397,7 @@ void Con_KeyDown( int key )
 	if( cls.state == CA_GETTING_TICKET || cls.state == CA_CONNECTING || cls.state == CA_CONNECTED )
 		return;
 
-	switch( key )
-	{
-	case KP_SLASH:
-		key = '/';
-		break;
-	case KP_MINUS:
-		key = '-';
-		break;
-	case KP_PLUS:
-		key = '+';
-		break;
-	case KP_HOME:
-		key = '7';
-		break;
-	case KP_UPARROW:
-		key = '8';
-		break;
-	case KP_PGUP:
-		key = '9';
-		break;
-	case KP_LEFTARROW:
-		key = '4';
-		break;
-	case KP_5:
-		key = '5';
-		break;
-	case KP_RIGHTARROW:
-		key = '6';
-		break;
-	case KP_END:
-		key = '1';
-		break;
-	case KP_DOWNARROW:
-		key = '2';
-		break;
-	case KP_PGDN:
-		key = '3';
-		break;
-	case KP_INS:
-		key = '0';
-		break;
-	case KP_DEL:
-		key = '.';
-		break;
-	}
+	key = Con_NumPadValue( key );
 
 	if( ( ( key == K_INS ) || ( key == KP_INS ) ) && ( Key_IsDown(K_LSHIFT) || Key_IsDown(K_RSHIFT)) )
 	{
@@ -1627,6 +1638,8 @@ void Con_MessageCharEvent( qwchar key )
 	if( !con_initialized )
 		return;
 
+	key = Con_NumPadValue( key );
+
 	switch( key )
 	{
 	case 12:
@@ -1751,6 +1764,8 @@ void Con_MessageKeyDown( int key )
 
 	if( !con_initialized )
 		return;
+
+	key = Con_NumPadValue( key );
 
 	if( key == K_ENTER || key == KP_ENTER )
 	{

--- a/source/unix/unix_input.c
+++ b/source/unix/unix_input.c
@@ -445,7 +445,7 @@ static char *XLateKey( int keycode, int *key )
 		case XK_Super_R: *key = K_WIN; break;
 		case XK_Multi_key: *key = K_WIN; break;
 		case XK_Menu: *key = K_MENU; break;
-		case XK_KP_Begin: *key = KP_5; break;
+		case XK_KP_Begin: case XK_KP_5: *key = KP_5; break;
 		case XK_KP_Insert: case XK_KP_0: *key = KP_INS; break;
 		case XK_Insert: *key = K_INS; break;
 		case XK_KP_Multiply: *key = KP_STAR; break;
@@ -587,6 +587,8 @@ static void handle_key(XGenericEventCookie *cookie)
 
 	if(name && name[0] && down) {
 		qwchar wc = keysym2ucs(XkbKeycodeToKeysym(x11display.dpy, keycode, 0, shift_down));
+		if( wc == -1 )
+			wc = ( qwchar )key;
 
 		// Convert ctrl-c / ctrl-v combinations to the expected events
 		if( Key_IsDown(K_LCTRL) || Key_IsDown(K_RCTRL) )

--- a/source/unix/unix_input.c
+++ b/source/unix/unix_input.c
@@ -587,7 +587,7 @@ static void handle_key(XGenericEventCookie *cookie)
 
 	if(name && name[0] && down) {
 		qwchar wc = keysym2ucs(XkbKeycodeToKeysym(x11display.dpy, keycode, 0, shift_down));
-		if( wc == -1 )
+		if( wc == -1 && key > K_NUMLOCK && key <= KP_EQUAL )
 			wc = ( qwchar )key;
 
 		// Convert ctrl-c / ctrl-v combinations to the expected events


### PR DESCRIPTION
Right now keypad input is semibroken in linux. It only works to navigate when typing in chat, not console. This sets keypad to always input characters instead of navigating in both console and chat. I'm not sure if this is the behavior you're looking for, if not let me know.
