### PR TITLE
Minimize after Alt+Tab on Linux

### DIFF
--- a/source/unix/unix_input.c
+++ b/source/unix/unix_input.c
@@ -660,9 +660,9 @@ static void HandleEvents( void )
 			}
 			if( focus )
 			{
-				if( Cvar_Value( "vid_fullscreen" ) != 0) {
-					Cbuf_ExecuteText( EXEC_APPEND, "set vid_fullscreen 0\n" );
-				}
+				if( Cvar_Value( "vid_fullscreen" ) ) {
+					XIconifyWindow( x11display.dpy, x11display.win, x11display.scr ); // minimize
+                                }
 				uninstall_grabs_keyboard();
 				Key_ClearStates();
 				focus = qfalse;


### PR DESCRIPTION
2 reasons why windows should minimized: 
1) that's how it works on Windows OS after Alt+Tab
2) w/o minimize it will be such shit after alt+tabing from the fullscreened game http://i.imgur.com/CmzkWBo.png
