### PR TITLE
Add stuffcmds.cfg for systems without command line

### DIFF
--- a/source/qcommon/common.c
+++ b/source/qcommon/common.c
@@ -1051,6 +1051,23 @@ void Qcommon_Init( int argc, char **argv )
 
 	SCR_EndLoadingPlaque();
 
+	if( !dedicated->integer )
+	{
+		Cbuf_AddText( "exec stuffcmds.cfg\n" );
+	}
+	else if( mm_server->integer )
+	{
+		Cbuf_AddText( "exec mmaker_stuffcmds.cfg\n" );
+	}
+	else if( tv_server->integer )
+	{
+		Cbuf_AddText( "exec tvserver_stuffcmds.cfg\n" );
+	}
+	else
+	{
+		Cbuf_AddText( "exec dedicated_stuffcmds.cfg\n" );
+	}
+
 	// add + commands from command line
 	if( !Cbuf_AddLateCommands() )
 	{


### PR DESCRIPTION
For systems without command line support (Android, for instance) and for convenience, here's a patch that lets you write startup console +commands and +variables in dedicated/mmaker/tvserver_stuffcmds.cfg instead of the command line.

This is executed after the initialization, as opposed to autoexec, which is executed before many concommands and convars are initialized.

Also this is executed before the actual command line so you can override the file from the command line.
