### PR TITLE
Add touchscreen input

### DIFF
--- a/source/cgame/cg_hud.cpp
+++ b/source/cgame/cg_hud.cpp
@@ -38,6 +38,7 @@ cvar_t *cg_showitemtimers;
 cvar_t *cg_placebo;
 cvar_t *cg_strafeHUD;
 cvar_t *cg_touch_flip;
+cvar_t *cg_touch_scale;
 
 static int cg_hud_touch_buttons, cg_hud_touch_upmove;
 

--- a/source/cgame/cg_hud.cpp
+++ b/source/cgame/cg_hud.cpp
@@ -615,6 +615,7 @@ static const reference_numeric_t cg_numeric_references[] =
 	{ "CHAT_MODE", CG_GetCvar, "con_messageMode" },
 
 	{ "TOUCH_FLIP", CG_GetCvar, "cg_touch_flip" },
+	{ "TOUCH_SCALE", CG_GetCvar, "cg_touch_scale" },
 
 	{ "ITEM_TIMER0", CG_GetItemTimer, (void *)0 },
 	{ "ITEM_TIMER0_COUNT", CG_GetItemTimerCount, (void *)0 },

--- a/source/cgame/cg_local.h
+++ b/source/cgame/cg_local.h
@@ -45,6 +45,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define GAMECHAT_STRING_SIZE	150
 #define GAMECHAT_STACK_SIZE		20
 
+#define CG_MAX_TOUCHES 10
+
 enum
 {
 	LOCALEFFECT_EV_PLAYER_TELEPORT_IN
@@ -721,14 +723,14 @@ void CG_LoadStatusBar( void );
 void CG_LoadingString( const char *str );
 void CG_LoadingItemName( const char *str );
 
-void CG_DrawCrosshair( int x, int y, int align );
+void CG_DrawCrosshair( int x, int y, int align, bool touch );
 void CG_DrawKeyState( int x, int y, int w, int h, int align, const char *key );
 
 void CG_ScreenCrosshairDamageUpdate( void );
 
 int CG_ParseValue( const char **s );
 
-void CG_DrawClock( int x, int y, int align, struct qfontface_s *font, vec4_t color );
+void CG_DrawClock( int x, int y, int align, struct qfontface_s *font, vec4_t color, bool touch );
 void CG_DrawPlayerNames( struct qfontface_s *font, vec4_t color );
 void CG_DrawTeamMates( void );
 void CG_DrawHUDNumeric( int x, int y, int align, float *color, int charwidth, int charheight, int value );
@@ -737,6 +739,27 @@ void CG_DrawNet( int x, int y, int w, int h, int align, vec4_t color );
 
 void CG_GameMenu_f( void );
 
+enum
+{
+	TOUCHAREA_SCREEN,
+	TOUCHAREA_HUD = 0x100
+};
+
+int CG_TouchArea( int area, int x, int y, int w, int h, bool sticky, void ( *upfunc )( int id ) );
+void CG_TouchEvent( int id, touchevent_t type, int x, int y );
+void CG_TouchFrame( qboolean active );
+void CG_TouchMove( usercmd_t *cmd, vec3_t viewangles, int frametime );
+
+enum
+{
+	TOUCHPAD_MOVE,
+	TOUCHPAD_VIEW,
+
+	TOUCHPAD_COUNT
+};
+
+void CG_SetTouchpad( int padID, int touchID );
+
 //
 // cg_hud.c
 //
@@ -744,10 +767,12 @@ extern cvar_t *cg_showminimap;
 extern cvar_t *cg_showitemtimers;
 extern cvar_t *cg_placebo;
 extern cvar_t *cg_strafeHUD;
+extern cvar_t *cg_touch_flip;
 
 void CG_SC_Obituary( void );
 void Cmd_CG_PrintHudHelp_f( void );
-void CG_ExecuteLayoutProgram( struct cg_layoutnode_s *rootnode );
+void CG_ExecuteLayoutProgram( struct cg_layoutnode_s *rootnode, bool touch );
+void CG_GetHUDTouchButtons( int &buttons, int &upmove );
 
 //
 // cg_damage_indicator.c

--- a/source/cgame/cg_local.h
+++ b/source/cgame/cg_local.h
@@ -741,8 +741,9 @@ void CG_GameMenu_f( void );
 
 enum
 {
+	TOUCHAREA_NONE,
 	TOUCHAREA_SCREEN,
-	TOUCHAREA_HUD = 0x100
+	TOUCHAREA_HUD = 0x101
 };
 
 int CG_TouchArea( int area, int x, int y, int w, int h, bool sticky, void ( *upfunc )( int id ) );

--- a/source/cgame/cg_local.h
+++ b/source/cgame/cg_local.h
@@ -769,6 +769,7 @@ extern cvar_t *cg_showitemtimers;
 extern cvar_t *cg_placebo;
 extern cvar_t *cg_strafeHUD;
 extern cvar_t *cg_touch_flip;
+extern cvar_t *cg_touch_scale;
 
 void CG_SC_Obituary( void );
 void Cmd_CG_PrintHudHelp_f( void );

--- a/source/cgame/cg_main.cpp
+++ b/source/cgame/cg_main.cpp
@@ -756,6 +756,7 @@ static void CG_RegisterVariables( void )
 	cg_showitemtimers = trap_Cvar_Get( "cg_showItemTimers", "3", CVAR_ARCHIVE );
 	cg_placebo =  trap_Cvar_Get( "cg_placebo", "0", CVAR_ARCHIVE );
 	cg_strafeHUD = trap_Cvar_Get( "cg_strafeHUD", "0", CVAR_ARCHIVE );
+	cg_touch_flip = trap_Cvar_Get( "cg_touch_flip", "0", CVAR_ARCHIVE );
 
 	cg_playList = trap_Cvar_Get( "cg_playList", S_PLAYLIST_MATCH, CVAR_ARCHIVE );
 	cg_playListShuffle = trap_Cvar_Get( "cg_playListShuffle", "1", CVAR_ARCHIVE );

--- a/source/cgame/cg_main.cpp
+++ b/source/cgame/cg_main.cpp
@@ -757,6 +757,7 @@ static void CG_RegisterVariables( void )
 	cg_placebo =  trap_Cvar_Get( "cg_placebo", "0", CVAR_ARCHIVE );
 	cg_strafeHUD = trap_Cvar_Get( "cg_strafeHUD", "0", CVAR_ARCHIVE );
 	cg_touch_flip = trap_Cvar_Get( "cg_touch_flip", "0", CVAR_ARCHIVE );
+	cg_touch_scale = trap_Cvar_Get( "cg_touch_scale", "1", CVAR_ARCHIVE );
 
 	cg_playList = trap_Cvar_Get( "cg_playList", S_PLAYLIST_MATCH, CVAR_ARCHIVE );
 	cg_playListShuffle = trap_Cvar_Get( "cg_playListShuffle", "1", CVAR_ARCHIVE );

--- a/source/cgame/cg_public.h
+++ b/source/cgame/cg_public.h
@@ -30,7 +30,7 @@ typedef unsigned int (*cg_get_raw_samples_cb_t)(void*);
 
 // cg_public.h -- client game dll information visible to engine
 
-#define	CGAME_API_VERSION   65
+#define	CGAME_API_VERSION   66
 
 //
 // structs and variables shared with the main engine
@@ -279,6 +279,12 @@ typedef struct
 	void ( *RenderView )( float frameTime, float realFrameTime, int realTime, unsigned int serverTime, float stereo_separation, unsigned int extrapolationTime );
 
 	void ( *NewFrameSnapshot )( snapshot_t *newSnapshot, snapshot_t *currentSnapshot );
+
+	void ( *TouchEvent )( int id, touchevent_t type, int x, int y );
+
+	void ( *TouchFrame )( qboolean active );
+
+	void ( *TouchMove )( usercmd_t *cmd, vec3_t viewangles, int frametime );
 } cgame_export_t;
 
 #endif

