### PR TITLE
GLES: u_TextureMatrix - 2 vec4s instead of 3 vec2s

### DIFF
--- a/glsl/defaultDistortion.glsl
+++ b/glsl/defaultDistortion.glsl
@@ -37,10 +37,9 @@ void main(void)
 
 	v_TexCoord.st = TextureMatrix2x3Mul(u_TextureMatrix, TexCoord);
 
-	vec2 textureMatrix3_[3];
+	vec4 textureMatrix3_[2];
 	textureMatrix3_[0] =  u_TextureMatrix[0];
-	textureMatrix3_[1] =  u_TextureMatrix[1];
-	textureMatrix3_[2] = -u_TextureMatrix[2];
+	textureMatrix3_[1] = -u_TextureMatrix[1];
 	v_TexCoord.pq = TextureMatrix2x3Mul(textureMatrix3_, TexCoord);
 
 #ifdef APPLY_EYEDOT

--- a/glsl/include/uniforms.glsl
+++ b/glsl/include/uniforms.glsl
@@ -20,8 +20,8 @@ uniform vec3 u_LightDir;
 
 uniform myhalf2 u_BlendMix;
 
-uniform vec2 u_TextureMatrix[3];
-#define TextureMatrix2x3Mul(m2x3,tc) vec2(dot((m2x3)[0],(tc)) + (m2x3)[2][0], dot((m2x3)[1],(tc)) + (m2x3)[2][1])
+uniform vec4 u_TextureMatrix[2];
+#define TextureMatrix2x3Mul(m2x3,tc) (vec2(dot((m2x3)[0].xy, (tc)), dot((m2x3)[0].zw, (tc))) + (m2x3)[1].xy)
 
 uniform float u_MirrorSide;
 

--- a/source/ref_gl/r_program.c
+++ b/source/ref_gl/r_program.c
@@ -1621,7 +1621,7 @@ void RP_UpdateShaderUniforms( int elem,
 		m[2] = texMatrix[1], m[3] = texMatrix[5];
 		m[4] = texMatrix[12], m[5] = texMatrix[13];
 
-		qglUniform2fvARB( program->loc.TextureMatrix, 3, m );
+		qglUniform4fvARB( program->loc.TextureMatrix, 2, m );
 	}
 }
 


### PR DESCRIPTION
One uniform compression taken from the GLES version.

u_TextureMatrix[0] and u_TextureMatrix[1] are now packed in a single vec4. This may save one uniform vector.

I don't want to use `#ifdef USE_GLES2` in this piece of code because the change can be easily applied to the desktop renderer code.

Also translation is now applied to the whole vec2, not to each component separately.
