### PR TITLE
Clear first frame in R_Init

### DIFF
--- a/source/ref_gl/r_backend.c
+++ b/source/ref_gl/r_backend.c
@@ -157,9 +157,6 @@ static void RB_SetGLDefaults( void )
 #endif
 	qglFrontFace( GL_CCW );
 
-	qglClearColor( 0.1, 0.09, 0.12, 1.0 );
-	qglClear( GL_COLOR_BUFFER_BIT );
-
 	memset( &rb.gl, 0, sizeof( rb.gl ) );
 	rb.gl.currentTMU = -1;
 }

--- a/source/ref_gl/r_register.c
+++ b/source/ref_gl/r_register.c
@@ -803,6 +803,11 @@ static void R_FinalizeGLExtensions( void )
 		ri.Cvar_ForceSet( "r_lighting_maxlmblocksize", va( "%i", glConfig.maxTextureSize / 4 ) );
 }
 
+/*
+* R_ClearFirstFrame
+*
+* Fills the window with a color during the initialization.
+*/
 static void R_ClearFirstFrame( void )
 {
 	qglClearColor( 0.1, 0.09, 0.12, 1.0 );

--- a/source/ref_gl/r_register.c
+++ b/source/ref_gl/r_register.c
@@ -807,7 +807,7 @@ static void R_ClearFirstFrame( void )
 {
 	qglClearColor( 0.1, 0.09, 0.12, 1.0 );
 #ifdef GL_ES_VERSION_2_0
-	if( glConfig.ext.multiview_draw_buffers )
+	if( glConfig.ext.multiview_draw_buffers && glConfig.stereoEnabled )
 	{
 		int location = GL_MULTIVIEW_NV;
 		int index = 1;

--- a/source/ref_gl/r_register.c
+++ b/source/ref_gl/r_register.c
@@ -803,6 +803,38 @@ static void R_FinalizeGLExtensions( void )
 		ri.Cvar_ForceSet( "r_lighting_maxlmblocksize", va( "%i", glConfig.maxTextureSize / 4 ) );
 }
 
+static void R_ClearFirstFrame( void )
+{
+	qglClearColor( 0.1, 0.09, 0.12, 1.0 );
+#ifdef GL_ES_VERSION_2_0
+	if( glConfig.ext.multiview_draw_buffers )
+	{
+		int location = GL_MULTIVIEW_NV;
+		int index = 1;
+		qglDrawBuffersIndexedNV( 1, &location, &index );
+		GLimp_BeginFrame();
+		qglClear( GL_COLOR_BUFFER_BIT );
+		GLimp_EndFrame();
+		index = 0;
+		qglDrawBuffersIndexedNV( 1, &location, &index );
+	}
+	GLimp_BeginFrame();
+	qglClear( GL_COLOR_BUFFER_BIT );
+	GLimp_EndFrame();
+#else
+	if( glConfig.stereoEnabled )
+	{
+		qglDrawBuffer( GL_FRONT_LEFT );
+		qglClear( GL_COLOR_BUFFER_BIT );
+		qglDrawBuffer( GL_FRONT_RIGHT );
+		qglClear( GL_COLOR_BUFFER_BIT );
+	}
+	qglDrawBuffer( GL_FRONT );
+	qglClear( GL_COLOR_BUFFER_BIT );
+	qglDrawBuffer( GL_BACK );
+#endif
+}
+
 static void R_Register( const char *screenshotsPrefix )
 {
 	const qgl_driverinfo_t *driver;
@@ -1079,6 +1111,8 @@ init_qgl:
 		QGL_Shutdown();
 		return rserr_unknown;
 	}
+
+	R_ClearFirstFrame();
 
 	R_TextureMode( r_texturemode->string );
 


### PR DESCRIPTION
Clear first rendering frame so the loading doesn't display a simple black/empty screen that looks like the engine being unresponsive.
