### PR TITLE
16-bit index buffers v2

### DIFF
--- a/source/ref_gl/r_alias.c
+++ b/source/ref_gl/r_alias.c
@@ -151,7 +151,8 @@ void Mod_LoadAliasMD3Model( model_t *mod, model_t *parent, void *buffer, bspForm
 	dmd3skin_t *pinskin;
 	dmd3coord_t *pincoord;
 	dmd3vertex_t *pinvert;
-	elem_t *pinelem, *poutelem;
+	unsigned int *pinelem;
+	elem_t *poutelem;
 	maliasvertex_t *poutvert;
 	vec2_t *poutcoord;
 	maliasskin_t *poutskin;
@@ -169,7 +170,7 @@ void Mod_LoadAliasMD3Model( model_t *mod, model_t *parent, void *buffer, bspForm
 		mod->name, version, MD3_ALIAS_VERSION );
 
 	mod->type = mod_alias;
-	mod->extradata = poutmodel = Mod_Malloc( mod, sizeof( maliasmodel_t ) );
+	mod->extradata = poutmodel = ( maliasmodel_t * )Mod_Malloc( mod, sizeof( maliasmodel_t ) );
 	mod->radius = 0;
 	mod->registrationSequence = rsh.registrationSequence;
 	mod->touch = &Mod_TouchAliasModel;
@@ -202,7 +203,7 @@ void Mod_LoadAliasMD3Model( model_t *mod, model_t *parent, void *buffer, bspForm
 	bufsize = poutmodel->numframes * ( sizeof( maliasframe_t ) + sizeof( maliastag_t ) * poutmodel->numtags ) +
 		poutmodel->nummeshes * sizeof( maliasmesh_t ) + 
 		poutmodel->nummeshes * sizeof( drawSurfaceAlias_t );
-	buf = Mod_Malloc( mod, bufsize );
+	buf = ( qbyte * )Mod_Malloc( mod, bufsize );
 
 	//
 	// load the frames
@@ -292,7 +293,7 @@ void Mod_LoadAliasMD3Model( model_t *mod, model_t *parent, void *buffer, bspForm
 
 		bufsize = sizeof( maliasskin_t ) * poutmesh->numskins + poutmesh->numtris * sizeof( elem_t ) * 3 +
 			numverts * ( sizeof( vec2_t ) + sizeof( maliasvertex_t ) * poutmodel->numframes );
-		buf = Mod_Malloc( mod, bufsize );
+		buf = ( qbyte * )Mod_Malloc( mod, bufsize );
 
 		//
 		// load the skins
@@ -307,7 +308,7 @@ void Mod_LoadAliasMD3Model( model_t *mod, model_t *parent, void *buffer, bspForm
 		//
 		// load the elems
 		//
-		pinelem = ( elem_t * )( ( qbyte * )pinmesh + LittleLong( pinmesh->ofs_elems ) );
+		pinelem = ( unsigned int * )( ( qbyte * )pinmesh + LittleLong( pinmesh->ofs_elems ) );
 		poutelem = poutmesh->elems = ( elem_t * )buf; buf += poutmesh->numtris * sizeof( elem_t ) * 3;
 		for( j = 0; j < poutmesh->numtris; j++, pinelem += 3, poutelem += 3 )
 		{
@@ -550,8 +551,8 @@ qboolean R_DrawAliasSurf( const entity_t *e, const shader_t *shader, const mfog_
 		move[i] = frame->translate[i] + ( oldframe->translate[i] - frame->translate[i] ) * backlerp;
 
 	// based on backend's needs
-	calcNormals = ( ( vattribs & VATTRIB_NORMAL_BIT ) != 0 ) && ( ( framenum != 0 ) || ( oldframenum != 0 ) );
-	calcSTVectors = ( ( vattribs & VATTRIB_SVECTOR_BIT ) != 0 ) && calcNormals;
+	calcNormals = ( ( ( vattribs & VATTRIB_NORMAL_BIT ) != 0 ) && ( ( framenum != 0 ) || ( oldframenum != 0 ) ) ) ? qtrue : qfalse;
+	calcSTVectors = ( ( ( vattribs & VATTRIB_SVECTOR_BIT ) != 0 ) && calcNormals ) ? qtrue : qfalse;
 
 	if( aliasmesh->vbo != NULL && !framenum && !oldframenum )
 	{

--- a/source/ref_gl/r_backend.c
+++ b/source/ref_gl/r_backend.c
@@ -1161,8 +1161,8 @@ void RB_DrawElementsReal( void )
 	if( numInstances ) {
 		if( glConfig.ext.instanced_arrays ) {
 			// the instance data is contained in vertex attributes
-			qglDrawElementsInstancedARB( rb.primitive, numElems, GL_UNSIGNED_INT, 
-				(GLvoid *)(firstElem * sizeof( int )), numInstances );
+			qglDrawElementsInstancedARB( rb.primitive, numElems, GL_UNSIGNED_SHORT, 
+				(GLvoid *)(firstElem * sizeof( elem_t )), numInstances );
 
 			rb.stats.c_totalDraws++;
 		} else if( glConfig.ext.draw_instanced ) {
@@ -1175,8 +1175,8 @@ void RB_DrawElementsReal( void )
 
 				RB_SetInstanceData( numUInstances, rb.drawInstances + i );
 
-				qglDrawElementsInstancedARB( rb.primitive, numElems, GL_UNSIGNED_INT, 
-					(GLvoid *)(firstElem * sizeof( int )), numUInstances );
+				qglDrawElementsInstancedARB( rb.primitive, numElems, GL_UNSIGNED_SHORT, 
+					(GLvoid *)(firstElem * sizeof( elem_t )), numUInstances );
 
 				rb.stats.c_totalDraws++;
 			}
@@ -1190,7 +1190,7 @@ void RB_DrawElementsReal( void )
 
 				qglDrawRangeElementsEXT( rb.primitive, 
 					firstVert, firstVert + numVerts - 1, numElems, 
-					GL_UNSIGNED_INT, (GLvoid *)(firstElem * sizeof( int )) );
+					GL_UNSIGNED_SHORT, (GLvoid *)(firstElem * sizeof( elem_t )) );
 
 				rb.stats.c_totalDraws++;
 			}
@@ -1201,7 +1201,7 @@ void RB_DrawElementsReal( void )
 
 		qglDrawRangeElementsEXT( rb.primitive, 
 			firstVert, firstVert + numVerts - 1, numElems, 
-			GL_UNSIGNED_INT, (GLvoid *)(firstElem * sizeof( int )) );
+			GL_UNSIGNED_SHORT, (GLvoid *)(firstElem * sizeof( elem_t )) );
 
 		rb.stats.c_totalDraws++;
 	}

--- a/source/ref_gl/r_local.h
+++ b/source/ref_gl/r_local.h
@@ -32,7 +32,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 typedef struct mempool_s mempool_t;
 typedef struct cinematics_s cinematics_t;
 
-typedef unsigned int elem_t;
+typedef unsigned short elem_t;
 
 typedef vec_t instancePoint_t[8]; // quaternion for rotation + xyz pos + uniform scale
 

--- a/source/ref_gl/r_model.c
+++ b/source/ref_gl/r_model.c
@@ -364,8 +364,8 @@ static int Mod_CreateSubmodelBufferObjects( model_t *mod, unsigned int modnum, s
 
 		// build visibility data for each face, based on what leafs
 		// this face belongs to (visible from)
-		visdata = Mod_Malloc( mod, rowlongs * 4 * loadbmodel->numsurfaces );
-		areadata = Mod_Malloc( mod, areabytes * loadbmodel->numsurfaces );
+		visdata = ( qbyte * )Mod_Malloc( mod, rowlongs * 4 * loadbmodel->numsurfaces );
+		areadata = ( qbyte * )Mod_Malloc( mod, areabytes * loadbmodel->numsurfaces );
 		for( pleaf = loadbmodel->visleafs, leaf = *pleaf; leaf; leaf = *pleaf++ )
 		{
 			mark = leaf->firstVisSurface;
@@ -406,7 +406,7 @@ static int Mod_CreateSubmodelBufferObjects( model_t *mod, unsigned int modnum, s
 	// vertex buffer objects if they share shader, lightmap texture and we can render
 	// them in hardware (some Q3A shaders require GLSL for that)
 
-	surfmap = Mod_Malloc( mod, bm->numfaces * sizeof( *surfmap ) );
+	surfmap = ( msurface_t ** )Mod_Malloc( mod, bm->numfaces * sizeof( *surfmap ) );
 
 	num_vbos = 0;
 	*vbo_total_size = 0;
@@ -456,6 +456,8 @@ static int Mod_CreateSubmodelBufferObjects( model_t *mod, unsigned int modnum, s
 				if( surf2->shader != surf->shader || surf2->superLightStyle != surf->superLightStyle )
 					continue;
 				if( surf2->fog != surf->fog )
+					continue;
+				if( ( vcount + surf2->mesh->numVerts ) > USHRT_MAX )
 					continue;
 
 				// unvised maps and submodels submodel can simply skip PVS checks

--- a/source/ref_gl/r_vbo.c
+++ b/source/ref_gl/r_vbo.c
@@ -176,7 +176,7 @@ mesh_vbo_t *R_CreateMeshVBO( void *owner, int numVerts, int numElems, int numIns
 		vbo->lmstOffset[i] = vertexSize;
 		vbo->lmstSize[i] = vattribs & VATTRIB_LMCOORDS0_BIT<<1 ? 4 : 2;
 		vertexSize += FLOAT_VATTRIB_SIZE(VATTRIB_LMCOORDS0_BIT, halfFloatVattribs) * vbo->lmstSize[i];
-		lmattrbit <<= 2;
+		lmattrbit = ( vattribbit_t )( ( vattribmask_t )lmattrbit << 2 );
 	}
 
 	// vertex colors
@@ -241,7 +241,7 @@ mesh_vbo_t *R_CreateMeshVBO( void *owner, int numVerts, int numElems, int numIns
 		goto error;
 	vbo->elemId = vbo_id;
 
-	size = numElems * sizeof( unsigned int );
+	size = numElems * sizeof( elem_t );
 	RB_BindElementArrayBuffer( vbo->elemId );
 	qglBufferDataARB( GL_ELEMENT_ARRAY_BUFFER_ARB, size, NULL, elem_usage );
 	if( qglGetError () == GL_OUT_OF_MEMORY )
@@ -723,7 +723,7 @@ void R_DiscardVBOElemData( mesh_vbo_t *vbo )
 static int R_UploadVBOElemQuadData( mesh_vbo_t *vbo, int vertsOffset, int elemsOffset, int numVerts )
 {
 	int numElems;
-	unsigned int *ielems;
+	elem_t *ielems;
 
 	assert( vbo != NULL );
 
@@ -736,8 +736,8 @@ static int R_UploadVBOElemQuadData( mesh_vbo_t *vbo, int vertsOffset, int elemsO
 	R_BuildQuadElements( vertsOffset, numVerts, ielems );
 
 	RB_BindElementArrayBuffer( vbo->elemId );
-	qglBufferSubDataARB( GL_ELEMENT_ARRAY_BUFFER_ARB, elemsOffset * sizeof( unsigned int ), 
-		numElems * sizeof( unsigned int ), ielems );
+	qglBufferSubDataARB( GL_ELEMENT_ARRAY_BUFFER_ARB, elemsOffset * sizeof( elem_t ), 
+		numElems * sizeof( elem_t ), ielems );
 
 	return numElems;
 }
@@ -750,7 +750,7 @@ static int R_UploadVBOElemQuadData( mesh_vbo_t *vbo, int vertsOffset, int elemsO
 static int R_UploadVBOElemTrifanData( mesh_vbo_t *vbo, int vertsOffset, int elemsOffset, int numVerts )
 {
 	int numElems;
-	unsigned int *ielems;
+	elem_t *ielems;
 
 	assert( vbo != NULL );
 
@@ -763,8 +763,8 @@ static int R_UploadVBOElemTrifanData( mesh_vbo_t *vbo, int vertsOffset, int elem
 	R_BuildTrifanElements( vertsOffset, numVerts, ielems );
 
 	RB_BindElementArrayBuffer( vbo->elemId );
-	qglBufferSubDataARB( GL_ELEMENT_ARRAY_BUFFER_ARB, elemsOffset * sizeof( unsigned int ), 
-		numElems * sizeof( unsigned int ), ielems );
+	qglBufferSubDataARB( GL_ELEMENT_ARRAY_BUFFER_ARB, elemsOffset * sizeof( elem_t ), 
+		numElems * sizeof( elem_t ), ielems );
 
 	return numElems;
 }
@@ -778,7 +778,7 @@ void R_UploadVBOElemData( mesh_vbo_t *vbo, int vertsOffset, int elemsOffset,
 	const mesh_t *mesh, vbo_hint_t hint )
 {
 	int i;
-	unsigned int *ielems;
+	elem_t *ielems;
 
 	assert( vbo != NULL );
 
@@ -801,8 +801,8 @@ void R_UploadVBOElemData( mesh_vbo_t *vbo, int vertsOffset, int elemsOffset,
 	}
 
 	RB_BindElementArrayBuffer( vbo->elemId );
-	qglBufferSubDataARB( GL_ELEMENT_ARRAY_BUFFER_ARB, elemsOffset * sizeof( unsigned int ), 
-		mesh->numElems * sizeof( unsigned int ), ielems );
+	qglBufferSubDataARB( GL_ELEMENT_ARRAY_BUFFER_ARB, elemsOffset * sizeof( elem_t ), 
+		mesh->numElems * sizeof( elem_t ), ielems );
 }
 
 /*


### PR DESCRIPTION
Updated version of #73. Doesn't merge more than 65536 world vertices.

Since mesh numVerts is already a short integer, all world meshes will fit in a 16-bit index buffer.

Also fixed VS2012 type casting errors.
