### PR TITLE
Add QGL_GetDriverInfo for systems without driver override

### DIFF
--- a/source/mac/mac_qgl.c
+++ b/source/mac/mac_qgl.c
@@ -170,9 +170,11 @@ qboolean QGL_Init( const char *dllname )
 */
 const qgl_driverinfo_t *QGL_GetDriverInfo( void )
 {
-	static qgl_driverinfo_t driver;
-	driver.dllname = "/System/Library/Frameworks/OpenGL.framework/Libraries/libGL.dylib";
-	driver.dllcvarname = "mac_gl_driver";
+	static const qgl_driverinfo_t driver =
+	{
+		"/System/Library/Frameworks/OpenGL.framework/Libraries/libGL.dylib",
+		"mac_gl_driver"
+	};
 	return &driver;
 }
 

--- a/source/mac/mac_qgl.c
+++ b/source/mac/mac_qgl.c
@@ -164,13 +164,16 @@ qboolean QGL_Init( const char *dllname )
 }
 
 /*
-** QGL_GetDriverName
+** QGL_GetDriverInfo
 **
-** Returns the default GL DLL name for the target operating system.
+** Returns information about the GL DLL.
 */
-const char *QGL_GetDriverName( void )
+const qgl_driverinfo_t *QGL_GetDriverInfo( void )
 {
-	return "/System/Library/Frameworks/OpenGL.framework/Libraries/libGL.dylib";
+	static qgl_driverinfo_t driver;
+	driver.dllname = "/System/Library/Frameworks/OpenGL.framework/Libraries/libGL.dylib";
+	driver.dllcvarname = "mac_gl_driver";
+	return &driver;
 }
 
 /*

--- a/source/ref_gl/qgl.h
+++ b/source/ref_gl/qgl.h
@@ -78,12 +78,18 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #undef GL_GLEXT_LEGACY
 #undef GLX_GLXEXT_LEGACY
 
-QGL_EXTERN	const char	*QGL_GetDriverName( void );
-QGL_EXTERN	qboolean	QGL_Init( const char *dllname );
-QGL_EXTERN	void		QGL_Shutdown( void );
+typedef struct qgl_driverinfo_s
+{
+	const char *dllname;		// default driver DLL name
+	const char *dllcvarname;	// custom driver DLL cvar name, NULL if can't override driver
+} qgl_driverinfo_t;
 
-QGL_EXTERN	void		*qglGetProcAddress( const GLubyte * );
-QGL_EXTERN	const char	*(*qglGetGLWExtensionsString)( void );
+QGL_EXTERN	const qgl_driverinfo_t	*QGL_GetDriverInfo( void );
+QGL_EXTERN	qboolean				QGL_Init( const char *dllname );
+QGL_EXTERN	void					QGL_Shutdown( void );
+
+QGL_EXTERN	void					*qglGetProcAddress( const GLubyte * );
+QGL_EXTERN	const char				*(*qglGetGLWExtensionsString)( void );
 
 /*
 ** extension constants

--- a/source/ref_gl/r_register.c
+++ b/source/ref_gl/r_register.c
@@ -777,6 +777,8 @@ static void R_Register( const char *screenshotsPrefix )
 	driver = QGL_GetDriverInfo();
 	if( driver->dllcvarname )
 		gl_driver = ri.Cvar_Get( driver->dllcvarname, driver->dllname, CVAR_ARCHIVE|CVAR_LATCH_VIDEO );
+	else
+		gl_driver = NULL;
 
 	ri.Cmd_AddCommand( "imagelist", R_ImageList_f );
 	ri.Cmd_AddCommand( "shaderlist", R_ShaderList_f );
@@ -834,7 +836,7 @@ rserr_t R_Init( const char *applicationName, const char *screenshotPrefix,
 	int x, int y, int width, int height, int displayFrequency,
 	qboolean fullScreen, qboolean wideScreen, qboolean verbose )
 {
-	const qgl_driverinfo_t *driver;
+	const char *dllname;
 	int i;
 	char renderer_buffer[1024];
 	char vendor_buffer[1024];
@@ -855,17 +857,16 @@ rserr_t R_Init( const char *applicationName, const char *screenshotPrefix,
 	memset( &glConfig, 0, sizeof(glConfig) );
 
 	// initialize our QGL dynamic bindings
-	driver = QGL_GetDriverInfo();
+	dllname = QGL_GetDriverInfo()->dllname;
 init_qgl:
-	if( !QGL_Init( driver->dllcvarname ? gl_driver->string : driver->dllname ) )
+	if( !QGL_Init( gl_driver ? gl_driver->string : dllname ) )
 	{
 		QGL_Shutdown();
-		Com_Printf( "ref_gl::R_Init() - could not load \"%s\"\n",
-			driver->dllcvarname ? gl_driver->string : driver->dllname );
+		Com_Printf( "ref_gl::R_Init() - could not load \"%s\"\n", gl_driver ? gl_driver->string : dllname );
 
-		if( driver->dllcvarname && strcmp( gl_driver->string, driver->dllname ) )
+		if( gl_driver && strcmp( gl_driver->string, dllname ) )
 		{
-			ri.Cvar_ForceSet( gl_driver->name, driver->dllname );
+			ri.Cvar_ForceSet( gl_driver->name, dllname );
 			goto init_qgl;
 		}
 

--- a/source/ref_gl/r_register.c
+++ b/source/ref_gl/r_register.c
@@ -662,6 +662,8 @@ static void R_FinalizeGLExtensions( void )
 
 static void R_Register( const char *screenshotsPrefix )
 {
+	const qgl_driverinfo_t *driver;
+
 	r_norefresh = ri.Cvar_Get( "r_norefresh", "0", 0 );
 	r_fullbright = ri.Cvar_Get( "r_fullbright", "0", CVAR_LATCH_VIDEO );
 	r_lightmap = ri.Cvar_Get( "r_lightmap", "0", 0 );
@@ -770,8 +772,11 @@ static void R_Register( const char *screenshotsPrefix )
 
 	gl_finish = ri.Cvar_Get( "gl_finish", "0", CVAR_ARCHIVE );
 	gl_cull = ri.Cvar_Get( "gl_cull", "1", 0 );
-	gl_driver = ri.Cvar_Get( "gl_driver", QGL_GetDriverName(), CVAR_ARCHIVE|CVAR_LATCH_VIDEO );
 	gl_drawbuffer = ri.Cvar_Get( "gl_drawbuffer", "GL_BACK", 0 );
+
+	driver = QGL_GetDriverInfo();
+	if( driver->dllcvarname )
+		gl_driver = ri.Cvar_Get( driver->dllcvarname, driver->dllname, CVAR_ARCHIVE|CVAR_LATCH_VIDEO );
 
 	ri.Cmd_AddCommand( "imagelist", R_ImageList_f );
 	ri.Cmd_AddCommand( "shaderlist", R_ShaderList_f );
@@ -829,6 +834,7 @@ rserr_t R_Init( const char *applicationName, const char *screenshotPrefix,
 	int x, int y, int width, int height, int displayFrequency,
 	qboolean fullScreen, qboolean wideScreen, qboolean verbose )
 {
+	const qgl_driverinfo_t *driver;
 	int i;
 	char renderer_buffer[1024];
 	char vendor_buffer[1024];
@@ -849,15 +855,17 @@ rserr_t R_Init( const char *applicationName, const char *screenshotPrefix,
 	memset( &glConfig, 0, sizeof(glConfig) );
 
 	// initialize our QGL dynamic bindings
+	driver = QGL_GetDriverInfo();
 init_qgl:
-	if( !QGL_Init( gl_driver->string ) )
+	if( !QGL_Init( driver->dllcvarname ? gl_driver->string : driver->dllname ) )
 	{
 		QGL_Shutdown();
-		Com_Printf( "ref_gl::R_Init() - could not load \"%s\"\n", gl_driver->string );
+		Com_Printf( "ref_gl::R_Init() - could not load \"%s\"\n",
+			driver->dllcvarname ? gl_driver->string : driver->dllname );
 
-		if( strcmp( gl_driver->string, QGL_GetDriverName() ) )
+		if( driver->dllcvarname && strcmp( gl_driver->string, driver->dllname ) )
 		{
-			ri.Cvar_ForceSet( gl_driver->name, QGL_GetDriverName() );
+			ri.Cvar_ForceSet( gl_driver->name, driver->dllname );
 			goto init_qgl;
 		}
 

--- a/source/unix/unix_qgl.c
+++ b/source/unix/unix_qgl.c
@@ -154,9 +154,11 @@ qboolean QGL_Init( const char *dllname )
 */
 const qgl_driverinfo_t *QGL_GetDriverInfo( void )
 {
-	static qgl_driverinfo_t driver;
-	driver.dllname = "libGL.so.1";
-	driver.dllcvarname = "unix_gl_driver";
+	static const qgl_driverinfo_t driver =
+	{
+		"libGL.so.1",
+		"unix_gl_driver"
+	};
 	return &driver;
 }
 