--- a/source/cgame/cg_screen.cpp
+++ b/source/cgame/cg_screen.cpp
@@ -55,6 +55,10 @@ cvar_t *cg_crosshair_strong_color;
 
 cvar_t *cg_crosshair_damage_color;
 
+cvar_t *cg_crosshair_touch_size;
+
+static bool cg_crosshair_zoom;
+
 cvar_t *cg_clientHUD;
 cvar_t *cg_specHUD;
 cvar_t *cg_debugHUD;
@@ -80,6 +84,13 @@ cvar_t *cg_scoreboardWidthScale;
 
 cvar_t *cg_showTeamLocations;
 cvar_t *cg_showViewBlends;
+
+cvar_t *cg_touch_moveThreshold;
+cvar_t *cg_touch_strafeThreshold;
+cvar_t *cg_touch_pitchThreshold;
+cvar_t *cg_touch_pitchSpeed;
+cvar_t *cg_touch_yawThreshold;
+cvar_t *cg_touch_yawSpeed;
 
 float scr_damagetime_start;
 float scr_damagetime_off;
@@ -258,6 +269,12 @@ static void CG_SizeDown_f( void )
 
 //============================================================================
 
+enum
+{
+	TOUCHAREA_SCREEN_CROSSHAIR = TOUCHAREA_SCREEN,
+	TOUCHAREA_SCREEN_TIMER
+};
+
 /*
 * CG_ScreenInit
 */
@@ -275,6 +292,7 @@ void CG_ScreenInit( void )
 	cg_crosshair_size =	trap_Cvar_Get( "cg_crosshair_size", "32", CVAR_ARCHIVE );
 	cg_crosshair_color =	trap_Cvar_Get( "cg_crosshair_color", "255 255 255", CVAR_ARCHIVE );
 	cg_crosshair_damage_color =	trap_Cvar_Get( "cg_crosshair_damage_color", "255 0 0", CVAR_ARCHIVE );
