### PR TITLE
QGL bugfixes

### DIFF
--- a/source/mac/mac_qgl.c
+++ b/source/mac/mac_qgl.c
@@ -164,6 +164,16 @@ qboolean QGL_Init( const char *dllname )
 }
 
 /*
+** QGL_GetDriverName
+**
+** Returns the default GL DLL name for the target operating system.
+*/
+const char *QGL_GetDriverName( void )
+{
+	return "/System/Library/Frameworks/OpenGL.framework/Libraries/libGL.dylib";
+}
+
+/*
 ** qglGetProcAddress
 */
 void *qglGetProcAddress( const GLubyte *procName )

--- a/source/unix/unix_qgl.c
+++ b/source/unix/unix_qgl.c
@@ -154,11 +154,7 @@ qboolean QGL_Init( const char *dllname )
 */
 const char *QGL_GetDriverName( void )
 {
-#ifdef __MACOSX__
-	return "/System/Library/Frameworks/OpenGL.framework/Libraries/libGL.dylib";
-#else
 	return "libGL.so.1";
-#endif
 }
 
 /*

--- a/source/win32/win_qgl.c
+++ b/source/win32/win_qgl.c
@@ -133,8 +133,12 @@ qboolean QGL_Init( const char *dllname )
 
 		buf = NULL;
 		FormatMessage( FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM, NULL, GetLastError(), MAKELANGID( LANG_NEUTRAL, SUBLANG_DEFAULT ), (LPTSTR) &buf, 0, NULL );
-		Com_Printf( "%s\n", buf );
-		MessageBox( NULL, buf, "Error", 0 /* MB_OK */ );
+		if( buf )
+		{
+			Com_Printf( "%s\n", buf );
+			MessageBox( NULL, buf, "Error", 0 /* MB_OK */ );
+			LocalFree( buf );
+		}
 		return qfalse;
 	}
 


### PR DESCRIPTION
Since Mac has its own QGL code, it doesn't share QGL_GetDriverName with Unix (my fault).

Also fixed a memory leak in Win32 QGL_Init caused by not freeing the buffer created by FormatMessage.
