### PR TITLE
cmake fixes for Xcode 6

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -51,8 +51,9 @@ endif()
 
 # OS X specific settings
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    set(CMAKE_OSX_ARCHITECTURES "$(ARCHS_STANDARD_64_BIT)") # Compile only 64-bit version
-    set(CMAKE_OSX_SYSROOT "macosx10.8")                     # With OS X 10.8 base SDK
+    set(CMAKE_OSX_ARCHITECTURES "$(ARCHS_STANDARD_64_BIT)")    # Compile only 64-bit version
+    set(CMAKE_OSX_SYSROOT "macosx")                            # Compile with latest available OS X sdk
+    set(CMAKE_XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET "10.8") # Use 10.8 as deployment target
     set(CMAKE_FRAMEWORK_PATH "mac/Frameworks")
     set(CMAKE_MACOSX_RPATH 1)
     set(JPEG_NAMES libjpeg) # libjpeg.framework should be renamed to jpeg.framework to remove this hack


### PR DESCRIPTION
Use latest available OS X sdk with deployment target set to 10.8
