### PR TITLE
16-bit index buffers

### DIFF
--- a/source/ref_gl/r_alias.c
+++ b/source/ref_gl/r_alias.c
@@ -151,7 +151,8 @@ void Mod_LoadAliasMD3Model( model_t *mod, model_t *parent, void *buffer, bspForm
 	dmd3skin_t *pinskin;
 	dmd3coord_t *pincoord;
 	dmd3vertex_t *pinvert;
-	elem_t *pinelem, *poutelem;
+	unsigned int *pinelem;
+	elem_t *poutelem;
 	maliasvertex_t *poutvert;
 	vec2_t *poutcoord;
 	maliasskin_t *poutskin;
@@ -169,7 +170,7 @@ void Mod_LoadAliasMD3Model( model_t *mod, model_t *parent, void *buffer, bspForm
 		mod->name, version, MD3_ALIAS_VERSION );
 
 	mod->type = mod_alias;
-	mod->extradata = poutmodel = Mod_Malloc( mod, sizeof( maliasmodel_t ) );
+	mod->extradata = poutmodel = ( maliasmodel_t * )Mod_Malloc( mod, sizeof( maliasmodel_t ) );
 	mod->radius = 0;
 	mod->registrationSequence = rsh.registrationSequence;
 	mod->touch = &Mod_TouchAliasModel;
@@ -202,7 +203,7 @@ void Mod_LoadAliasMD3Model( model_t *mod, model_t *parent, void *buffer, bspForm
 	bufsize = poutmodel->numframes * ( sizeof( maliasframe_t ) + sizeof( maliastag_t ) * poutmodel->numtags ) +
 		poutmodel->nummeshes * sizeof( maliasmesh_t ) + 
 		poutmodel->nummeshes * sizeof( drawSurfaceAlias_t );
-	buf = Mod_Malloc( mod, bufsize );
+	buf = ( qbyte * )Mod_Malloc( mod, bufsize );
 
 	//
 	// load the frames
@@ -307,7 +308,7 @@ void Mod_LoadAliasMD3Model( model_t *mod, model_t *parent, void *buffer, bspForm
 		//
 		// load the elems
 		//
-		pinelem = ( elem_t * )( ( qbyte * )pinmesh + LittleLong( pinmesh->ofs_elems ) );
+		pinelem = ( unsigned int * )( ( qbyte * )pinmesh + LittleLong( pinmesh->ofs_elems ) );
 		poutelem = poutmesh->elems = ( elem_t * )buf; buf += poutmesh->numtris * sizeof( elem_t ) * 3;
 		for( j = 0; j < poutmesh->numtris; j++, pinelem += 3, poutelem += 3 )
 		{

--- a/source/ref_gl/r_backend.c
+++ b/source/ref_gl/r_backend.c
@@ -1168,8 +1168,8 @@ void RB_DrawElementsReal( void )
 	if( numInstances ) {
 		if( glConfig.ext.instanced_arrays ) {
 			// the instance data is contained in vertex attributes
-			qglDrawElementsInstancedARB( rb.primitive, numElems, GL_UNSIGNED_INT, 
-				(GLvoid *)(firstElem * sizeof( int )), numInstances );
+			qglDrawElementsInstancedARB( rb.primitive, numElems, GL_UNSIGNED_SHORT, 
+				(GLvoid *)(firstElem * sizeof( elem_t )), numInstances );
 
 			rb.stats.c_totalDraws++;
 		} else if( glConfig.ext.draw_instanced ) {
@@ -1182,8 +1182,8 @@ void RB_DrawElementsReal( void )
 
 				RB_SetInstanceData( numUInstances, rb.drawInstances + i );
 
-				qglDrawElementsInstancedARB( rb.primitive, numElems, GL_UNSIGNED_INT, 
-					(GLvoid *)(firstElem * sizeof( int )), numUInstances );
+				qglDrawElementsInstancedARB( rb.primitive, numElems, GL_UNSIGNED_SHORT, 
+					(GLvoid *)(firstElem * sizeof( elem_t )), numUInstances );
 
 				rb.stats.c_totalDraws++;
 			}
@@ -1197,7 +1197,7 @@ void RB_DrawElementsReal( void )
 
 				qglDrawRangeElementsEXT( rb.primitive, 
 					firstVert, firstVert + numVerts - 1, numElems, 
-					GL_UNSIGNED_INT, (GLvoid *)(firstElem * sizeof( int )) );
+					GL_UNSIGNED_SHORT, (GLvoid *)(firstElem * sizeof( elem_t )) );
 
 				rb.stats.c_totalDraws++;
 			}
@@ -1208,7 +1208,7 @@ void RB_DrawElementsReal( void )
 
 		qglDrawRangeElementsEXT( rb.primitive, 
 			firstVert, firstVert + numVerts - 1, numElems, 
-			GL_UNSIGNED_INT, (GLvoid *)(firstElem * sizeof( int )) );
+			GL_UNSIGNED_SHORT, (GLvoid *)(firstElem * sizeof( elem_t )) );
 
 		rb.stats.c_totalDraws++;
 	}

--- a/source/ref_gl/r_local.h
+++ b/source/ref_gl/r_local.h
@@ -32,7 +32,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 typedef struct mempool_s mempool_t;
 typedef struct cinematics_s cinematics_t;
 
-typedef unsigned int elem_t;
+typedef unsigned short elem_t;
 
 typedef vec_t instancePoint_t[8]; // quaternion for rotation + xyz pos + uniform scale
 

--- a/source/ref_gl/r_vbo.c
+++ b/source/ref_gl/r_vbo.c
@@ -244,7 +244,7 @@ mesh_vbo_t *R_CreateMeshVBO( void *owner, int numVerts, int numElems, int numIns
 		goto error;
 	vbo->elemId = vbo_id;
 
-	size = numElems * sizeof( unsigned int );
+	size = numElems * sizeof( elem_t );
 	RB_BindElementArrayBuffer( vbo->elemId );
 	qglBufferDataARB( GL_ELEMENT_ARRAY_BUFFER_ARB, size, NULL, elem_usage );
 	if( qglGetError () == GL_OUT_OF_MEMORY )
@@ -781,7 +781,7 @@ void R_DiscardVBOElemData( mesh_vbo_t *vbo )
 static int R_UploadVBOElemQuadData( mesh_vbo_t *vbo, int vertsOffset, int elemsOffset, int numVerts )
 {
 	int numElems;
-	unsigned int *ielems;
+	elem_t *ielems;
 
 	assert( vbo != NULL );
 
@@ -794,8 +794,8 @@ static int R_UploadVBOElemQuadData( mesh_vbo_t *vbo, int vertsOffset, int elemsO
 	R_BuildQuadElements( vertsOffset, numVerts, ielems );
 
 	RB_BindElementArrayBuffer( vbo->elemId );
-	qglBufferSubDataARB( GL_ELEMENT_ARRAY_BUFFER_ARB, elemsOffset * sizeof( unsigned int ), 
-		numElems * sizeof( unsigned int ), ielems );
+	qglBufferSubDataARB( GL_ELEMENT_ARRAY_BUFFER_ARB, elemsOffset * sizeof( elem_t ), 
+		numElems * sizeof( elem_t ), ielems );
 
 	return numElems;
 }
@@ -808,7 +808,7 @@ static int R_UploadVBOElemQuadData( mesh_vbo_t *vbo, int vertsOffset, int elemsO
 static int R_UploadVBOElemTrifanData( mesh_vbo_t *vbo, int vertsOffset, int elemsOffset, int numVerts )
 {
 	int numElems;
-	unsigned int *ielems;
+	elem_t *ielems;
 
 	assert( vbo != NULL );
 
@@ -821,8 +821,8 @@ static int R_UploadVBOElemTrifanData( mesh_vbo_t *vbo, int vertsOffset, int elem
 	R_BuildTrifanElements( vertsOffset, numVerts, ielems );
 
 	RB_BindElementArrayBuffer( vbo->elemId );
-	qglBufferSubDataARB( GL_ELEMENT_ARRAY_BUFFER_ARB, elemsOffset * sizeof( unsigned int ), 
-		numElems * sizeof( unsigned int ), ielems );
+	qglBufferSubDataARB( GL_ELEMENT_ARRAY_BUFFER_ARB, elemsOffset * sizeof( elem_t ), 
+		numElems * sizeof( elem_t ), ielems );
 
 	return numElems;
 }
@@ -836,7 +836,7 @@ void R_UploadVBOElemData( mesh_vbo_t *vbo, int vertsOffset, int elemsOffset,
 	const mesh_t *mesh, vbo_hint_t hint )
 {
 	int i;
-	unsigned int *ielems;
+	elem_t *ielems;
 
 	assert( vbo != NULL );
 
@@ -859,8 +859,8 @@ void R_UploadVBOElemData( mesh_vbo_t *vbo, int vertsOffset, int elemsOffset,
 	}
 
 	RB_BindElementArrayBuffer( vbo->elemId );
-	qglBufferSubDataARB( GL_ELEMENT_ARRAY_BUFFER_ARB, elemsOffset * sizeof( unsigned int ), 
-		mesh->numElems * sizeof( unsigned int ), ielems );
+	qglBufferSubDataARB( GL_ELEMENT_ARRAY_BUFFER_ARB, elemsOffset * sizeof( elem_t ), 
+		mesh->numElems * sizeof( elem_t ), ielems );
 }
 
 /*


### PR DESCRIPTION
Since OpenGL ES 2 supports 32-bit vertex indices only as an extension, and the engine doesn't really need them, this patch makes index buffers use 16-bit indices.
