### PR TITLE
Dynamic library code improvements

### DIFF
--- a/source/qcommon/library.c
+++ b/source/qcommon/library.c
@@ -48,12 +48,16 @@ void *Com_LoadLibrary( const char *name, dllfunc_t *funcs )
 
 	Com_DPrintf( "LoadLibrary (%s)\n", name );
 
+#ifdef LIB_OPEN_DIRECTLY
+	fullname = name;
+#else
 	fullname = FS_AbsoluteNameForBaseFile( name );
 	if( !fullname )
 	{
 		Com_DPrintf( "LoadLibrary (%s):(Not found)\n", name );
 		return NULL;
 	}
+#endif
 
 	lib = Sys_Library_Open( fullname );
 	if( !lib )
@@ -237,6 +241,10 @@ void *Com_LoadGameLibrary( const char *basename, const char *apifuncname, void *
 	libname = ( char* )Mem_TempMalloc( libname_size );
 	Q_snprintfz( libname, libname_size, "%s_" ARCH LIB_SUFFIX, basename );
 
+#ifdef LIB_OPEN_DIRECTLY
+	tempname = ( char * )Mem_ZoneMalloc( libname_size );
+	strcpy( tempname, libname );
+#else
 	// it exists?
 	if( FS_FOpenFile( libname, NULL, FS_READ ) == -1 )
 	{
@@ -277,6 +285,7 @@ void *Com_LoadGameLibrary( const char *basename, const char *apifuncname, void *
 	// with gamedir for dlopen
 	Q_snprintfz( tempname, tempname_size, "%s/%s/tempmodules%i/%s", FS_WriteDirectory(), FS_GameDirectory(),
 	             randomizer, libname );
+#endif
 
 	gamelib->fullname = COM_SanitizeFilePath( tempname );
 	gamelib->lib = Sys_Library_Open( gamelib->fullname );

--- a/source/qcommon/sys_library.h
+++ b/source/qcommon/sys_library.h
@@ -24,6 +24,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 qboolean    Sys_Library_Close( void *lib );
 void *Sys_Library_Open( const char *name );
 void *Sys_Library_ProcAddress( void *lib, const char *apifuncname );
-char *Sys_Library_ErrorString( void );
+const char *Sys_Library_ErrorString( void );
 
 #endif // __SYS_LIBRARY_H

--- a/source/unix/unix_lib.c
+++ b/source/unix/unix_lib.c
@@ -51,7 +51,7 @@ void *Sys_Library_ProcAddress( void *lib, const char *apifuncname )
 /*
 * Sys_Library_ErrorString
 */
-char *Sys_Library_ErrorString( void )
+const char *Sys_Library_ErrorString( void )
 {
 	return dlerror();
 }

--- a/source/win32/win_lib.c
+++ b/source/win32/win_lib.c
@@ -51,7 +51,7 @@ void *Sys_Library_ProcAddress( void *lib, const char *apifuncname )
 /*
 * Sys_Library_ErrorString
 */
-char *Sys_Library_ErrorString( void )
+const char *Sys_Library_ErrorString( void )
 {
 	static char errbuf[80];
 


### PR DESCRIPTION
I made 2 changes to the library code.

The first is the addition of #ifdef LIB_OPEN_DIRECTLY (to be defined in q_arch.h) for systems that load libraries in a way different from Windows and Linux. Android, for example, has all libraries in a system directory unpacked from the .apk during the installation.

Another modification is making Sys_Library_ErrorString const. I get a compiler warning when the output of dlerror is implicitly casted to non-const char*.
