### PR TITLE
Use stdint and stdbool on all platforms

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -54,6 +54,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(CMAKE_OSX_ARCHITECTURES "$(ARCHS_STANDARD_64_BIT)")    # Compile only 64-bit version
     set(CMAKE_OSX_SYSROOT "macosx")                            # Compile with latest available OS X sdk
     set(CMAKE_XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET "10.8") # Use 10.8 as deployment target
+    set(CMAKE_XCODE_ATTRIBUTE_GCC_C_LANGUAGE_STANDARD "c99")   # Use C99 standart for compiling C files    
     set(CMAKE_FRAMEWORK_PATH "mac/Frameworks")
     set(CMAKE_MACOSX_RPATH 1)
     set(JPEG_NAMES libjpeg) # libjpeg.framework should be renamed to jpeg.framework to remove this hack

--- a/source/gameshared/q_arch.h
+++ b/source/gameshared/q_arch.h
@@ -38,6 +38,8 @@ extern "C" {
 #include <string.h>
 #include <stdlib.h>
 #include <time.h>
+#include <stdint.h>
+#include <stdbool.h>
 
 //==============================================
 
@@ -138,12 +140,6 @@ extern "C" {
 
 // wsw : aiwa : 64bit integers and integer-pointer types
 #include <basetsd.h>
-#include <stdint.h>
-typedef int64_t qint64;
-typedef uint64_t quint64;
-typedef intptr_t qintptr;
-typedef uintptr_t quintptr;
-
 
 typedef int socklen_t;
 typedef unsigned long ioctl_param_t;
@@ -235,12 +231,6 @@ typedef UINT_PTR socket_handle_t;
 #include <alloca.h>
 
 // wsw : aiwa : 64bit integers and integer-pointer types
-#include <stdint.h>
-typedef int64_t qint64;
-typedef uint64_t quint64;
-typedef intptr_t qintptr;
-typedef uintptr_t quintptr;
-
 typedef int ioctl_param_t;
 
 typedef int socket_handle_t;
@@ -280,12 +270,6 @@ typedef int socket_handle_t;
 #define VAR( x ) # x
 
 #include <alloca.h>
-
-#include <stdint.h>
-typedef int64_t qint64;
-typedef uint64_t quint64;
-typedef intptr_t qintptr;
-typedef uintptr_t quintptr;
 
 typedef int ioctl_param_t;
 
@@ -426,8 +410,16 @@ typedef int socket_handle_t;
 
 //==============================================
 
-typedef unsigned char qbyte;
-typedef enum { qfalse, qtrue }	  qboolean;
+typedef uint8_t qbyte;
+typedef int64_t qint64;
+typedef uint64_t quint64;
+typedef intptr_t qintptr;
+typedef uintptr_t quintptr;
+
+typedef bool qboolean;
+#define qtrue true
+#define qfalse false
+
 typedef unsigned int qwchar;	// Unicode character
 
 #ifndef NULL

--- a/source/ref_gl/r_register.c
+++ b/source/ref_gl/r_register.c
@@ -420,7 +420,7 @@ static const gl_extension_func_t glx_ext_swap_control_SGI_funcs[] =
 
 //=======================================================================
 
-#define GL_EXTENSION_EXT(pre,name,val,ro,mnd,funcs,dep) { #pre, #name, #val, q##ro, q##mnd, (gl_extension_func_t * const)funcs, GLINF_FOFS(name), GLINF_FOFS(dep) }
+#define GL_EXTENSION_EXT(pre,name,val,ro,mnd,funcs,dep) { #pre, #name, #val, ro, mnd, (gl_extension_func_t * const)funcs, GLINF_FOFS(name), GLINF_FOFS(dep) }
 #define GL_EXTENSION(pre,name,ro,mnd,funcs) GL_EXTENSION_EXT(pre,name,1,ro,mnd,funcs,_extMarker)
 
 //


### PR DESCRIPTION
After recent migration to Visual Studio 2013 C99 is now finally available on all platforms so we can safely use stdint and stdbool types. Maybe we should remove qboolean, qint64, .. aliases in future and use bool, int64_t, ... directly? It will make code a bit cleaner.
