### PR TITLE
Home directory platform independence

### DIFF
--- a/source/qcommon/files.c
+++ b/source/qcommon/files.c
@@ -3664,6 +3664,7 @@ static void Cmd_FileMTime_f( void )
 void FS_Init( void )
 {
 	int i;
+	const char *homedir;
 
 	assert( !fs_initialized );
 
@@ -3695,7 +3696,8 @@ void FS_Init( void )
 	//
 	fs_cdpath = Cvar_Get( "fs_cdpath", "", CVAR_NOSET );
 	fs_basepath = Cvar_Get( "fs_basepath", ".", CVAR_NOSET );
-	if( Sys_FS_GetHomeDirectory() != NULL )
+	homedir = Sys_FS_GetHomeDirectory();
+	if( homedir != NULL )
 #ifdef PUBLIC_BUILD
 		fs_usehomedir = Cvar_Get( "fs_usehomedir", "1", CVAR_NOSET );
 #else
@@ -3705,15 +3707,8 @@ void FS_Init( void )
 	if( fs_cdpath->string[0] )
 		FS_AddBasePath( fs_cdpath->string );
 	FS_AddBasePath( fs_basepath->string );
-	if( Sys_FS_GetHomeDirectory() != NULL && fs_usehomedir->integer )
-#ifdef __MACOSX__
-		FS_AddBasePath( va( "%s/Library/Application Support/%s-%d.%d", Sys_FS_GetHomeDirectory(), APPLICATION, APP_VERSION_MAJOR, APP_VERSION_MINOR ) );
-#elif defined(_WIN32)
-		FS_AddBasePath( va( "%s/%s %d.%d", Sys_FS_GetHomeDirectory(), APPLICATION, APP_VERSION_MAJOR, APP_VERSION_MINOR ) );
-#else	// Unix
-		FS_AddBasePath( va( "%s/.%c%s-%d.%d", Sys_FS_GetHomeDirectory(), tolower( *( (const char *)APPLICATION ) ),
-			( (const char *)APPLICATION ) + 1, APP_VERSION_MAJOR, APP_VERSION_MINOR ) );
-#endif
+	if( homedir != NULL && fs_usehomedir->integer )
+		FS_AddBasePath( homedir );
 
 	//
 	// set game directories

--- a/source/unix/unix_fs.c
+++ b/source/unix/unix_fs.c
@@ -22,6 +22,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "../qcommon/sys_fs.h"
 
 #include <dirent.h>
+#include <linux/limits.h>
 #include <unistd.h>
 #include <sys/stat.h>
 
@@ -195,7 +196,23 @@ void Sys_FS_FindClose( void )
 */
 const char *Sys_FS_GetHomeDirectory( void )
 {
-	return getenv( "HOME" );
+	static char home[PATH_MAX] = { '\0' };
+	const char *homeEnv;
+
+	if( home[0] != '\0' )
+		return home;
+	homeEnv = getenv( "HOME" );
+	if( !homeEnv )
+		return NULL;
+
+#ifdef __MACOSX__
+	Q_snprintfz( home, sizeof( home ), "%s/Library/Application Support/%s-%d.%d", homeEnv, APPLICATION,
+		APP_VERSION_MAJOR, APP_VERSION_MINOR );
+#else
+	Q_snprintfz( home, sizeof( home ), "%s/.%c%s-%d.%d", homeEnv, tolower( *( (const char *)APPLICATION ) ),
+		( (const char *)APPLICATION ) + 1, APP_VERSION_MAJOR, APP_VERSION_MINOR );
+#endif
+	return home;
 }
 
 /*

--- a/source/win32/win_fs.c
+++ b/source/win32/win_fs.c
@@ -183,6 +183,9 @@ void Sys_FS_FindClose( void )
 const char *Sys_FS_GetHomeDirectory( void )
 {
 	static char home[MAX_PATH] = { '\0' };
+	if( home[0] != '\0' )
+		return home;
+
 #ifndef SHGetFolderPath
 	HINSTANCE shFolderDll = LoadLibrary( "shfolder.dll" );
 
@@ -197,7 +200,11 @@ const char *Sys_FS_GetHomeDirectory( void )
 #else
 	SHGetFolderPath( 0, CSIDL_APPDATA, 0, 0, home );
 #endif
-	return (home[0] == '\0' ? NULL : COM_SanitizeFilePath( home ) );
+
+	if ( home[0] == '\0' )
+		return NULL;
+	Q_strncpyz( home, va( "%s/%s %d.%d", COM_SanitizeFilePath( home ), APPLICATION, APP_VERSION_MAJOR, APP_VERSION_MINOR ), sizeof( home ) );
+	return home;
 }
 
 /*


### PR DESCRIPTION
In qcommon/files.c, there are platform-dependent #ifdefs for home directory setting. It would be better to move all platform-dependent code to Sys_FS_GetHomeDirectory.

This is an updated version of #68.