+	cg_crosshair_touch_size =	trap_Cvar_Get( "cg_crosshair_touch_size", "96", CVAR_ARCHIVE );
 	cg_crosshair_color->modified = qtrue;
 	cg_crosshair_damage_color->modified = qfalse;
 
@@ -311,6 +329,13 @@ void CG_ScreenInit( void )
 	// wsw : hud debug prints
 	cg_debugHUD =		    trap_Cvar_Get( "cg_debugHUD", "0", 0 );
 
+	cg_touch_moveThreshold = trap_Cvar_Get( "cg_touch_moveThreshold", "12", CVAR_ARCHIVE );
+	cg_touch_strafeThreshold = trap_Cvar_Get( "cg_touch_strafeThreshold", "12", CVAR_ARCHIVE );
+	cg_touch_pitchThreshold = trap_Cvar_Get( "cg_touch_pitchThreshold", "12", CVAR_ARCHIVE );
+	cg_touch_pitchSpeed = trap_Cvar_Get( "cg_touch_pitchSpeed", "4", CVAR_ARCHIVE );
+	cg_touch_yawThreshold = trap_Cvar_Get( "cg_touch_yawThreshold", "8", CVAR_ARCHIVE );
+	cg_touch_yawSpeed = trap_Cvar_Get( "cg_touch_yawSpeed", "4", CVAR_ARCHIVE );
+
 	//
 	// register our commands
 	//
@@ -318,6 +343,10 @@ void CG_ScreenInit( void )
 	trap_Cmd_AddCommand( "sizedown", CG_SizeDown_f );
 	trap_Cmd_AddCommand( "help_hud", Cmd_CG_PrintHudHelp_f );
 	trap_Cmd_AddCommand( "gamemenu", CG_GameMenu_f );
+
+	int i;
+	for( i = 0; i < TOUCHPAD_COUNT; ++i )
+		CG_SetTouchpad( i, -1 );
 }
 
 /*
@@ -372,9 +401,9 @@ void CG_DrawNet( int x, int y, int w, int h, int align, vec4_t color )
 }
 
 /*
-*  CG_DrawCrosshair
+* CG_DrawCrosshair
 */
-void CG_DrawCrosshair( int x, int y, int align )
+void CG_DrawCrosshair( int x, int y, int align, bool touch )
 {
 	static vec4_t chColor = { 255, 255, 255, 255 };
 	static vec4_t chColorStrong = { 255, 255, 255, 255 };
@@ -383,15 +412,22 @@ void CG_DrawCrosshair( int x, int y, int align )
 	if( cg_crosshair->modified )
 	{
 		if( cg_crosshair->integer >= NUM_CROSSHAIRS || cg_crosshair->integer < 0 )
-			trap_Cvar_Set( "cg_crosshair", va( "%i", 0 ) );
+			trap_Cvar_Set( "cg_crosshair", "0" );
 		cg_crosshair->modified = qfalse;
 	}
 
 	if( cg_crosshair_size->modified )
 	{
 		if( cg_crosshair_size->integer < 0 || cg_crosshair_size->integer > 2000 )
-			trap_Cvar_Set( "cg_crosshair_size", va( "%i", 32 ) );
+			trap_Cvar_Set( "cg_crosshair_size", "32" );
 		cg_crosshair_size->modified = qfalse;
+	}
+
+	if( cg_crosshair_touch_size->modified )
+	{
+		if( cg_crosshair_touch_size->integer < 0 || cg_crosshair_touch_size->integer > 2000 )
+			trap_Cvar_Set( "cg_crosshair_touch_size", "96" );
+		cg_crosshair_touch_size->modified = qfalse;
 	}
 
 	if( cg_crosshair_color->modified || cg_crosshair_damage_color->modified )
@@ -421,14 +457,14 @@ void CG_DrawCrosshair( int x, int y, int align )
 	if( cg_crosshair_strong->modified )
 	{
 		if( cg_crosshair_strong->integer >= NUM_CROSSHAIRS || cg_crosshair_strong->integer < 0 )
-			trap_Cvar_Set( "cg_crosshair_strong", va( "%i", 0 ) );
+			trap_Cvar_Set( "cg_crosshair_strong", "0" );
 		cg_crosshair_strong->modified = qfalse;
 	}
 
 	if( cg_crosshair_strong_size->modified )
 	{
 		if( cg_crosshair_strong_size->integer < 0 || cg_crosshair_strong_size->integer > 2000 )
-			trap_Cvar_Set( "cg_crosshair_strong_size", va( "%i", 32 ) );
+			trap_Cvar_Set( "cg_crosshair_strong_size", "32" );
 		cg_crosshair_strong_size->modified = qfalse;
 	}
 
@@ -451,28 +487,44 @@ void CG_DrawCrosshair( int x, int y, int align )
 		cg_crosshair_strong_color->modified = qfalse;
 	}
 
