### PR TITLE
Fix Player color inconsistencies

### DIFF
--- a/source/gameshared/q_shared.c
+++ b/source/gameshared/q_shared.c
@@ -959,7 +959,10 @@ int COM_ValidatePlayerColor( int rgbcolor )
 	if( r + g + b >= 128 * 3 )
 		return rgbcolor;
 
-	return COLOR_RGB( 128 + r, 128 + g, 128 + b );
+	r = r > 127 ? 255 : 128 + r;
+	g = g > 127 ? 255 : 128 + g;
+	b = b > 127 ? 255 : 128 + b;
+	return COLOR_RGB( r, g, b );
 }
 
 

--- a/source/ui/widgets/ui_modelview.cpp
+++ b/source/ui/widgets/ui_modelview.cpp
@@ -10,6 +10,7 @@
 #include "kernel/ui_main.h"
 #include "kernel/ui_boneposes.h"
 #include "widgets/ui_widgets.h"
+#include "../gameshared/q_shared.h"
 
 #define MODELVIEW_EPSILON		1.0f
 
@@ -169,7 +170,8 @@ public:
 			else if (*it == "model-shader-color")
 			{
 				Rocket::Core::Colourb color = GetProperty(*it)->Get<Rocket::Core::Colourb>();
-				Vector4Set(entity.shaderRGBA, color.red, color.green, color.blue, color.alpha);
+				int shaderColor = COM_ValidatePlayerColor( COLOR_RGB( color.red, color.green, color.blue ) );
+				Vector4Set(entity.shaderRGBA, COLOR_R( shaderColor ), COLOR_G( shaderColor ), COLOR_B( shaderColor ), color.alpha);
 			}
 			else if (*it == "model-fov-x")
 			{


### PR DESCRIPTION
Fixed bug where some `color` values gave fun unexpected results from the rgb values overflowing into each other. Also fixed the ui to show the same (lightened/muted) color that will appear ingame.
