### PR TITLE
AddHomeDirectory instead of GetHomeDirectory

### DIFF
--- a/source/qcommon/files.c
+++ b/source/qcommon/files.c
@@ -3695,25 +3695,17 @@ void FS_Init( void )
 	//
 	fs_cdpath = Cvar_Get( "fs_cdpath", "", CVAR_NOSET );
 	fs_basepath = Cvar_Get( "fs_basepath", ".", CVAR_NOSET );
-	if( Sys_FS_GetHomeDirectory() != NULL )
 #ifdef PUBLIC_BUILD
-		fs_usehomedir = Cvar_Get( "fs_usehomedir", "1", CVAR_NOSET );
+	fs_usehomedir = Cvar_Get( "fs_usehomedir", "1", CVAR_NOSET );
 #else
-		fs_usehomedir = Cvar_Get( "fs_usehomedir", "0", CVAR_NOSET );
+	fs_usehomedir = Cvar_Get( "fs_usehomedir", "0", CVAR_NOSET );
 #endif
 
 	if( fs_cdpath->string[0] )
 		FS_AddBasePath( fs_cdpath->string );
 	FS_AddBasePath( fs_basepath->string );
-	if( Sys_FS_GetHomeDirectory() != NULL && fs_usehomedir->integer )
-#ifdef __MACOSX__
-		FS_AddBasePath( va( "%s/Library/Application Support/%s-%d.%d", Sys_FS_GetHomeDirectory(), APPLICATION, APP_VERSION_MAJOR, APP_VERSION_MINOR ) );
-#elif defined(_WIN32)
-		FS_AddBasePath( va( "%s/%s %d.%d", Sys_FS_GetHomeDirectory(), APPLICATION, APP_VERSION_MAJOR, APP_VERSION_MINOR ) );
-#else	// Unix
-		FS_AddBasePath( va( "%s/.%c%s-%d.%d", Sys_FS_GetHomeDirectory(), tolower( *( (const char *)APPLICATION ) ),
-			( (const char *)APPLICATION ) + 1, APP_VERSION_MAJOR, APP_VERSION_MINOR ) );
-#endif
+	if( fs_usehomedir->integer && !Sys_FS_AddHomeDirectory() )
+		Cvar_ForceSet( "fs_usehomedir", "0" );
 
 	//
 	// set game directories

--- a/source/qcommon/files.c
+++ b/source/qcommon/files.c
@@ -3471,7 +3471,7 @@ qboolean FS_SetGameDirectory( const char *dir, qboolean force )
 /*
 * FS_AddBasePath
 */
-static void FS_AddBasePath( const char *path )
+void FS_AddBasePath( const char *path )
 {
 	searchpath_t *newpath;
 

--- a/source/qcommon/qcommon.h
+++ b/source/qcommon/qcommon.h
@@ -725,6 +725,7 @@ const char *FS_GameDirectory( void );
 const char *FS_BaseGameDirectory( void );
 qboolean    FS_SetGameDirectory( const char *dir, qboolean force );
 int			FS_GetGameDirectoryList( char *buf, size_t bufsize );
+void	    FS_AddBasePath( const char *path );
 int			FS_GetExplicitPurePakList( char ***paknames );
 
 // handling of absolute filenames

--- a/source/qcommon/sys_fs.h
+++ b/source/qcommon/sys_fs.h
@@ -21,7 +21,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #ifndef __SYS_FS_H
 #define __SYS_FS_H
 
-const char *Sys_FS_GetHomeDirectory( void );
+qboolean    Sys_FS_AddHomeDirectory( void );
 
 qboolean    Sys_FS_RemoveDirectory( const char *path );
 qboolean    Sys_FS_CreateDirectory( const char *path );

--- a/source/unix/unix_fs.c
+++ b/source/unix/unix_fs.c
@@ -191,11 +191,20 @@ void Sys_FS_FindClose( void )
 }
 
 /*
-* Sys_FS_GetHomeDirectory
+* Sys_FS_AddHomeDirectory
 */
-const char *Sys_FS_GetHomeDirectory( void )
+qboolean Sys_FS_AddHomeDirectory( void )
 {
-	return getenv( "HOME" );
+	const char *home = getenv( "HOME" );
+	if ( !home )
+		return qfalse;
+#ifdef __MACOSX__
+	FS_AddBasePath( va( "%s/Library/Application Support/%s-%d.%d", home, APPLICATION, APP_VERSION_MAJOR, APP_VERSION_MINOR ) );
+#else	// Unix
+	FS_AddBasePath( va( "%s/.%c%s-%d.%d", home, tolower( *( (const char *)APPLICATION ) ),
+		( (const char *)APPLICATION ) + 1, APP_VERSION_MAJOR, APP_VERSION_MINOR ) );
+#endif
+	return qtrue;
 }
 
 /*

--- a/source/win32/win_fs.c
+++ b/source/win32/win_fs.c
@@ -178,9 +178,9 @@ void Sys_FS_FindClose( void )
 }
 
 /*
-* Sys_FS_GetHomeDirectory
+* GetHomeDirectory
 */
-const char *Sys_FS_GetHomeDirectory( void )
+static const char *GetHomeDirectory( void )
 {
 	static char home[MAX_PATH] = { '\0' };
 #ifndef SHGetFolderPath
@@ -198,6 +198,18 @@ const char *Sys_FS_GetHomeDirectory( void )
 	SHGetFolderPath( 0, CSIDL_APPDATA, 0, 0, home );
 #endif
 	return (home[0] == '\0' ? NULL : COM_SanitizeFilePath( home ) );
+}
+
+/*
+* Sys_FS_AddHomeDirectory
+*/
+qboolean Sys_FS_AddHomeDirectory( void )
+{
+	const char *home = GetHomeDirectory();
+	if ( !home )
+		return qfalse;
+	FS_AddBasePath( va( "%s/%s %d.%d", home, APPLICATION, APP_VERSION_MAJOR, APP_VERSION_MINOR ) );
+	return qtrue;
 }
 
 /*


### PR DESCRIPTION
In qcommon/files.c, there are platform-dependent #ifdefs for home directory setting. It would be better to move all platform-dependent code to Sys.
