### PR TITLE
Use Xrandr to detect screensize

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -265,7 +265,7 @@ else
 LIB=lib
 endif
 
-LDFLAGS_CLIENT=-lz -lpthread -lX11 -lXext -lXi -lrt $(shell curl-config --libs)
+LDFLAGS_CLIENT=-lz -lpthread -lX11 -lXext -lXi -lXrandr -lrt $(shell curl-config --libs)
 LDFLAGS_DED=-lz -lpthread $(shell curl-config --libs)
 LDFLAGS_MODULE=-shared
 LDFLAGS_TV_SERVER=-lz -lpthread $(shell curl-config --libs)

--- a/source/unix/unix_vid.c
+++ b/source/unix/unix_vid.c
@@ -126,14 +126,24 @@ void VID_FlashWindow( int count )
 */
 qboolean VID_GetDisplaySize( int *width, int *height )
 {
-	Display *dpy = XOpenDisplay( NULL );
-	if( dpy ) {
-		int scr = DefaultScreen( dpy );
+	XRRScreenConfiguration *xrrConfig;
+	XRRScreenSize *xrrSizes;
+	Display *dpy;
+	Window root;
+	Rotation rotation;
+	SizeID size_id;
+	int num_sizes;
 
-		*width = DisplayWidth( dpy, scr );
-		*height = DisplayHeight( dpy, scr );
-		
-		XCloseDisplay( dpy );
+	dpy = XOpenDisplay( NULL );
+	if( dpy )
+	{
+		root = DefaultRootWindow( dpy );
+		xrrConfig = XRRGetScreenInfo( dpy, root );
+		xrrSizes = XRRConfigSizes( xrrConfig, &num_sizes );
+		size_id = XRRConfigCurrentConfiguration( xrrConfig, &rotation );
+
+		*width = xrrSizes[size_id].width;
+		*height = xrrSizes[size_id].height;
 
 		return qtrue;
 	}


### PR DESCRIPTION
DisplayHeight and DisplayWidth give the combined screen size in multimonitor and xinerama setups which causes crashing. The best solution I have found is to use Xrandr to detect allowable screen sizes. I haven't yet tested while using Xinerama, but normal multi-head no longer crashes with this patch.

edit: I don't think I can test xinerama easily with my current hardware, but its an outdated system anyways :D. I doub't it would make a difference