+	float scale = cgs.vidHeight * ( 1.0f / 600.0f );
+
 	if( cg_crosshair_strong->integer )
 	{
 		firedef_t *firedef = GS_FiredefForPlayerState( &cg.predictedPlayerState, cg.predictedPlayerState.stats[STAT_WEAPON] );
 		if( firedef && firedef->fire_mode == FIRE_MODE_STRONG ) // strong
 		{
+			int size = cg_crosshair_strong_size->integer * scale;
 			int sx, sy;
-			sx = CG_HorizontalAlignForWidth( x, align, cg_crosshair_strong_size->integer );
-			sy = CG_VerticalAlignForHeight( y, align, cg_crosshair_strong_size->integer );
+			sx = CG_HorizontalAlignForWidth( x, align, size );
+			sy = CG_VerticalAlignForHeight( y, align, size );
 
-			trap_R_DrawStretchPic( sx, sy, cg_crosshair_strong_size->integer, cg_crosshair_strong_size->integer,
-				0, 0, 1, 1, chColorStrong,
-				CG_MediaShader( cgs.media.shaderCrosshair[cg_crosshair_strong->integer] ) );
+			if( !touch )
+			{
+				trap_R_DrawStretchPic( sx, sy, size, size, 0, 0, 1, 1, chColorStrong,
+					CG_MediaShader( cgs.media.shaderCrosshair[cg_crosshair_strong->integer] ) );
+			}
 		}
 	}
 
 	if( cg_crosshair->integer && cg.predictedPlayerState.stats[STAT_WEAPON] != WEAP_NONE )
 	{
-		x = CG_HorizontalAlignForWidth( x, align, cg_crosshair_size->integer );
-		y = CG_VerticalAlignForHeight( y, align, cg_crosshair_size->integer );
+		int size = cg_crosshair_size->integer * scale;
+		x = CG_HorizontalAlignForWidth( x, align, size );
+		y = CG_VerticalAlignForHeight( y, align, size );
 
-		trap_R_DrawStretchPic( x, y, cg_crosshair_size->integer, cg_crosshair_size->integer,
-			0, 0, 1, 1, chColor, CG_MediaShader( cgs.media.shaderCrosshair[cg_crosshair->integer] ) );
+		if( touch )
+		{
+			int touch_size = cg_crosshair_touch_size->integer * scale;
+			int offset = ( touch_size - size ) / 2;
+			if( CG_TouchArea( TOUCHAREA_SCREEN_CROSSHAIR, x - offset, y - offset, touch_size, touch_size, true, NULL ) >= 0 )
+				cg_crosshair_zoom = !cg_crosshair_zoom;
+		}
+		else
+		{
+			trap_R_DrawStretchPic( x, y, size, size, 0, 0, 1, 1, chColor,
+				CG_MediaShader( cgs.media.shaderCrosshair[cg_crosshair->integer] ) );
+		}
 	}
 }
 
@@ -508,13 +560,22 @@ void CG_DrawKeyState( int x, int y, int w, int h, int align, const char *key )
 }
 
 /*
+* CG_ClockUpFunc
+*/
+void CG_ClockUpFunc( int id )
+{
+	CG_ScoresOff_f();
+}
+
+/*
 * CG_DrawClock
 */
-void CG_DrawClock( int x, int y, int align, struct qfontface_s *font, vec4_t color )
+void CG_DrawClock( int x, int y, int align, struct qfontface_s *font, vec4_t color, bool touch )
 {
 	unsigned int clocktime, startTime, duration, curtime;
 	double seconds;
 	int minutes;
+	char string[12];
 
 	if( !cg_showTimer->integer )
 		return;
@@ -557,11 +618,27 @@ void CG_DrawClock( int x, int y, int align, struct qfontface_s *font, vec4_t col
 	if( cg.predictedPlayerState.stats[STAT_NEXT_RESPAWN] )
 	{
 		int respawn = cg.predictedPlayerState.stats[STAT_NEXT_RESPAWN];
-		trap_SCR_DrawString( x, y, align, va( "%02i:%02i R:%02i", minutes, (int)seconds, respawn ), font, color );
+		Q_snprintfz( string, sizeof( string ), "%02i:%02i R:%02i", minutes, (int)seconds, respawn );
 	}
 	else
 	{
-		trap_SCR_DrawString( x, y, align, va( "%02i:%02i", minutes, (int)seconds ), font, color );
+		Q_snprintfz( string, sizeof( string ), "%02i:%02i", minutes, (int)seconds );
+	}
+
+	if( touch )
+	{
+		int w = trap_SCR_strWidth( string, font, 0 );
+		int h = trap_SCR_strHeight( font );
+		if( CG_TouchArea( TOUCHAREA_SCREEN_TIMER,
+			CG_HorizontalAlignForWidth( x, align, w ), CG_VerticalAlignForHeight( y, align, h ),
+			w, h, true, CG_ClockUpFunc ) >= 0 )
+		{
+			CG_ScoresOn_f();
+		}
+	}
+	else
+	{
+		trap_SCR_DrawString( x, y, align, string, font, color );
 	}
 }
 
@@ -1304,7 +1381,7 @@ void CG_Draw2DView( void )
 	}
 
 	if( cg_showHUD->integer )