--- a/source/unix/unix_qgl.c
+++ b/source/unix/unix_qgl.c
@@ -148,13 +148,16 @@ qboolean QGL_Init( const char *dllname )
 }
 
 /*
-** QGL_GetDriverName
+** QGL_GetDriverInfo
 **
-** Returns the default GL DLL name for the target operating system.
+** Returns information about the GL DLL.
 */
-const char *QGL_GetDriverName( void )
+const qgl_driverinfo_t *QGL_GetDriverInfo( void )
 {
-	return "libGL.so.1";
+	static qgl_driverinfo_t driver;
+	driver.dllname = "libGL.so.1";
+	driver.dllcvarname = "unix_gl_driver";
+	return &driver;
 }
 
 /*

--- a/source/win32/win_qgl.c
+++ b/source/win32/win_qgl.c
@@ -106,13 +106,16 @@ void QGL_Shutdown( void )
 #pragma warning( disable : 4113 4133 4047 )
 
 /*
-** QGL_GetDriverName
+** QGL_GetDriverInfo
 **
-** Returns the default GL DLL name for the target operating system.
+** Returns information about the GL DLL.
 */
-const char *QGL_GetDriverName( void )
+const qgl_driverinfo_t *QGL_GetDriverInfo( void )
 {
-	return "opengl32.dll";
+	static qgl_driverinfo_t driver;
+	driver.dllname = "opengl32.dll";
+	driver.dllcvarname = "win_gl_driver";
+	return &driver;
 }
 
 /*

--- a/source/win32/win_qgl.c
+++ b/source/win32/win_qgl.c
@@ -112,9 +112,11 @@ void QGL_Shutdown( void )
 */
 const qgl_driverinfo_t *QGL_GetDriverInfo( void )
 {
-	static qgl_driverinfo_t driver;
-	driver.dllname = "opengl32.dll";
-	driver.dllcvarname = "win_gl_driver";
+	static const qgl_driverinfo_t driver =
+	{
+		"opengl32.dll",
+		"win_gl_driver"
+	};
 	return &driver;
 }
 


### PR DESCRIPTION
A cleaned-up version of https://github.com/viciious/qfusion/commit/7886b80fb6cac3b5d5c0a7112e29d62a3293227f

QGL now specifies which convar to use to override the default GL driver DLL and whether to use it at all.

This solves the issue with updating to Android 4.3: if the engine ran on a GLES3-supporting device on an old OS version before the update, `libGLESv2.so` would be stored in `config.cfg`, which is not the valid library for GLES3.