-		CG_ExecuteLayoutProgram( cg.statusBar );
+		CG_ExecuteLayoutProgram( cg.statusBar, false );
 
 	if( drawScoreboard )
 		CG_DrawScoreboard();
@@ -1326,4 +1403,261 @@ void CG_Draw2D( void )
 
 	CG_Draw2DView();
 	CG_DrawDemocam2D();
+}
+
+/*
+===============================================================================
+
+TOUCH INPUT
+
+===============================================================================
+*/
+
+typedef struct {
+	bool down; // is the finger currently down?
+	int x, y; // current x and y of the touch
+	int area; // hud area unique id (0 = not caught by hud)
+	int area_x, area_y, area_x2, area_y2; // dimensions of the area to discard the touch if out of range
+	bool area_valid; // was the area of this touch checked this frame, if not, the area doesn't exist anymore
+	bool sticky; // if true, the touch won't be cancelled when the finger leaves the area
+	void ( *upfunc )( int id ); // function to call when the finger is released
+} cg_touch_t;
+
+static cg_touch_t cg_touches[CG_MAX_TOUCHES];
+
+typedef struct {
+	int touch;
+	int x, y;
+} cg_touchpad_t;
+
+static cg_touchpad_t cg_touchpads[TOUCHPAD_COUNT];
+
+/*
+* CG_TouchArea
+*
+* Touches a rectangle. Returns touch id if it's a new touch.
+*/
+int CG_TouchArea( int area, int x, int y, int w, int h, bool sticky, void ( *upfunc )( int id ) )
+{
+	if( ( w <= 0 ) || ( h <= 0 ) )
+		return -1;
+
+	int i;
+
+	// first check if already touched
+	for( i = 0; i < CG_MAX_TOUCHES; ++i )
+	{
+		cg_touch_t &touch = cg_touches[i];
+
+		if( touch.down && ( touch.area == area ) )
+		{
+			touch.area_valid = true;
+			return -1;
+		}
+	}
+
+	// now add a new touch
+	int x2 = x + w, y2 = y + h;
+	for( i = 0; i < CG_MAX_TOUCHES; ++i )
+	{
+		cg_touch_t &touch = cg_touches[i];
+
+		if( touch.down && !touch.area && ( touch.x >= x ) && ( touch.y >= y ) && ( touch.x < x2 ) && ( touch.y < y2 ) )
+		{
+			touch.area = area;
+			touch.area_x = x;
+			touch.area_y = y;
+			touch.area_x2 = x2;
+			touch.area_y2 = y2;
+			touch.area_valid = true;
+			touch.sticky = sticky;
+			touch.upfunc = upfunc;
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+/*
+* CG_TouchEvent
+*/
+void CG_TouchEvent( int id, touchevent_t type, int x, int y )
+{
+	if( id >= CG_MAX_TOUCHES )
+		return;
+
+	cg_touch_t &touch = cg_touches[id];
+
+	switch( type )
+	{
+	case TOUCH_DOWN:
+	case TOUCH_MOVE:
+		touch.x = x;
+		touch.y = y;
+		if( !touch.down )
+		{
+			touch.down = true;
+			touch.area = 0;
+		}
+		else if( touch.area && !touch.sticky )
+		{
+			if( ( x < touch.area_x ) || ( y < touch.area_y ) || ( x >= touch.area_x2 ) || ( y >= touch.area_y2 ) )
+			{
+				if( touch.upfunc )
+					touch.upfunc( id );
+				touch.area = 0;
+			}
+		}
+		break;
+
+	case TOUCH_UP:
+	case TOUCH_CANCEL:
+		if( touch.down )
+		{
+			touch.down = false;
+			if( touch.area && touch.upfunc )
+				touch.upfunc( id );
+		}
+		break;
+	}
+}
+
+/*
+* CG_TouchFrame
+*/
+void CG_TouchFrame( qboolean active )
+{
+	int i;
+
+	if( !cg.view.draw2D || !cg_showHUD->integer )
+		active = qfalse;
+
+	for( i = 0; i < CG_MAX_TOUCHES; ++i )
+	{
+		cg_touches[i].area_valid = false;
+	}
+	
+	if( active )
+		CG_ExecuteLayoutProgram( cg.statusBar, true );
+
+	// cancel non-existent areas
+	for( i = 0; i < CG_MAX_TOUCHES; ++i )
+	{
+		cg_touch_t &touch = cg_touches[i];
+		if( touch.down )
+		{
+			if( touch.area && !touch.area_valid )
+			{
+				if( touch.upfunc )
+					touch.upfunc( i );
+				touch.area = 0;
+			}
+			if( !active )
+				touch.down = false;
+		}
+	}
+}
+
+/*
+* CG_TouchMove
+*/
+void CG_TouchMove( usercmd_t *cmd, vec3_t viewangles, int frametime )
+{
+	int buttons, upmove;
+	CG_GetHUDTouchButtons( buttons, upmove );
+
+	cmd->buttons |= buttons;
+	if( cg_crosshair_zoom )
+		cmd->buttons |= BUTTON_ZOOM;
+
+	if( frametime )
+	{
+		float scale = 600.0f / ( float )cgs.vidHeight;
+
+		cg_touchpad_t &movepad = cg_touchpads[TOUCHPAD_MOVE];
+		if( movepad.touch >= 0 )
+		{
+			if( cg_touch_moveThreshold->modified )
+			{
+				if( cg_touch_moveThreshold->integer < 0 )
+					trap_Cvar_Set( "cg_touch_moveThreshold", "12" );
+				cg_touch_moveThreshold->modified = qfalse;
+			}
+			if( cg_touch_strafeThreshold->modified )
+			{
+				if( cg_touch_strafeThreshold->integer < 0 )
+					trap_Cvar_Set( "cg_touch_strafeThreshold", "12" );
+				cg_touch_strafeThreshold->modified = qfalse;
+			}
+
+			cg_touch_t &touch = cg_touches[movepad.touch];
+
+			int move = movepad.y - touch.y;
+			if( abs( move * scale ) > cg_touch_moveThreshold->integer )
+				cmd->forwardmove += ( move < 0 ) ? -frametime : frametime;
+
+			move = touch.x - movepad.x;
+			if( abs( move * scale ) > cg_touch_strafeThreshold->integer )
+				cmd->sidemove += ( move < 0 ) ? -frametime : frametime;
+		}
+
+		cg_touchpad_t &viewpad = cg_touchpads[TOUCHPAD_VIEW];
+		if( viewpad.touch >= 0 )
+		{
+			if( cg_touch_pitchThreshold->modified )
+			{
+				if( cg_touch_pitchThreshold->integer < 0 )
+					trap_Cvar_Set( "cg_touch_pitchThreshold", "12" );
+				cg_touch_pitchThreshold->modified = qfalse;
+			}
+			if( cg_touch_yawThreshold->modified )
+			{
+				if( cg_touch_yawThreshold->integer < 0 )
+					trap_Cvar_Set( "cg_touch_yawThreshold", "8" );
+				cg_touch_yawThreshold->modified = qfalse;
+			}
+
+			float sensScale;
+			if( !cgs.demoPlaying && ( cg.predictedPlayerState.pmove.stats[PM_STAT_ZOOMTIME] > 0 ) )
+				sensScale = cg.predictedPlayerState.fov / cgs.clientInfo[cgs.playerNum].fov;
+			else
+				sensScale = 1.0f;
+
+			cg_touch_t &touch = cg_touches[viewpad.touch];
+
+			float angle = ( touch.y - viewpad.y ) * scale;
+			if( fabs( angle ) > cg_touch_pitchThreshold->value )
+			{
+				angle -= cg_touch_pitchThreshold->value * ( angle < 0.0f ? -1.0f : 1.0f );
+				viewangles[PITCH] += angle * cg_touch_pitchSpeed->value * sensScale * ( float )frametime * 0.001f;
+			}
+
+			angle = ( viewpad.x - touch.x ) * scale;
+			if( fabs( angle ) > cg_touch_yawThreshold->value )
+			{
+				angle -= cg_touch_yawThreshold->value * ( angle < 0.0f ? -1.0f : 1.0f );
+				viewangles[YAW] += angle * cg_touch_yawSpeed->value * sensScale * ( float )frametime * 0.001f;
+			}
+		}
+
+		cmd->upmove += upmove * frametime;
+	}
+}
+
+/*
+* CG_SetTouchpad
+*/
+void CG_SetTouchpad( int padID, int touchID )
+{
+	cg_touchpad_t &pad = cg_touchpads[padID];
+
+	pad.touch = touchID;
+
+	if( touchID >= 0 )
+	{
+		cg_touch_t &touch = cg_touches[touchID];
+		pad.x = touch.x;
+		pad.y = touch.y;
+	}
 }

--- a/source/cgame/cg_screen.cpp
+++ b/source/cgame/cg_screen.cpp
@@ -1416,7 +1416,7 @@ TOUCH INPUT
 typedef struct {
 	bool down; // is the finger currently down?
 	int x, y; // current x and y of the touch
-	int area; // hud area unique id (0 = not caught by hud)
+	int area; // hud area unique id (TOUCHAREA_NONE = not caught by hud)
 	int area_x, area_y, area_x2, area_y2; // dimensions of the area to discard the touch if out of range
 	bool area_valid; // was the area of this touch checked this frame, if not, the area doesn't exist anymore
 	bool sticky; // if true, the touch won't be cancelled when the finger leaves the area
@@ -1462,7 +1462,8 @@ int CG_TouchArea( int area, int x, int y, int w, int h, bool sticky, void ( *upf
 	{
 		cg_touch_t &touch = cg_touches[i];
 
-		if( touch.down && !touch.area && ( touch.x >= x ) && ( touch.y >= y ) && ( touch.x < x2 ) && ( touch.y < y2 ) )
+		if( touch.down && ( touch.area == TOUCHAREA_NONE ) &&
+			( touch.x >= x ) && ( touch.y >= y ) && ( touch.x < x2 ) && ( touch.y < y2 ) )
 		{
 			touch.area = area;
 			touch.area_x = x;
@@ -1498,15 +1499,15 @@ void CG_TouchEvent( int id, touchevent_t type, int x, int y )
 		if( !touch.down )
 		{
 			touch.down = true;
-			touch.area = 0;
+			touch.area = TOUCHAREA_NONE;
 		}
-		else if( touch.area && !touch.sticky )
+		else if( ( touch.area != TOUCHAREA_NONE ) && !touch.sticky )
 		{
 			if( ( x < touch.area_x ) || ( y < touch.area_y ) || ( x >= touch.area_x2 ) || ( y >= touch.area_y2 ) )
 			{
 				if( touch.upfunc )
 					touch.upfunc( id );
-				touch.area = 0;
+				touch.area = TOUCHAREA_NONE;
 			}
 		}
 		break;
@@ -1516,7 +1517,7 @@ void CG_TouchEvent( int id, touchevent_t type, int x, int y )
 		if( touch.down )
 		{
 			touch.down = false;
-			if( touch.area && touch.upfunc )
+			if( ( touch.area != TOUCHAREA_NONE ) && touch.upfunc )
 				touch.upfunc( id );
 		}
 		break;
@@ -1547,11 +1548,11 @@ void CG_TouchFrame( qboolean active )
 		cg_touch_t &touch = cg_touches[i];
 		if( touch.down )
 		{
-			if( touch.area && !touch.area_valid )
+			if( ( touch.area != TOUCHAREA_NONE ) && !touch.area_valid )
 			{
 				if( touch.upfunc )
 					touch.upfunc( i );
-				touch.area = 0;
+				touch.area = TOUCHAREA_NONE;
 			}
 			if( !active )
 				touch.down = false;

--- a/source/cgame/cg_syscalls.cpp
+++ b/source/cgame/cg_syscalls.cpp
@@ -52,6 +52,10 @@ extern "C" QF_DLL_EXPORT cgame_export_t *GetCGameAPI( cgame_import_t *import )
 
 	globals.NewFrameSnapshot = CG_NewFrameSnap;
 
+	globals.TouchEvent = CG_TouchEvent;
+	globals.TouchFrame = CG_TouchFrame;
+	globals.TouchMove = CG_TouchMove;
+
 	return &globals;
 }
 

--- a/source/client/cl_game.c
+++ b/source/client/cl_game.c
@@ -671,3 +671,30 @@ void CL_GameModule_RenderView( float stereo_separation )
 		cge->RenderView( cls.frametime, cls.realframetime, cls.realtime, cl.serverTime, stereo_separation, 
 		cl_extrapolate->integer && !cls.demo.playing ? cl_extrapolationTime->integer : 0 );
 }
+
+/*
+* CL_GameModule_TouchEvent
+*/
+void CL_GameModule_TouchEvent( int id, touchevent_t type, int x, int y )
+{
+	if( cge )
+		cge->TouchEvent( id, type, x, y );
+}
+
+/*
+* CL_GameModule_TouchFrame
+*/
+void CL_GameModule_TouchFrame( qboolean active )
+{
+	if( cge )
+		cge->TouchFrame( active );
+}
+
+/*
+* CL_GameModule_TouchMove
+*/
+void CL_GameModule_TouchMove( usercmd_t *cmd, vec3_t viewangles, int frametime )
+{
+	if( cge )
+		cge->TouchMove( cmd, viewangles, frametime );
+}

--- a/source/client/cl_input.c
+++ b/source/client/cl_input.c
@@ -491,6 +491,42 @@ static float CL_KeyState( kbutton_t *key )
 	return bound( 0, val, 1 );
 }
 
+/*
+===============================================================================
+
+TOUCHSCREEN
+
+===============================================================================
+*/
+void CL_TouchEvent( int id, touchevent_t type, int x, int y, unsigned int time )
+{
+	switch( cls.key_dest )
+	{
+	case key_game:
+		CL_GameModule_TouchEvent( id, type, x, y );
+		return;
+		
+	case key_menu:
+		if( id != 0 )
+			return;
+
+		CL_UIModule_MouseSet( x, y );
+
+		switch( type )
+		{
+		case TOUCH_DOWN:
+			Key_MouseEvent( K_MOUSE1, qtrue, time );
+			break;
+		case TOUCH_UP:
+		case TOUCH_CANCEL:
+			Key_MouseEvent( K_MOUSE1, qfalse, time );
+			CL_UIModule_MouseSet( 0, 0 );
+			break;
+		}
+		return;
+	}
+}
+
 //==========================================================================
 
 cvar_t *cl_yawspeed;
@@ -605,6 +641,7 @@ void CL_UpdateCommandInput( void )
 	// always let the mouse refresh cl.viewangles
 	IN_MouseMove( cmd );
 	CL_AddButtonBits( &cmd->buttons );
+	CL_GameModule_TouchMove( cmd, cl.viewangles, keys_frame_time );
 
 	if( keys_frame_time )
 	{
@@ -801,6 +838,9 @@ void CL_UserInputFrame( void )
 
 	// get new key events from mice or external controllers
 	IN_Commands();
+
+	// let the game handle touch events
+	CL_GameModule_TouchFrame( ( cls.key_dest == key_game ) ? qtrue : qfalse );
 
 	// process console commands
 	Cbuf_Execute();

--- a/source/client/client.h
+++ b/source/client/client.h
@@ -411,6 +411,9 @@ float CL_GameModule_SetSensitivityScale( const float sens );
 qboolean CL_GameModule_NewSnapshot( int pendingSnapshot );
 void CL_GameModule_RenderView( float stereo_separation );
 void CL_GameModule_GetEntitySpatilization( int entnum, vec3_t origin, vec3_t velocity );
+void CL_GameModule_TouchEvent( int id, touchevent_t type, int x, int y );
+void CL_GameModule_TouchFrame( qboolean active );
+void CL_GameModule_TouchMove( usercmd_t *cmd, vec3_t viewangles, int frametime );
 
 //
 // cl_sound.c
@@ -501,6 +504,7 @@ void CL_UserInputFrame( void );
 void CL_NewUserCommand( int msec );
 void CL_WriteUcmdsToMessage( msg_t *msg );
 void CL_MouseMove( usercmd_t *cmd, int mx, int my );
+void CL_TouchEvent( int id, touchevent_t type, int x, int y, unsigned int time );
 void CL_UpdateCommandInput( void );
 void IN_CenterView( void );
 

--- a/source/gameshared/config.h
+++ b/source/gameshared/config.h
@@ -3,7 +3,7 @@
 /* define this when we compile for a public release                     */
 /* this will protect dangerous and untested pieces of code              */
 /************************************************************************/
-//#define PUBLIC_BUILD
+#define PUBLIC_BUILD
 
 //==============================================
 // wsw : jal :	these defines affect every project file. They are
@@ -27,7 +27,7 @@
 //==============================================
 // undecided status
 
-//#define PURE_CHEAT
+#define PURE_CHEAT
 
 //#define ANTICHEAT_MODULE
 

--- a/source/gameshared/q_shared.h
+++ b/source/gameshared/q_shared.h
@@ -403,6 +403,14 @@ typedef enum {
 	QFONT_STYLE_MASK			= (1<<2)-1
 } qfontstyle_t;
 
+typedef enum
+{
+	TOUCH_DOWN,
+	TOUCH_UP,
+	TOUCH_MOVE,
+	TOUCH_CANCEL
+} touchevent_t;
+
 #ifdef __cplusplus
 };
 #endif


### PR DESCRIPTION
Adds touch input to HUD scripts.
- Tapping the crosshair toggles zoom.
- Holding the timer opens the scoreboard.
- Weapon selection using weapon HUD icons.
- Touch areas (using cursor position and size): touchJump, touchCrouch, touchAttack, touchSpecial, touchMove, touchView.
- Movement touch input acts as a D-pad with thresholds (cg_touch_moveThreshold, cg_touch_strafeThreshold).
- View touch input can be used both for swiping and as a virtual joystick. Configurable with cg_touch_pitch/yawThreshold/Speed cvars.
- New HUD variables:
  - TOUCH_FLIP: whether the player wants to swap the left and right side of the screen (cg_touch_flip cvar).
  - TOUCH_ATTACK/TOUCH_SPECIAL: whether the attack/special touch buttons are held.
  - TOUCH_UPMOVE: >0 if holding touchscreen jump button, <0 if holding duck, 0 if holding neither or both.
- The crosshair size is now proportional to the screen size.

To send a touch event, the OS must call CL_TouchEvent(int id, touchevent_t type, int x, int y, unsigned int time).
