### PR TITLE
Replace integer q-types with stdint ones

### DIFF
--- a/source/android/android_lib.c
+++ b/source/android/android_lib.c
@@ -43,7 +43,7 @@ const char *Sys_Library_GetFullName( const char *name )
 /*
 * Sys_Library_GetGameLibPath
 */
-const char *Sys_Library_GetGameLibPath( const char *name, qint64 time, int randomizer )
+const char *Sys_Library_GetGameLibPath( const char *name, int64_t time, int randomizer )
 {
 	static char tempname[PATH_MAX];
 	Q_snprintfz( tempname, sizeof( tempname ), "/data/data/%s/cache/%s/tempmodules/lib%s",

--- a/source/android/android_snd.c
+++ b/source/android/android_snd.c
@@ -53,11 +53,11 @@ void S_Activate( qboolean active )
 
 static void SNDDMA_Android_Callback( SLAndroidSimpleBufferQueueItf bq, void *context )
 {
-	qbyte *buffer2;
+	uint8_t *buffer2;
 
 	trap_Mutex_Lock( snddma_android_mutex );
 
-	buffer2 = ( qbyte * )dma.buffer + snddma_android_size;
+	buffer2 = ( uint8_t * )dma.buffer + snddma_android_size;
 	(*bq)->Enqueue( bq, buffer2, snddma_android_size );
 	memcpy( buffer2, dma.buffer, snddma_android_size );
 	memset( dma.buffer, ( dma.samplebits == 8 ) ? 128 : 0, snddma_android_size );

--- a/source/angelwrap/addon/addon_dictionary.cpp
+++ b/source/angelwrap/addon/addon_dictionary.cpp
@@ -66,18 +66,18 @@ CScriptDictionary::CScriptDictionary(asBYTE *buffer)
 		if( typeId >= asTYPEID_INT8 && typeId <= asTYPEID_DOUBLE )
 		{
 			// Convert primitive values to either int64 or double, so we can use the overloaded Set methods
-			qint64 i64;
+			int64_t i64;
 			double d;
 			switch( typeId )
 			{
 			case asTYPEID_INT8: i64 = *(char*)ref; break;
 			case asTYPEID_INT16: i64 = *(short*)ref; break;
 			case asTYPEID_INT32: i64 = *(int*)ref; break;
-			case asTYPEID_INT64: i64 = *(qint64*)ref; break;
+			case asTYPEID_INT64: i64 = *(int64_t*)ref; break;
 			case asTYPEID_UINT8: i64 = *(unsigned char*)ref; break;
 			case asTYPEID_UINT16: i64 = *(unsigned short*)ref; break;
 			case asTYPEID_UINT32: i64 = *(unsigned int*)ref; break;
-			case asTYPEID_UINT64: i64 = *(qint64*)ref; break;
+			case asTYPEID_UINT64: i64 = *(int64_t*)ref; break;
 			case asTYPEID_FLOAT: d = *(float*)ref; break;
 			case asTYPEID_DOUBLE: d = *(double*)ref; break;
 			}
@@ -248,7 +248,7 @@ void CScriptDictionary::Set(const asstring_t &key, asstring_t *value)
 // through implicit conversions. This simplifies the management of the
 // numeric types when the script retrieves the stored value using a 
 // different type.
-void CScriptDictionary::Set(const asstring_t &key, qint64 &value)
+void CScriptDictionary::Set(const asstring_t &key, int64_t &value)
 {
 	Set(key, &value, asTYPEID_INT64);
 }
@@ -328,7 +328,7 @@ bool CScriptDictionary::Get(const asstring_t &key, void *value, int typeId) cons
 	return false;
 }
 
-bool CScriptDictionary::Get(const asstring_t &key, qint64 &value) const
+bool CScriptDictionary::Get(const asstring_t &key, int64_t &value) const
 {
 	return Get(key, &value, asTYPEID_INT64);
 }
@@ -472,7 +472,7 @@ void ScriptDictionarySetInt_Generic(asIScriptGeneric *gen)
 	CScriptDictionary *dict = (CScriptDictionary*)gen->GetObject();
 	asstring_t *key = *(asstring_t**)gen->GetAddressOfArg(0);
 	void *ref = *(void**)gen->GetAddressOfArg(1);
-	dict->Set(*key, *(qint64*)ref);
+	dict->Set(*key, *(int64_t*)ref);
 }
 
 void ScriptDictionarySetFlt_Generic(asIScriptGeneric *gen)
@@ -505,7 +505,7 @@ void ScriptDictionaryGetInt_Generic(asIScriptGeneric *gen)
 	CScriptDictionary *dict = (CScriptDictionary*)gen->GetObject();
 	asstring_t *key = *(asstring_t**)gen->GetAddressOfArg(0);
 	void *ref = *(void**)gen->GetAddressOfArg(1);
-	*(bool*)gen->GetAddressOfReturnLocation() = dict->Get(*key, *(qint64*)ref);
+	*(bool*)gen->GetAddressOfReturnLocation() = dict->Get(*key, *(int64_t*)ref);
 }
 
 void ScriptDictionaryGetFlt_Generic(asIScriptGeneric *gen)
@@ -601,8 +601,8 @@ static void RegisterScriptDictionary_Native(asIScriptEngine *engine)
 	r = engine->RegisterObjectMethod("Dictionary", "void set(const String &in, ?&in)", asMETHODPR(CScriptDictionary,Set,(const asstring_t&,void*,int),void), asCALL_THISCALL); assert( r >= 0 );
 	r = engine->RegisterObjectMethod("Dictionary", "bool get(const String &in, ?&out) const", asMETHODPR(CScriptDictionary,Get,(const asstring_t&,void*,int) const,bool), asCALL_THISCALL); assert( r >= 0 );
 
-	r = engine->RegisterObjectMethod("Dictionary", "void set(const String &in, int64&in)", asMETHODPR(CScriptDictionary,Set,(const asstring_t&,qint64&),void), asCALL_THISCALL); assert( r >= 0 );
-	r = engine->RegisterObjectMethod("Dictionary", "bool get(const String &in, int64&out) const", asMETHODPR(CScriptDictionary,Get,(const asstring_t&,qint64&) const,bool), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("Dictionary", "void set(const String &in, int64&in)", asMETHODPR(CScriptDictionary,Set,(const asstring_t&,int64_t&),void), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("Dictionary", "bool get(const String &in, int64&out) const", asMETHODPR(CScriptDictionary,Get,(const asstring_t&,int64_t&) const,bool), asCALL_THISCALL); assert( r >= 0 );
 
 	r = engine->RegisterObjectMethod("Dictionary", "void set(const String &in, double&in)", asMETHODPR(CScriptDictionary,Set,(const asstring_t&,double&),void), asCALL_THISCALL); assert( r >= 0 );
 	r = engine->RegisterObjectMethod("Dictionary", "bool get(const String &in, double&out) const", asMETHODPR(CScriptDictionary,Get,(const asstring_t&,double&) const,bool), asCALL_THISCALL); assert( r >= 0 );

--- a/source/angelwrap/addon/addon_dictionary.h
+++ b/source/angelwrap/addon/addon_dictionary.h
@@ -52,8 +52,8 @@ public:
     bool Get(const asstring_t &key, void *value, int typeId) const;
 
 	// Sets/Gets an integer number value for a key
-    void Set(const asstring_t &key, qint64 &value);
-    bool Get(const asstring_t &key, qint64 &value) const;
+    void Set(const asstring_t &key, int64_t &value);
+    bool Get(const asstring_t &key, int64_t &value) const;
 
 	// Sets/Gets a real number value for a key
     void Set(const asstring_t &key, double &value);

--- a/source/angelwrap/addon/addon_string.cpp
+++ b/source/angelwrap/addon/addon_string.cpp
@@ -59,11 +59,11 @@ asstring_t *objectString_FactoryBuffer( const char *buffer, unsigned int length 
 const asstring_t *objectString_ConstFactoryBuffer( const char *buffer, unsigned int length )
 {
 	asstring_t *object;
-	qbyte *rawmem;
+	uint8_t *rawmem;
 	unsigned int size = (length + 1) & ~CONST_STRING_BITFLAG;
 
 	length = size - 1;
-	rawmem = new qbyte[sizeof( asstring_t ) + size];
+	rawmem = new uint8_t[sizeof( asstring_t ) + size];
 	object = ( asstring_t * )rawmem;
 	object->asRefCount = 1;
 	object->buffer = ( char * )( object + 1 );
@@ -209,7 +209,7 @@ void objectString_Release( asstring_t *obj )
 		}
 		else
 		{
-			qbyte *rawmem = ( qbyte * )obj;
+			uint8_t *rawmem = ( uint8_t * )obj;
 			delete[] rawmem;
 		}
 	}

--- a/source/cgame/cg_boneposes.cpp
+++ b/source/cgame/cg_boneposes.cpp
@@ -101,7 +101,7 @@ cgs_skeleton_t *CG_SkeletonForModel( struct model_s *model )
 {
 	int i, j;
 	cgs_skeleton_t *skel;
-	qbyte *buffer;
+	uint8_t *buffer;
 	cgs_bone_t *bone;
 	bonepose_t *bonePose;
 	int numBones, numFrames;
@@ -120,7 +120,7 @@ cgs_skeleton_t *CG_SkeletonForModel( struct model_s *model )
 	}
 
 	// allocate one huge array to hold our data
-	buffer = (qbyte *)CG_Malloc( sizeof( cgs_skeleton_t ) + numBones * sizeof( cgs_bone_t ) +
+	buffer = (uint8_t *)CG_Malloc( sizeof( cgs_skeleton_t ) + numBones * sizeof( cgs_bone_t ) +
 		numFrames * ( sizeof( bonepose_t * ) + numBones * sizeof( bonepose_t ) ) );
 
 	skel = ( cgs_skeleton_t * )buffer; buffer += sizeof( cgs_skeleton_t );

--- a/source/cgame/cg_decals.cpp
+++ b/source/cgame/cg_decals.cpp
@@ -166,10 +166,10 @@ int CG_SpawnDecal( vec3_t origin, vec3_t dir, float orient, float radius,
 	if( b < 0 ) b = 0;else if( b > 1 ) b = 255;else b *= 255;
 	if( a < 0 ) a = 0;else if( a > 1 ) a = 255;else a *= 255;
 
-	color[0] = ( qbyte )( r );
-	color[1] = ( qbyte )( g );
-	color[2] = ( qbyte )( b );
-	color[3] = ( qbyte )( a );
+	color[0] = ( uint8_t )( r );
+	color[1] = ( uint8_t )( g );
+	color[2] = ( uint8_t )( b );
+	color[3] = ( uint8_t )( a );
 
 	radius = 0.5f / radius;
 	VectorScale( axis[1], radius, axis[1] );
@@ -250,17 +250,17 @@ void CG_AddDecals( void )
 
 			if( dl->fadealpha )
 			{
-				color[0] = ( qbyte )( dl->color[0] );
-				color[1] = ( qbyte )( dl->color[1] );
-				color[2] = ( qbyte )( dl->color[2] );
-				color[3] = ( qbyte )( dl->color[3] * fade );
+				color[0] = ( uint8_t )( dl->color[0] );
+				color[1] = ( uint8_t )( dl->color[1] );
+				color[2] = ( uint8_t )( dl->color[2] );
+				color[3] = ( uint8_t )( dl->color[3] * fade );
 			}
 			else
 			{
-				color[0] = ( qbyte )( dl->color[0] * fade );
-				color[1] = ( qbyte )( dl->color[1] * fade );
-				color[2] = ( qbyte )( dl->color[2] * fade );
-				color[3] = ( qbyte )( dl->color[3] );
+				color[0] = ( uint8_t )( dl->color[0] * fade );
+				color[1] = ( uint8_t )( dl->color[1] * fade );
+				color[2] = ( uint8_t )( dl->color[2] * fade );
+				color[3] = ( uint8_t )( dl->color[3] );
 			}
 
 			for( i = 0; i < poly->numverts; i++ )

--- a/source/cgame/cg_democams.cpp
+++ b/source/cgame/cg_democams.cpp
@@ -460,7 +460,7 @@ static void CG_Democam_ExecutePathAnalysis( void )
 bool CG_LoadRecamScriptFile( char *filename )
 {
 	int filelen, filehandle;
-	qbyte *buf = NULL;
+	uint8_t *buf = NULL;
 	char *ptr, *token;
 	int linecount;
 	cg_democam_t *cam = NULL;
@@ -478,7 +478,7 @@ bool CG_LoadRecamScriptFile( char *filename )
 	}
 	else
 	{
-		buf = ( qbyte * )CG_Malloc( filelen + 1 );
+		buf = ( uint8_t * )CG_Malloc( filelen + 1 );
 		filelen = trap_FS_Read( buf, filelen, filehandle );
 		trap_FS_FCloseFile( filehandle );
 	}

--- a/source/cgame/cg_effects.cpp
+++ b/source/cgame/cg_effects.cpp
@@ -238,10 +238,10 @@ static void CG_AddBlobShadow( vec3_t origin, vec3_t dir, float orient, float rad
 	if( b < 0 ) b = 0;else if( b > 1 ) b = 255;else b *= 255;
 	if( a < 0 ) a = 0;else if( a > 1 ) a = 255;else a *= 255;
 
-	color[0] = ( qbyte )( r );
-	color[1] = ( qbyte )( g );
-	color[2] = ( qbyte )( b );
-	color[3] = ( qbyte )( a );
+	color[0] = ( uint8_t )( r );
+	color[1] = ( uint8_t )( g );
+	color[2] = ( uint8_t )( b );
+	color[3] = ( uint8_t )( a );
 	c = *( int * )color;
 
 	radius = 0.5f / radius;
@@ -436,10 +436,10 @@ void CG_AddFragmentedDecal( vec3_t origin, vec3_t dir, float orient, float radiu
 	if( b < 0 ) b = 0;else if( b > 1 ) b = 255;else b *= 255;
 	if( a < 0 ) a = 0;else if( a > 1 ) a = 255;else a *= 255;
 
-	color[0] = ( qbyte )( r );
-	color[1] = ( qbyte )( g );
-	color[2] = ( qbyte )( b );
-	color[3] = ( qbyte )( a );
+	color[0] = ( uint8_t )( r );
+	color[1] = ( uint8_t )( g );
+	color[2] = ( uint8_t )( b );
+	color[3] = ( uint8_t )( a );
 	c = *( int * )color;
 
 	radius = 0.5f / radius;
@@ -950,10 +950,10 @@ void CG_AddParticles( void )
 		org[1] = p->org[1] + p->vel[1]*time + p->accel[1]*time2;
 		org[2] = p->org[2] + p->vel[2]*time + p->accel[2]*time2;
 
-		color[0] = (qbyte)( bound( 0, p->color[0], 1.0f ) * 255 );
-		color[1] = (qbyte)( bound( 0, p->color[1], 1.0f ) * 255 );
-		color[2] = (qbyte)( bound( 0, p->color[2], 1.0f ) * 255 );
-		color[3] = (qbyte)( bound( 0, alpha, 1.0f ) * 255 );
+		color[0] = (uint8_t)( bound( 0, p->color[0], 1.0f ) * 255 );
+		color[1] = (uint8_t)( bound( 0, p->color[1], 1.0f ) * 255 );
+		color[2] = (uint8_t)( bound( 0, p->color[2], 1.0f ) * 255 );
+		color[3] = (uint8_t)( bound( 0, alpha, 1.0f ) * 255 );
 
 		corner[0] = org[0];
 		corner[1] = org[1] - 0.5f * p->scale;

--- a/source/cgame/cg_ents.cpp
+++ b/source/cgame/cg_ents.cpp
@@ -591,7 +591,7 @@ static void CG_EntAddBobEffect( centity_t *cent )
 static void CG_EntAddTeamColorTransitionEffect( centity_t *cent )
 {
 	float f;
-	qbyte *currentcolor;
+	uint8_t *currentcolor;
 	vec4_t scaledcolor, newcolor;
 	const vec4_t neutralcolor = { 1.0f, 1.0f, 1.0f, 1.0f };
 
@@ -606,9 +606,9 @@ static void CG_EntAddTeamColorTransitionEffect( centity_t *cent )
 	Vector4Scale( currentcolor, 1.0/255.0, scaledcolor );
 	VectorLerp( neutralcolor, f, scaledcolor, newcolor );
 
-	cent->ent.shaderRGBA[0] = (qbyte)( newcolor[0] * 255 );
-	cent->ent.shaderRGBA[1] = (qbyte)( newcolor[1] * 255 );
-	cent->ent.shaderRGBA[2] = (qbyte)( newcolor[2] * 255 );
+	cent->ent.shaderRGBA[0] = (uint8_t)( newcolor[0] * 255 );
+	cent->ent.shaderRGBA[1] = (uint8_t)( newcolor[1] * 255 );
+	cent->ent.shaderRGBA[2] = (uint8_t)( newcolor[2] * 255 );
 }
 
 /*
@@ -891,9 +891,9 @@ static void CG_AddGenericEnt( centity_t *cent )
 			{
 				vec4_t scolor;
 				Vector4Copy( color_table[ColorIndex( cent->item->color[1] )], scolor );
-				cent->ent.shaderRGBA[0] = ( qbyte )( 255 * scolor[0] );
-				cent->ent.shaderRGBA[1] = ( qbyte )( 255 * scolor[1] );
-				cent->ent.shaderRGBA[2] = ( qbyte )( 255 * scolor[2] );
+				cent->ent.shaderRGBA[0] = ( uint8_t )( 255 * scolor[0] );
+				cent->ent.shaderRGBA[1] = ( uint8_t )( 255 * scolor[1] );
+				cent->ent.shaderRGBA[2] = ( uint8_t )( 255 * scolor[2] );
 			}
 			else  // set white
 				VectorSet( cent->ent.shaderRGBA, 255, 255, 255 );
@@ -982,10 +982,10 @@ void CG_AddFlagModelOnTag( centity_t *cent, byte_vec4_t teamcolor, const char *t
 	flag.renderfx = cent->ent.renderfx;
 	flag.customShader = NULL;
 	flag.customSkin = NULL;
-	flag.shaderRGBA[0] = ( qbyte )teamcolor[0];
-	flag.shaderRGBA[1] = ( qbyte )teamcolor[1];
-	flag.shaderRGBA[2] = ( qbyte )teamcolor[2];
-	flag.shaderRGBA[3] = ( qbyte )teamcolor[3];
+	flag.shaderRGBA[0] = ( uint8_t )teamcolor[0];
+	flag.shaderRGBA[1] = ( uint8_t )teamcolor[1];
+	flag.shaderRGBA[2] = ( uint8_t )teamcolor[2];
+	flag.shaderRGBA[3] = ( uint8_t )teamcolor[3];
 
 	VectorCopy( cent->ent.origin, flag.origin );
 	VectorCopy( cent->ent.origin, flag.origin2 );
@@ -1014,9 +1014,9 @@ void CG_AddFlagModelOnTag( centity_t *cent, byte_vec4_t teamcolor, const char *t
 	}
 
 	CG_AddColoredOutLineEffect( &flag, EF_OUTLINE,
-		(qbyte)( teamcolor[0]*0.3 ),
-		(qbyte)( teamcolor[1]*0.3 ),
-		(qbyte)( teamcolor[2]*0.3 ),
+		(uint8_t)( teamcolor[0]*0.3 ),
+		(uint8_t)( teamcolor[1]*0.3 ),
+		(uint8_t)( teamcolor[2]*0.3 ),
 		255 );
 
 	CG_AddEntityToScene( &flag );
@@ -1642,7 +1642,7 @@ static void CG_AddPortalSurfaceEnt( centity_t *cent )
 */
 static void CG_UpdateVideoSpeakerEnt( void *centp,
 	unsigned int samples, unsigned int rate, 
-	unsigned short width, unsigned short channels, const qbyte *data )
+	unsigned short width, unsigned short channels, const uint8_t *data )
 {
 	centity_t *cent = ( centity_t * )centp;
 

--- a/source/cgame/cg_hud.cpp
+++ b/source/cgame/cg_hud.cpp
@@ -130,9 +130,9 @@ static int CG_GetStatEnemyTeam( const void *parameter )
 
 static int CG_GetStatValue( const void *parameter )
 {
-	assert( (qintptr)parameter >= 0 && (qintptr)parameter < MAX_STATS );
+	assert( (intptr_t)parameter >= 0 && (intptr_t)parameter < MAX_STATS );
 
-	return cg.predictedPlayerState.stats[(qintptr)parameter];
+	return cg.predictedPlayerState.stats[(intptr_t)parameter];
 }
 
 static int CG_GetRaceStatValue( const void *parameter )
@@ -208,7 +208,7 @@ static int CG_GetFPS( const void *parameter )
 
 static int CG_GetPowerupTime( const void *parameter )
 {
-	int powerup = (qintptr)parameter;
+	int powerup = (intptr_t)parameter;
 	return cg.predictedPlayerState.inventory[powerup];
 }
 
@@ -282,7 +282,7 @@ static int CG_GetCvar( const void *parameter )
 static int CG_GetDamageIndicatorDirValue( const void *parameter )
 {
 	float frac = 0;
-	int index = (qintptr)parameter;
+	int index = (intptr_t)parameter;
 
 	if( cg.damageBlends[index] > cg.time && !cg.view.thirdperson )
 	{
@@ -299,7 +299,7 @@ static int CG_GetCurrentWeaponInventoryData( const void *parameter )
 	firedef_t *firedef;
 	int result;
 
-	switch( (qintptr)parameter )
+	switch( (intptr_t)parameter )
 	{
 	case 0: // AMMO_ITEM
 	default:
@@ -336,7 +336,7 @@ static int CG_GetShowItemTimers( const void *parameter )
 
 static int CG_GetItemTimer( const void *parameter )
 {
-	int num = (qintptr)parameter;
+	int num = (intptr_t)parameter;
 	centity_t *cent;
 
 	cent = CG_GetItemTimerEnt( num );
@@ -347,7 +347,7 @@ static int CG_GetItemTimer( const void *parameter )
 
 static int CG_GetItemTimerCount( const void *parameter )
 {
-	int num = (qintptr)parameter;
+	int num = (intptr_t)parameter;
 	centity_t *cent;
 
 	cent = CG_GetItemTimerEnt( num );
@@ -358,7 +358,7 @@ static int CG_GetItemTimerCount( const void *parameter )
 
 static int CG_GetItemTimerLocation( const void *parameter )
 {
-	int num = (qintptr)parameter;
+	int num = (intptr_t)parameter;
 	centity_t *cent;
 
 	cent = CG_GetItemTimerEnt( num );
@@ -369,7 +369,7 @@ static int CG_GetItemTimerLocation( const void *parameter )
 
 static int CG_GetItemTimerTeam( const void *parameter )
 {
-	int num = (qintptr)parameter;
+	int num = (intptr_t)parameter;
 	centity_t *cent;
 
 	cent = CG_GetItemTimerEnt( num );
@@ -398,7 +398,7 @@ enum race_index {
 
 static int CG_GetRaceVars( const void* parameter )
 {
-	int index = (qintptr)parameter;
+	int index = (intptr_t)parameter;
 	int iNum;
 	vec3_t hor_vel, view_dir, an;
 
@@ -496,7 +496,7 @@ static int CG_GetAccel( const void* parameter )
 
 static int CG_GetTouchButtonPressed( const void *parameter )
 {
-	return ( cg_hud_touch_buttons & ( qintptr )parameter ) ? 1 : 0;
+	return ( cg_hud_touch_buttons & ( intptr_t )parameter ) ? 1 : 0;
 }
 
 static int CG_GetTouchUpmove( const void *parameter )

--- a/source/cgame/cg_lents.cpp
+++ b/source/cgame/cg_lents.cpp
@@ -120,32 +120,32 @@ static lentity_t *CG_AllocLocalEntity( letype_t type, float r, float g, float b,
 	case LE_NO_FADE:
 		break;
 	case LE_RGB_FADE:
-		le->ent.shaderRGBA[3] = ( qbyte )( 255 * a );
+		le->ent.shaderRGBA[3] = ( uint8_t )( 255 * a );
 		break;
 	case LE_SCALE_ALPHA_FADE:
 	case LE_INVERSESCALE_ALPHA_FADE:
 	case LE_PUFF_SHRINK:
-		le->ent.shaderRGBA[0] = ( qbyte )( 255 * r );
-		le->ent.shaderRGBA[1] = ( qbyte )( 255 * g );
-		le->ent.shaderRGBA[2] = ( qbyte )( 255 * b );
-		le->ent.shaderRGBA[3] = ( qbyte )( 255 * a );
+		le->ent.shaderRGBA[0] = ( uint8_t )( 255 * r );
+		le->ent.shaderRGBA[1] = ( uint8_t )( 255 * g );
+		le->ent.shaderRGBA[2] = ( uint8_t )( 255 * b );
+		le->ent.shaderRGBA[3] = ( uint8_t )( 255 * a );
 		break;
 	case LE_PUFF_SCALE_2:
-		le->ent.shaderRGBA[0] = ( qbyte )( 255 * r );
-		le->ent.shaderRGBA[1] = ( qbyte )( 255 * g );
-		le->ent.shaderRGBA[2] = ( qbyte )( 255 * b );
-		le->ent.shaderRGBA[3] = ( qbyte )( 255 * a );
+		le->ent.shaderRGBA[0] = ( uint8_t )( 255 * r );
+		le->ent.shaderRGBA[1] = ( uint8_t )( 255 * g );
+		le->ent.shaderRGBA[2] = ( uint8_t )( 255 * b );
+		le->ent.shaderRGBA[3] = ( uint8_t )( 255 * a );
 		break;
 	case LE_PUFF_SCALE:
-		le->ent.shaderRGBA[0] = ( qbyte )( 255 * r );
-		le->ent.shaderRGBA[1] = ( qbyte )( 255 * g );
-		le->ent.shaderRGBA[2] = ( qbyte )( 255 * b );
-		le->ent.shaderRGBA[3] = ( qbyte )( 255 * a );
+		le->ent.shaderRGBA[0] = ( uint8_t )( 255 * r );
+		le->ent.shaderRGBA[1] = ( uint8_t )( 255 * g );
+		le->ent.shaderRGBA[2] = ( uint8_t )( 255 * b );
+		le->ent.shaderRGBA[3] = ( uint8_t )( 255 * a );
 		break;
 	case LE_ALPHA_FADE:
-		le->ent.shaderRGBA[0] = ( qbyte )( 255 * r );
-		le->ent.shaderRGBA[1] = ( qbyte )( 255 * g );
-		le->ent.shaderRGBA[2] = ( qbyte )( 255 * b );
+		le->ent.shaderRGBA[0] = ( uint8_t )( 255 * r );
+		le->ent.shaderRGBA[1] = ( uint8_t )( 255 * g );
+		le->ent.shaderRGBA[2] = ( uint8_t )( 255 * b );
 		break;
 	default:
 		break;
@@ -1678,25 +1678,25 @@ void CG_AddLocalEntities( void )
 			break;
 		case LE_RGB_FADE:
 			fade = min( fade, fadeIn );
-			ent->shaderRGBA[0] = ( qbyte )( fade * le->color[0] );
-			ent->shaderRGBA[1] = ( qbyte )( fade * le->color[1] );
-			ent->shaderRGBA[2] = ( qbyte )( fade * le->color[2] );
+			ent->shaderRGBA[0] = ( uint8_t )( fade * le->color[0] );
+			ent->shaderRGBA[1] = ( uint8_t )( fade * le->color[1] );
+			ent->shaderRGBA[2] = ( uint8_t )( fade * le->color[2] );
 			break;
 		case LE_SCALE_ALPHA_FADE:
 			fade = min( fade, fadeIn );
 			ent->scale = 1.0f + 1.0f / scale;
 			ent->scale = min( ent->scale, 5.0f );
-			ent->shaderRGBA[3] = ( qbyte )( fade * le->color[3] );
+			ent->shaderRGBA[3] = ( uint8_t )( fade * le->color[3] );
 			break;
 		case LE_INVERSESCALE_ALPHA_FADE:
 			fade = min( fade, fadeIn );
 			ent->scale = scale + 0.1f;
 			clamp( ent->scale, 0.1f, 1.0f );
-			ent->shaderRGBA[3] = ( qbyte )( fade * le->color[3] );
+			ent->shaderRGBA[3] = ( uint8_t )( fade * le->color[3] );
 			break;
 		case LE_ALPHA_FADE:
 			fade = min( fade, fadeIn );
-			ent->shaderRGBA[3] = ( qbyte )( fade * le->color[3] );
+			ent->shaderRGBA[3] = ( uint8_t )( fade * le->color[3] );
 			break;
 		default:
 			break;

--- a/source/cgame/cg_local.h
+++ b/source/cgame/cg_local.h
@@ -631,7 +631,7 @@ void CG_LerpEntities( void );
 void CG_LerpGenericEnt( centity_t *cent );
 
 void CG_SetOutlineColor( byte_vec4_t outlineColor, byte_vec4_t color );
-void CG_AddColoredOutLineEffect( entity_t *ent, int effects, qbyte r, qbyte g, qbyte b, qbyte a );
+void CG_AddColoredOutLineEffect( entity_t *ent, int effects, uint8_t r, uint8_t g, uint8_t b, uint8_t a );
 void CG_AddCentityOutLineEffect( centity_t *cent );
 void CG_AddItemGhostEffect( centity_t *cent );
 
@@ -928,8 +928,8 @@ void CG_SetSceneTeamColors( void );
 pmodelinfo_t *CG_PModelForCentity( centity_t *cent );
 struct skinfile_s *CG_SkinForCentity( centity_t *cent );
 vec_t *CG_TeamColor( int team, vec4_t color );
-qbyte *CG_TeamColorForEntity( int entNum, byte_vec4_t color );
-qbyte *CG_PlayerColorForEntity( int entNum, byte_vec4_t color );
+uint8_t *CG_TeamColorForEntity( int entNum, byte_vec4_t color );
+uint8_t *CG_PlayerColorForEntity( int entNum, byte_vec4_t color );
 
 //
 // cg_view.c

--- a/source/cgame/cg_pmodels.cpp
+++ b/source/cgame/cg_pmodels.cpp
@@ -152,7 +152,7 @@ static void CG_ParseTagMask( struct model_s *model, int bonenum, char *name, flo
 */
 static bool CG_ParseAnimationScript( pmodelinfo_t *pmodelinfo, char *filename )
 {
-	qbyte *buf;
+	uint8_t *buf;
 	char *ptr, *token;
 	int rounder, counter, i;
 	bool debug = true;
@@ -177,7 +177,7 @@ static bool CG_ParseAnimationScript( pmodelinfo_t *pmodelinfo, char *filename )
 		return false;
 	}
 
-	buf = ( qbyte * )CG_Malloc( length + 1 );
+	buf = ( uint8_t * )CG_Malloc( length + 1 );
 	length = trap_FS_Read( buf, length, filenum );
 	trap_FS_FCloseFile( filenum );
 	if( !length )
@@ -642,10 +642,10 @@ void CG_AddShellEffects( entity_t *ent, int effects )
 void CG_SetOutlineColor( byte_vec4_t outlineColor, byte_vec4_t color )
 {
 	float darken = 0.25f;
-	outlineColor[0] = ( qbyte )( color[0] * darken );
-	outlineColor[1] = ( qbyte )( color[1] * darken );
-	outlineColor[2] = ( qbyte )( color[2] * darken );
-	outlineColor[3] = ( qbyte )( 255 );
+	outlineColor[0] = ( uint8_t )( color[0] * darken );
+	outlineColor[1] = ( uint8_t )( color[1] * darken );
+	outlineColor[2] = ( uint8_t )( color[2] * darken );
+	outlineColor[3] = ( uint8_t )( 255 );
 }
 
 /*
@@ -690,10 +690,10 @@ static float CG_OutlineScaleForDist( entity_t *e, float maxdist, float scale )
 /*
 * CG_AddColoredOutLineEffect
 */
-void CG_AddColoredOutLineEffect( entity_t *ent, int effects, qbyte r, qbyte g, qbyte b, qbyte a )
+void CG_AddColoredOutLineEffect( entity_t *ent, int effects, uint8_t r, uint8_t g, uint8_t b, uint8_t a )
 {
 	float scale;
-	qbyte *RGBA;
+	uint8_t *RGBA;
 
 	if( effects & EF_QUAD )
 	{
@@ -786,7 +786,7 @@ void CG_AddColoredOutLineEffect( entity_t *ent, int effects, qbyte r, qbyte g, q
 	else if( effects & EF_REGEN )
 		Vector4Set( RGBA, 255, 0, 0, 255 );
 	else
-		Vector4Set( RGBA, ( qbyte )r, ( qbyte )g, ( qbyte )b, ( qbyte )a );
+		Vector4Set( RGBA, ( uint8_t )r, ( uint8_t )g, ( uint8_t )b, ( uint8_t )a );
 }
 
 /*

--- a/source/cgame/cg_polys.cpp
+++ b/source/cgame/cg_polys.cpp
@@ -218,40 +218,40 @@ static cpoly_t *CG_SpawnPolyBeam( vec3_t start, vec3_t end, vec4_t color, int wi
 	Vector4Set( poly->verts[poly->numverts], xmin, 0, ymin, 1 );
 	poly->stcoords[poly->numverts][0] = 0;
 	poly->stcoords[poly->numverts][1] = 0;
-	poly->colors[poly->numverts][0] = ( qbyte )( cgpoly->color[0] * 255 );
-	poly->colors[poly->numverts][1] = ( qbyte )( cgpoly->color[1] * 255 );
-	poly->colors[poly->numverts][2] = ( qbyte )( cgpoly->color[2] * 255 );
-	poly->colors[poly->numverts][3] = ( qbyte )( cgpoly->color[3] * 255 );
+	poly->colors[poly->numverts][0] = ( uint8_t )( cgpoly->color[0] * 255 );
+	poly->colors[poly->numverts][1] = ( uint8_t )( cgpoly->color[1] * 255 );
+	poly->colors[poly->numverts][2] = ( uint8_t )( cgpoly->color[2] * 255 );
+	poly->colors[poly->numverts][3] = ( uint8_t )( cgpoly->color[3] * 255 );
 	poly->numverts++;
 
 	// B
 	Vector4Set( poly->verts[poly->numverts], xmin, 0, ymax, 1 );
 	poly->stcoords[poly->numverts][0] = 0;
 	poly->stcoords[poly->numverts][1] = sty;
-	poly->colors[poly->numverts][0] = ( qbyte )( cgpoly->color[0] * 255 );
-	poly->colors[poly->numverts][1] = ( qbyte )( cgpoly->color[1] * 255 );
-	poly->colors[poly->numverts][2] = ( qbyte )( cgpoly->color[2] * 255 );
-	poly->colors[poly->numverts][3] = ( qbyte )( cgpoly->color[3] * 255 );
+	poly->colors[poly->numverts][0] = ( uint8_t )( cgpoly->color[0] * 255 );
+	poly->colors[poly->numverts][1] = ( uint8_t )( cgpoly->color[1] * 255 );
+	poly->colors[poly->numverts][2] = ( uint8_t )( cgpoly->color[2] * 255 );
+	poly->colors[poly->numverts][3] = ( uint8_t )( cgpoly->color[3] * 255 );
 	poly->numverts++;
 
 	// C
 	Vector4Set( poly->verts[poly->numverts], xmax, 0, ymax, 1 );
 	poly->stcoords[poly->numverts][0] = stx;
 	poly->stcoords[poly->numverts][1] = sty;
-	poly->colors[poly->numverts][0] = ( qbyte )( cgpoly->color[0] * 255 );
-	poly->colors[poly->numverts][1] = ( qbyte )( cgpoly->color[1] * 255 );
-	poly->colors[poly->numverts][2] = ( qbyte )( cgpoly->color[2] * 255 );
-	poly->colors[poly->numverts][3] = ( qbyte )( cgpoly->color[3] * 255 );
+	poly->colors[poly->numverts][0] = ( uint8_t )( cgpoly->color[0] * 255 );
+	poly->colors[poly->numverts][1] = ( uint8_t )( cgpoly->color[1] * 255 );
+	poly->colors[poly->numverts][2] = ( uint8_t )( cgpoly->color[2] * 255 );
+	poly->colors[poly->numverts][3] = ( uint8_t )( cgpoly->color[3] * 255 );
 	poly->numverts++;
 
 	// D
 	Vector4Set( poly->verts[poly->numverts], xmax, 0, ymin, 1 );
 	poly->stcoords[poly->numverts][0] = stx;
 	poly->stcoords[poly->numverts][1] = 0;
-	poly->colors[poly->numverts][0] = ( qbyte )( cgpoly->color[0] * 255 );
-	poly->colors[poly->numverts][1] = ( qbyte )( cgpoly->color[1] * 255 );
-	poly->colors[poly->numverts][2] = ( qbyte )( cgpoly->color[2] * 255 );
-	poly->colors[poly->numverts][3] = ( qbyte )( cgpoly->color[3] * 255 );
+	poly->colors[poly->numverts][0] = ( uint8_t )( cgpoly->color[0] * 255 );
+	poly->colors[poly->numverts][1] = ( uint8_t )( cgpoly->color[1] * 255 );
+	poly->colors[poly->numverts][2] = ( uint8_t )( cgpoly->color[2] * 255 );
+	poly->colors[poly->numverts][3] = ( uint8_t )( cgpoly->color[3] * 255 );
 	poly->numverts++;
 
 	// the verts data is stored inside cgpoly, cause it can be moved later
@@ -487,10 +487,10 @@ void CG_AddPolys( void )
 
 			for( i = 0; i < poly->numverts; i++ )
 			{
-				poly->colors[i][0] = ( qbyte )( cgpoly->color[0] * fade * 255 );
-				poly->colors[i][1] = ( qbyte )( cgpoly->color[1] * fade * 255 );
-				poly->colors[i][2] = ( qbyte )( cgpoly->color[2] * fade * 255 );
-				poly->colors[i][3] = ( qbyte )( cgpoly->color[3] * fade * 255 );
+				poly->colors[i][0] = ( uint8_t )( cgpoly->color[0] * fade * 255 );
+				poly->colors[i][1] = ( uint8_t )( cgpoly->color[1] * fade * 255 );
+				poly->colors[i][2] = ( uint8_t )( cgpoly->color[2] * fade * 255 );
+				poly->colors[i][3] = ( uint8_t )( cgpoly->color[3] * fade * 255 );
 			}
 		}
 

--- a/source/cgame/cg_public.h
+++ b/source/cgame/cg_public.h
@@ -25,7 +25,7 @@ typedef size_t (*cg_async_stream_read_cb_t)(const void *buf, size_t numb, float 
 	int status, const char *contentType, void *privatep);
 typedef void (*cg_async_stream_done_cb_t)(int status, const char *contentType, void *privatep);
 
-typedef void (*cg_raw_samples_cb_t)(void*,unsigned int, unsigned int, unsigned short, unsigned short, const qbyte *);
+typedef void (*cg_raw_samples_cb_t)(void*,unsigned int, unsigned int, unsigned short, unsigned short, const uint8_t *);
 typedef unsigned int (*cg_get_raw_samples_cb_t)(void*);
 
 // cg_public.h -- client game dll information visible to engine
@@ -48,7 +48,7 @@ typedef struct snapshot_s
 	qboolean multipov;
 	int deltaFrameNum;
 	size_t areabytes;
-	qbyte *areabits;             // portalarea visibility bits
+	uint8_t *areabits;             // portalarea visibility bits
 	int numplayers;
 	player_state_t playerState;
 	player_state_t playerStates[MAX_CLIENTS];
@@ -146,8 +146,8 @@ typedef struct
 	unsigned int ( *Milliseconds )( void );
 	qboolean ( *DownloadRequest )( const char *filename, qboolean requestpak );
 
-	unsigned int (* Hash_BlockChecksum )( const qbyte * data, size_t len );
-	unsigned int (* Hash_SuperFastHash )( const qbyte * data, size_t len, unsigned int seed );
+	unsigned int (* Hash_BlockChecksum )( const uint8_t * data, size_t len );
+	unsigned int (* Hash_SuperFastHash )( const uint8_t * data, size_t len, unsigned int seed );
 
 	void ( *NET_GetUserCmd )( int frame, usercmd_t *cmd );
 	int ( *NET_GetCurrentUserCmdNum )( void );
@@ -176,7 +176,7 @@ typedef struct
 	void ( *R_ModelFrameBounds )( const struct model_s *mod, int frame, vec3_t mins, vec3_t maxs );
 	struct model_s *( *R_RegisterModel )( const char *name );
 	struct shader_s *( *R_RegisterPic )( const char *name );
-	struct shader_s *( *R_RegisterRawPic )( const char *name, int width, int height, qbyte *data );
+	struct shader_s *( *R_RegisterRawPic )( const char *name, int width, int height, uint8_t *data );
 	struct shader_s *( *R_RegisterLevelshot )( const char *name, struct shader_s *defaultPic, qboolean *matchesDefault );
 	struct shader_s *( *R_RegisterSkin )( const char *name );
 	struct skinfile_s *( *R_RegisterSkinFile )( const char *name );
@@ -219,9 +219,9 @@ typedef struct
 	void ( *S_AddLoopSound )( struct sfx_s *sfx, int entnum, float fvol, float attenuation );
 	void ( *S_StartBackgroundTrack )( const char *intro, const char *loop );
 	void ( *S_StopBackgroundTrack )( void );
-	void ( *S_RawSamples )( unsigned int samples, unsigned int rate, unsigned short width, unsigned short channels, const qbyte *data );
+	void ( *S_RawSamples )( unsigned int samples, unsigned int rate, unsigned short width, unsigned short channels, const uint8_t *data );
 	void ( *S_PositionedRawSamples )( int entnum, float fvol, float attenuation, 
-		unsigned int samples, unsigned int rate, unsigned short width, unsigned short channels, const qbyte *data );
+		unsigned int samples, unsigned int rate, unsigned short width, unsigned short channels, const uint8_t *data );
 	unsigned int ( *S_GetRawSamplesLength )( void );
 	unsigned int ( *S_GetPositionedRawSamplesLength )( int entnum );
 

--- a/source/cgame/cg_screen.cpp
+++ b/source/cgame/cg_screen.cpp
@@ -548,7 +548,7 @@ void CG_DrawCrosshair( int x, int y, int align, bool touch )
 void CG_DrawKeyState( int x, int y, int w, int h, int align, const char *key )
 {
 	int i;
-	qbyte on = 0;
+	uint8_t on = 0;
 	usercmd_t cmd;
 	vec4_t color;
 

--- a/source/cgame/cg_syscalls.h
+++ b/source/cgame/cg_syscalls.h
@@ -347,7 +347,7 @@ static inline struct shader_s *trap_R_RegisterPic( const char *name )
 	return CGAME_IMPORT.R_RegisterPic( name );
 }
 
-static inline struct shader_s *trap_R_RegisterRawPic( const char *name, int width, int height, qbyte *data )
+static inline struct shader_s *trap_R_RegisterRawPic( const char *name, int width, int height, uint8_t *data )
 {
 	return CGAME_IMPORT.R_RegisterRawPic( name, width, height, data );
 }
@@ -531,14 +531,14 @@ static inline void trap_S_StopBackgroundTrack( void )
 }
 
 static inline void trap_S_RawSamples( unsigned int samples, unsigned int rate, 
-	unsigned short width, unsigned short channels, const qbyte *data )
+	unsigned short width, unsigned short channels, const uint8_t *data )
 {
 	CGAME_IMPORT.S_RawSamples( samples, rate, width, channels, data );
 }
 
 static inline void trap_S_PositionedRawSamples( int entnum, float fvol, float attenuation, 
 		unsigned int samples, unsigned int rate, unsigned short width, 
-		unsigned short channels, const qbyte *data )
+		unsigned short channels, const uint8_t *data )
 {
 	CGAME_IMPORT.S_PositionedRawSamples( entnum, fvol, attenuation, samples, rate, width, channels, data );
 }

--- a/source/cgame/cg_teams.cpp
+++ b/source/cgame/cg_teams.cpp
@@ -71,7 +71,7 @@ void CG_SetSceneTeamColors( void )
 	for( team = TEAM_PLAYERS; team < GS_MAX_TEAMS; team++ )
 	{
 		CG_TeamColor( team, color );
-		trap_R_SetCustomColor( team, (qbyte)( color[0] * 255 ), (qbyte)( color[1] * 255 ), (qbyte)( color[2] * 255 ) ); // update the renderer
+		trap_R_SetCustomColor( team, (uint8_t)( color[0] * 255 ), (uint8_t)( color[1] * 255 ), (uint8_t)( color[2] * 255 ) ); // update the renderer
 	}
 }
 
@@ -311,7 +311,7 @@ vec_t *CG_TeamColor( int team, vec4_t color )
 /*
 * 
 */
-qbyte *_ColorForEntity( int entNum, byte_vec4_t color, bool player )
+uint8_t *_ColorForEntity( int entNum, byte_vec4_t color, bool player )
 {
 	centity_t *cent;
 	int team;
@@ -389,7 +389,7 @@ qbyte *_ColorForEntity( int entNum, byte_vec4_t color, bool player )
 /*
 * 
 */
-qbyte *CG_TeamColorForEntity( int entNum, byte_vec4_t color )
+uint8_t *CG_TeamColorForEntity( int entNum, byte_vec4_t color )
 {
 	return _ColorForEntity( entNum, color, false );
 }
@@ -397,7 +397,7 @@ qbyte *CG_TeamColorForEntity( int entNum, byte_vec4_t color )
 /*
 * 
 */
-qbyte *CG_PlayerColorForEntity( int entNum, byte_vec4_t color )
+uint8_t *CG_PlayerColorForEntity( int entNum, byte_vec4_t color )
 {
 	return _ColorForEntity( entNum, color, true );
 }

--- a/source/cgame/cg_wmodels.cpp
+++ b/source/cgame/cg_wmodels.cpp
@@ -54,7 +54,7 @@ static const char *wmPartSufix[] = { "", "_expansion", "_barrel", "_flash", "_ha
 */
 static bool CG_vWeap_ParseAnimationScript( weaponinfo_t *weaponinfo, const char *filename )
 {
-	qbyte *buf;
+	uint8_t *buf;
 	char *ptr, *token;
 	int rounder, counter, i;
 	bool debug = true;
@@ -80,7 +80,7 @@ static bool CG_vWeap_ParseAnimationScript( weaponinfo_t *weaponinfo, const char 
 		trap_FS_FCloseFile( filenum );
 		return false;
 	}
-	buf = ( qbyte * )CG_Malloc( length + 1 );
+	buf = ( uint8_t * )CG_Malloc( length + 1 );
 	trap_FS_Read( buf, length, filenum );
 	trap_FS_FCloseFile( filenum );
 
@@ -683,12 +683,12 @@ void CG_AddWeaponOnTag( entity_t *ent, orientation_t *tag, int weaponid, int eff
 	if( weaponInfo->model[FLASH] )
 	{
 		entity_t flash;
-		qbyte c;
+		uint8_t c;
 
 		if( weaponInfo->flashFade )
 		{
 			intensity = (float)( flash_time - cg.time )/(float)weaponInfo->flashTime;
-			c = ( qbyte )( 255 * intensity );
+			c = ( uint8_t )( 255 * intensity );
 		}
 		else
 		{

--- a/source/cgame/ref.h
+++ b/source/cgame/ref.h
@@ -152,7 +152,7 @@ typedef struct entity_s
 	union
 	{
 		byte_vec4_t color;
-		qbyte shaderRGBA[4];
+		uint8_t shaderRGBA[4];
 	};
 
 	float scale;
@@ -163,7 +163,7 @@ typedef struct entity_s
 	union
 	{
 		byte_vec4_t outlineColor;
-		qbyte outlineRGBA[4];
+		uint8_t outlineRGBA[4];
 	};
 } entity_t;
 
@@ -184,7 +184,7 @@ typedef struct refdef_s
 	unsigned int time;					// time is used for timing offsets
 	int rdflags;						// RDF_UNDERWATER, etc
 	skyportal_t skyportal;
-	qbyte *areabits;					// if not NULL, only areas with set bits will be drawn
+	uint8_t *areabits;					// if not NULL, only areas with set bits will be drawn
 	float weaponAlpha;
 	float minLight;						// minimum value of ambient lighting applied to RF_MINLIGHT entities
 } refdef_t;

--- a/source/cin/cin.c
+++ b/source/cin/cin.c
@@ -47,7 +47,7 @@ typedef struct
 	void ( *shutdown )( cinematics_t *cin );
 	void ( *reset )( cinematics_t *cin );
 	qboolean ( *need_next_frame )( cinematics_t *cin );
-	qbyte *( *read_next_frame )( cinematics_t *cin, qboolean *redraw );
+	uint8_t *( *read_next_frame )( cinematics_t *cin, qboolean *redraw );
 	cin_yuv_t *( *read_next_frame_yuv )( cinematics_t *cin, qboolean *redraw );
 } cin_type_t;
 
@@ -226,11 +226,11 @@ qboolean CIN_NeedNextFrame( cinematics_t *cin, unsigned int curtime )
 /*
 * CIN_ReadNextFrame_
 */
-static qbyte *CIN_ReadNextFrame_( cinematics_t *cin, int *width, int *height, 
+static uint8_t *CIN_ReadNextFrame_( cinematics_t *cin, int *width, int *height, 
 	int *aspect_numerator, int *aspect_denominator, qboolean *redraw, qboolean yuv )
 {
 	int i;
-	qbyte *frame = NULL;
+	uint8_t *frame = NULL;
 	const cin_type_t *type;
 	qboolean redraw_ = qfalse;
 
@@ -245,7 +245,7 @@ static qbyte *CIN_ReadNextFrame_( cinematics_t *cin, int *width, int *height,
 	{
 		redraw_ = qfalse;
 		if( yuv ) {
-			frame = ( qbyte * )type->read_next_frame_yuv( cin, &redraw_ );
+			frame = ( uint8_t * )type->read_next_frame_yuv( cin, &redraw_ );
 		}
 		else {
 			frame = type->read_next_frame( cin, &redraw_ );
@@ -281,7 +281,7 @@ static qbyte *CIN_ReadNextFrame_( cinematics_t *cin, int *width, int *height,
 /*
 * CIN_ReadNextFrame
 */
-qbyte *CIN_ReadNextFrame( cinematics_t *cin, int *width, int *height, 
+uint8_t *CIN_ReadNextFrame( cinematics_t *cin, int *width, int *height, 
 	int *aspect_numerator, int *aspect_denominator, qboolean *redraw )
 {
 	return CIN_ReadNextFrame_( cin, width, height, 
@@ -342,7 +342,7 @@ qboolean CIN_AddRawSamplesListener( cinematics_t *cin, void *listener,
 * CIN_RawSamplesToListeners
 */
 void CIN_RawSamplesToListeners( cinematics_t *cin, unsigned int samples, unsigned int rate, 
-		unsigned short width, unsigned short channels, const qbyte *data )
+		unsigned short width, unsigned short channels, const uint8_t *data )
 {
 	int i;
 

--- a/source/cin/cin_local.h
+++ b/source/cin/cin_local.h
@@ -71,7 +71,7 @@ typedef struct cinematics_s
 
 	qboolean	yuv;
 
-	qbyte		*vid_buffer;
+	uint8_t		*vid_buffer;
 
 	qboolean	haveAudio;			// only valid for the current frame
 	int			num_listeners;
@@ -94,7 +94,7 @@ struct cinematics_s *CIN_Open( const char *name, unsigned int start_time,
 
 qboolean CIN_NeedNextFrame( cinematics_t *cin, unsigned int curtime );
 
-qbyte *CIN_ReadNextFrame( cinematics_t *cin, int *width, int *height, 
+uint8_t *CIN_ReadNextFrame( cinematics_t *cin, int *width, int *height, 
 	int *aspect_numerator, int *aspect_denominator, qboolean *redraw );
 
 cin_yuv_t *CIN_ReadNextFrameYUV( cinematics_t *cin, int *width, int *height, 
@@ -106,7 +106,7 @@ qboolean CIN_AddRawSamplesListener( cinematics_t *cin, void *listener,
 	cin_raw_samples_cb_t raw_samples, cin_get_raw_samples_cb_t get_raw_samples );
 
 void CIN_RawSamplesToListeners( cinematics_t *cin, unsigned int samples, unsigned int rate, 
-		unsigned short width, unsigned short channels, const qbyte *data );
+		unsigned short width, unsigned short channels, const uint8_t *data );
 
 unsigned int CIN_GetRawSamplesLengthFromListeners( cinematics_t *cin );
 

--- a/source/cin/cin_public.h
+++ b/source/cin/cin_public.h
@@ -68,7 +68,7 @@ typedef struct {
 } cin_yuv_t;
 
 typedef void (*cin_raw_samples_cb_t)(void*,unsigned int, unsigned int, 
-	unsigned short, unsigned short, const qbyte *);
+	unsigned short, unsigned short, const uint8_t *);
 typedef unsigned int (*cin_get_raw_samples_cb_t)(void*);
 
 //
@@ -120,7 +120,7 @@ typedef struct
 
 	// clock
 	unsigned int	( *Milliseconds )( void );
-	quint64			( *Microseconds )( void );
+	uint64_t			( *Microseconds )( void );
 
 	// managed memory allocation
 	struct mempool_s *( *Mem_AllocPool )( const char *name, const char *filename, int fileline );
@@ -144,7 +144,7 @@ typedef struct
 
 	struct cinematics_s *( *Open )( const char *name, unsigned int start_time, qboolean loop, qboolean *yuv, float *framerate );
 	qboolean ( *NeedNextFrame )( struct cinematics_s *cin, unsigned int curtime );
-	qbyte *( *ReadNextFrame )( struct cinematics_s *cin, int *width, int *height, int *aspect_numerator, int *aspect_denominator, qboolean *redraw );
+	uint8_t *( *ReadNextFrame )( struct cinematics_s *cin, int *width, int *height, int *aspect_numerator, int *aspect_denominator, qboolean *redraw );
 	cin_yuv_t *( *ReadNextFrameYUV )( struct cinematics_s *cin, int *width, int *height, int *aspect_numerator, int *aspect_denominator, qboolean *redraw );
 	qboolean ( *AddRawSamplesListener )( struct cinematics_s *cin, void *listener, cin_raw_samples_cb_t rs, cin_get_raw_samples_cb_t grs );
 	void ( *Reset )( struct cinematics_s *cin, unsigned int cur_time );

--- a/source/cin/cin_roq.c
+++ b/source/cin/cin_roq.c
@@ -42,7 +42,7 @@ typedef struct
 	int				height_2;
 
 	cin_yuv_t		cyuv[2];
-	qbyte			*yuv_pixels;
+	uint8_t			*yuv_pixels;
 } roq_info_t;
 
 static short snd_sqr_arr[256];
@@ -109,7 +109,7 @@ static void RoQ_ReadInfo( cinematics_t *cin )
 	short t[4];
 	roq_info_t *roq = cin->fdata;
 	cin_yuv_t *cyuv = roq->cyuv;
-	qbyte *pixels;
+	uint8_t *pixels;
 	int width, height;
 
 	trap_FS_Read( t, sizeof( short ) * 4, cin->file );
@@ -186,8 +186,8 @@ static void RoQ_ReadCodebook( cinematics_t *cin )
 */
 static void RoQ_ApplyVector2x2( cinematics_t *cin, int xpos, int ypos, const roq_cell_t *cell )
 {
-	qbyte *dst_y0, *dst_y1;
-	qbyte *dst_u, *dst_v;
+	uint8_t *dst_y0, *dst_y1;
+	uint8_t *dst_u, *dst_v;
 	roq_info_t *roq = cin->fdata;
 	cin_img_plane_t *plane;
 	int xpos_2 = xpos / 2, ypos_2 = ypos / 2;
@@ -218,9 +218,9 @@ static void RoQ_ApplyVector2x2( cinematics_t *cin, int xpos, int ypos, const roq
 */
 static void RoQ_ApplyVector4x4( cinematics_t *cin, int xpos, int ypos, const roq_cell_t *cell )
 {
-	qbyte *dst_y0, *dst_y1;
-	qbyte *dst_u0, *dst_v0;
-	qbyte p[4], u[2], v[2];
+	uint8_t *dst_y0, *dst_y1;
+	uint8_t *dst_u0, *dst_v0;
+	uint8_t p[4], u[2], v[2];
 	roq_info_t *roq = cin->fdata;
 	cin_img_plane_t *y_plane, *u_plane, *v_plane;
 	int xpos_2 = xpos / 2, ypos_2 = ypos / 2;
@@ -267,12 +267,12 @@ static void RoQ_ApplyVector4x4( cinematics_t *cin, int xpos, int ypos, const roq
 /*
 * RoQ_ApplyMotion4x4
 */
-static void RoQ_ApplyMotion4x4( cinematics_t *cin, int xpos, int ypos, qbyte mv, char mean_x, char mean_y )
+static void RoQ_ApplyMotion4x4( cinematics_t *cin, int xpos, int ypos, uint8_t mv, char mean_x, char mean_y )
 {
 	int i, j;
 	int xpos_2, ypos_2;
 	int xpos1, ypos1, xpos1_2, ypos1_2;
-	qbyte *src, *dst;
+	uint8_t *src, *dst;
 	roq_info_t *roq = cin->fdata;
 	cin_img_plane_t *plane, *plane1;
 
@@ -313,12 +313,12 @@ static void RoQ_ApplyMotion4x4( cinematics_t *cin, int xpos, int ypos, qbyte mv,
 /*
 * RoQ_ApplyMotion8x8
 */
-static void RoQ_ApplyMotion8x8( cinematics_t *cin, int xpos, int ypos, qbyte mv, char mean_x, char mean_y )
+static void RoQ_ApplyMotion8x8( cinematics_t *cin, int xpos, int ypos, uint8_t mv, char mean_x, char mean_y )
 {
 	int i, j;
 	int xpos_2, ypos_2;
 	int xpos1, ypos1, xpos1_2, ypos1_2;
-	qbyte *src, *dst;
+	uint8_t *src, *dst;
 	roq_info_t *roq = cin->fdata;
 	cin_img_plane_t *plane, *plane1;
 
@@ -366,9 +366,9 @@ static cin_yuv_t *RoQ_ReadVideo( cinematics_t *cin )
 	roq_chunk_t *chunk = &roq->chunk;
 	int i, vqflg, vqflg_pos, vqid;
 	int xpos, ypos, x, y, xp, yp;
-	qbyte c;
+	uint8_t c;
 	roq_qcell_t *qcell;
-	qbyte raw[RoQ_READ_BLOCK];
+	uint8_t raw[RoQ_READ_BLOCK];
 	unsigned remaining, bpos, read;
 
 	vqflg = 0;
@@ -483,7 +483,7 @@ static void RoQ_ReadAudio( cinematics_t *cin )
 {
 	unsigned int i;
 	int snd_left, snd_right;
-	qbyte raw[RoQ_READ_BLOCK];
+	uint8_t raw[RoQ_READ_BLOCK];
 	short samples[RoQ_READ_BLOCK];
 	roq_info_t *roq = cin->fdata;
 	roq_chunk_t *chunk = &roq->chunk;
@@ -514,7 +514,7 @@ static void RoQ_ReadAudio( cinematics_t *cin )
 				snd_left = (short)snd_left;
 			}
 
-			CIN_RawSamplesToListeners( cin, read, cin->s_rate, 2, 1, (qbyte *)samples );
+			CIN_RawSamplesToListeners( cin, read, cin->s_rate, 2, 1, (uint8_t *)samples );
 		}
 		else if( chunk->id == RoQ_SOUND_STEREO )
 		{
@@ -529,7 +529,7 @@ static void RoQ_ReadAudio( cinematics_t *cin )
 				snd_right = (short)snd_right;
 			}
 
-			CIN_RawSamplesToListeners( cin, read / 2, cin->s_rate, 2, 2, (qbyte *)samples );
+			CIN_RawSamplesToListeners( cin, read / 2, cin->s_rate, 2, 2, (uint8_t *)samples );
 		}
 	}
 }

--- a/source/cin/cin_syscalls.h
+++ b/source/cin/cin_syscalls.h
@@ -166,7 +166,7 @@ static inline unsigned int trap_Milliseconds( void )
 	return CIN_IMPORT.Milliseconds();
 }
 
-static inline quint64 trap_Microseconds( void )
+static inline uint64_t trap_Microseconds( void )
 {
 	return CIN_IMPORT.Microseconds();
 }

--- a/source/cin/cin_theora.c
+++ b/source/cin/cin_theora.c
@@ -144,7 +144,7 @@ static qboolean OggVorbis_LoadAudioFrame( cinematics_t *cin )
 	float *right,*left;
 	qboolean haveAudio = qfalse;
 	int	samples, samplesNeeded;
-	qbyte rawBuffer[RAW_BUFFER_SIZE];
+	uint8_t rawBuffer[RAW_BUFFER_SIZE];
 	ogg_packet op;
 	vorbis_block vb;
 	qtheora_info_t *qth = cin->fdata;
@@ -456,7 +456,7 @@ static qboolean Theora_ReadNextFrame_CIN_( cinematics_t *cin, qboolean *redraw, 
 /*
 * Theora_DecodeYCbCr2RGB_420
 */
-static void Theora_DecodeYCbCr2RGB_420( cin_yuv_t *cyuv, int bytes, qbyte *out )
+static void Theora_DecodeYCbCr2RGB_420( cin_yuv_t *cyuv, int bytes, uint8_t *out )
 {
 	int 
 		x_offset = cyuv->x_offset, 
@@ -469,16 +469,16 @@ static void Theora_DecodeYCbCr2RGB_420( cin_yuv_t *cyuv, int bytes, qbyte *out )
 		uStride = cyuv->yuv[1].stride,
 		vStride = cyuv->yuv[2].stride,
 		outStride = width * bytes;
-	qbyte 
+	uint8_t 
 		*yData = cyuv->yuv[0].data + (x_offset     ) + yStride * (y_offset     ), 
 		*uData = cyuv->yuv[1].data + (x_offset >> 1) + uStride * (y_offset >> 1),
 		*vData = cyuv->yuv[2].data + (x_offset >> 1) + vStride * (y_offset >> 1);
-	qbyte
+	uint8_t
 		*yRow  = yData,
 		*yRow2 = yData + yStride,
 		*uRow  = uData,
 		*vRow  = vData;
-	qbyte
+	uint8_t
 		*oRow  = out,
 		*oRow2 = out + outStride;
 	unsigned int xPos, yPos;
@@ -529,7 +529,7 @@ static void Theora_DecodeYCbCr2RGB_420( cin_yuv_t *cyuv, int bytes, qbyte *out )
 /*
 * Theora_DecodeYCbCr2RGB_422
 */
-static void Theora_DecodeYCbCr2RGB_422( cin_yuv_t *cyuv, int bytes, qbyte *out )
+static void Theora_DecodeYCbCr2RGB_422( cin_yuv_t *cyuv, int bytes, uint8_t *out )
 {
 	int 
 		x_offset = cyuv->x_offset, 
@@ -542,15 +542,15 @@ static void Theora_DecodeYCbCr2RGB_422( cin_yuv_t *cyuv, int bytes, qbyte *out )
 		uStride = cyuv->yuv[1].stride,
 		vStride = cyuv->yuv[2].stride,
 		outStride = width * bytes;
-	qbyte 
+	uint8_t 
 		*yData = cyuv->yuv[0].data + (x_offset     ) + yStride * (y_offset), 
 		*uData = cyuv->yuv[1].data + (x_offset >> 1) + uStride * (y_offset),
 		*vData = cyuv->yuv[2].data + (x_offset >> 1) + vStride * (y_offset);
-	qbyte
+	uint8_t
 		*yRow  = yData,
 		*uRow  = uData,
 		*vRow  = vData;
-	qbyte
+	uint8_t
 		*oRow  = out;
 	unsigned int xPos, yPos;
 	int y = 0, u = 0, v = 0, c[3];
@@ -593,7 +593,7 @@ static void Theora_DecodeYCbCr2RGB_422( cin_yuv_t *cyuv, int bytes, qbyte *out )
 /*
 * Theora_DecodeYCbCr2RGB_444
 */
-static void Theora_DecodeYCbCr2RGB_444( cin_yuv_t *cyuv, int bytes, qbyte *out )
+static void Theora_DecodeYCbCr2RGB_444( cin_yuv_t *cyuv, int bytes, uint8_t *out )
 {
 	int 
 		x_offset = cyuv->x_offset, 
@@ -606,15 +606,15 @@ static void Theora_DecodeYCbCr2RGB_444( cin_yuv_t *cyuv, int bytes, qbyte *out )
 		uStride = cyuv->yuv[1].stride,
 		vStride = cyuv->yuv[2].stride,
 		outStride = width * bytes;
-	qbyte 
+	uint8_t 
 		*yData = cyuv->yuv[0].data + x_offset + yStride * y_offset, 
 		*uData = cyuv->yuv[1].data + x_offset + uStride * y_offset,
 		*vData = cyuv->yuv[2].data + x_offset + vStride * y_offset;
-	qbyte
+	uint8_t
 		*yRow  = yData,
 		*uRow  = uData,
 		*vRow  = vData;
-	qbyte
+	uint8_t
 		*oRow  = out;
 	unsigned int xPos, yPos;
 	int y = 0, u = 0, v = 0, c[3];
@@ -650,7 +650,7 @@ static void Theora_DecodeYCbCr2RGB_444( cin_yuv_t *cyuv, int bytes, qbyte *out )
 /*
 * Theora_DecodeYCbCr2RGB
 */
-static void Theora_DecodeYCbCr2RGB( th_pixel_fmt pfmt, cin_yuv_t *cyuv, int bytes, qbyte *out )
+static void Theora_DecodeYCbCr2RGB( th_pixel_fmt pfmt, cin_yuv_t *cyuv, int bytes, uint8_t *out )
 {
 	switch( pfmt ) {
 		case TH_PF_444:
@@ -670,7 +670,7 @@ static void Theora_DecodeYCbCr2RGB( th_pixel_fmt pfmt, cin_yuv_t *cyuv, int byte
 /*
 * Theora_ReadNextFrame_CIN
 */
-qbyte *Theora_ReadNextFrame_CIN( cinematics_t *cin, qboolean *redraw )
+uint8_t *Theora_ReadNextFrame_CIN( cinematics_t *cin, qboolean *redraw )
 {
 	qboolean eos;
 	qboolean haveVideo;

--- a/source/cin/cin_theora.h
+++ b/source/cin/cin_theora.h
@@ -30,7 +30,7 @@ qboolean Theora_Init_CIN( cinematics_t *cin );
 void Theora_Shutdown_CIN( cinematics_t *cin );
 void Theora_Reset_CIN( cinematics_t *cin );
 qboolean Theora_NeedNextFrame_CIN( cinematics_t *cin );
-qbyte *Theora_ReadNextFrame_CIN( cinematics_t *cin, qboolean *redraw );
+uint8_t *Theora_ReadNextFrame_CIN( cinematics_t *cin, qboolean *redraw );
 cin_yuv_t *Theora_ReadNextFrameYUV_CIN( cinematics_t *cin, qboolean *redraw );
 
 #endif

--- a/source/cin/roq.h
+++ b/source/cin/roq.h
@@ -37,12 +37,12 @@
 
 typedef struct
 {
-	qbyte y[4], u, v;
+	uint8_t y[4], u, v;
 } roq_cell_t;
 
 typedef struct
 {
-	qbyte idx[4];
+	uint8_t idx[4];
 } roq_qcell_t;
 
 typedef struct

--- a/source/client/cin.c
+++ b/source/client/cin.c
@@ -233,7 +233,7 @@ qboolean CIN_NeedNextFrame( struct cinematics_s *cin, unsigned int curtime )
 	return qfalse;
 }
 
-qbyte *CIN_ReadNextFrame( struct cinematics_s *cin, int *width, 
+uint8_t *CIN_ReadNextFrame( struct cinematics_s *cin, int *width, 
 	int *height, int *aspect_numerator, int *aspect_denominator, qboolean *redraw )
 {
 	if( cin_export ) {

--- a/source/client/cin.h
+++ b/source/client/cin.h
@@ -28,7 +28,7 @@ struct cinematics_s *CIN_Open( const char *name, unsigned int start_time,
 
 qboolean CIN_NeedNextFrame( struct cinematics_s *cin, unsigned int curtime );
 
-qbyte *CIN_ReadNextFrame( struct cinematics_s *cin, int *width, int *height, 
+uint8_t *CIN_ReadNextFrame( struct cinematics_s *cin, int *width, int *height, 
 	int *aspect_numerator, int *aspect_denominator, qboolean *redraw );
 
 ref_yuv_t *CIN_ReadNextFrameYUV( struct cinematics_s *cin, int *width, int *height, 

--- a/source/client/cl_cin.c
+++ b/source/client/cl_cin.c
@@ -60,7 +60,7 @@ void SCR_FinishCinematic( void )
 * SCR_CinematicRawSamples
 */
 static void SCR_CinematicRawSamples( void *unused, unsigned int samples, 
-	unsigned int rate, unsigned short width, unsigned short channels, const qbyte *data )
+	unsigned int rate, unsigned short width, unsigned short channels, const uint8_t *data )
 {
 	(void)unused;
 	
@@ -89,7 +89,7 @@ static void SCR_ReadNextCinematicFrame( void )
 			&cl.cin.redraw );
 
 		// so that various cl.cin.pic == NULL checks still make sense
-		cl.cin.pic = ( qbyte * )cl.cin.cyuv;
+		cl.cin.pic = ( uint8_t * )cl.cin.cyuv;
 	}
 	else {
 		cl.cin.pic = CIN_ReadNextFrame( cl.cin.h, 

--- a/source/client/cl_demo.c
+++ b/source/client/cl_demo.c
@@ -288,7 +288,7 @@ void CL_DemoCompleted( void )
 */
 static void CL_ReadDemoMessage( void )
 {
-	static qbyte msgbuf[MAX_MSGLEN];
+	static uint8_t msgbuf[MAX_MSGLEN];
 	static msg_t demomsg;
 	static qboolean init = qtrue;
 	int read;

--- a/source/client/cl_game.c
+++ b/source/client/cl_game.c
@@ -254,7 +254,7 @@ void CL_GameModule_L10n_ClearDomain( void )
 * CL_GameModule_S_RawSamples
 */
 static void CL_GameModule_S_RawSamples( unsigned int samples, unsigned int rate, 
-	unsigned short width, unsigned short channels, const qbyte *data )
+	unsigned short width, unsigned short channels, const uint8_t *data )
 {
 	CL_SoundModule_RawSamples( samples, rate, width, channels, data, qfalse );
 }
@@ -284,7 +284,7 @@ cg_raw_samples_listener_t cg_raw_samples_listeners[MAX_CGAME_RAW_SAMPLES_LISTENE
 */
 static void CL_GameModule_RawSamples( void *ptr, unsigned int samples, 
 	unsigned int rate, unsigned short width, unsigned short channels, 
-	const qbyte *data )
+	const uint8_t *data )
 {
 	cg_raw_samples_listener_t *cglistener;
 

--- a/source/client/cl_input.c
+++ b/source/client/cl_input.c
@@ -146,15 +146,15 @@ static void CL_MouseExtrapolate( int mx, int my, float *extra_x, float *extra_y 
 
 	static unsigned int frameNo = 0;
 	static float sub_x = 0, sub_y = 0;
-	static qint64 lastMicros = 0;
-	static qint64 avgMicros = 0;
+	static int64_t lastMicros = 0;
+	static int64_t avgMicros = 0;
 
 	float add_x = 0.0, add_y = 0.0;
 	float decay = 1.0;
 	float decaySum = buf_size > 1 ? 0.0 : decay;
 	unsigned int i;
 
-	qint64 micros;
+	int64_t micros;
 	if( !lastMicros )
 		lastMicros = Sys_Microseconds() - 10000;    // start at 100 FPS
 	micros = Sys_Microseconds();                        // get current time in us
@@ -569,7 +569,7 @@ cvar_t *cl_zoom;
 /*
 * CL_AddButtonBits
 */
-static void CL_AddButtonBits( qbyte *buttons )
+static void CL_AddButtonBits( uint8_t *buttons )
 {
 	// figure button bits
 
@@ -942,7 +942,7 @@ void CL_WriteUcmdsToMessage( msg_t *msg )
 
 	// write the id number of first ucmd to be sent, and the count
 	MSG_WriteLong( msg, ucmdHead );
-	MSG_WriteByte( msg, (qbyte)( ucmdHead - ucmdFirst ) );
+	MSG_WriteByte( msg, (uint8_t)( ucmdHead - ucmdFirst ) );
 
 	// write the ucmds
 	for( i = ucmdFirst; i < ucmdHead; i++ )

--- a/source/client/cl_main.c
+++ b/source/client/cl_main.c
@@ -547,10 +547,10 @@ static void CL_Rcon_f( void )
 		return;
 	}
 
-	message[0] = (qbyte)255;
-	message[1] = (qbyte)255;
-	message[2] = (qbyte)255;
-	message[3] = (qbyte)255;
+	message[0] = (uint8_t)255;
+	message[1] = (uint8_t)255;
+	message[2] = (uint8_t)255;
+	message[3] = (uint8_t)255;
 	message[4] = 0;
 
 	Q_strncatz( message, "rcon ", sizeof( message ) );
@@ -1355,7 +1355,7 @@ static qboolean CL_ProcessPacket( netchan_t *netchan, msg_t *msg )
 void CL_ReadPackets( void )
 {
 	static msg_t msg;
-	static qbyte msgData[MAX_MSGLEN];
+	static uint8_t msgData[MAX_MSGLEN];
 	int socketind, ret;
 	socket_t *socket;
 	netadr_t address;
@@ -2492,7 +2492,7 @@ static qboolean CL_MaxPacketsReached( void )
 void CL_SendMessagesToServer( qboolean sendNow )
 {
 	msg_t message;
-	qbyte messageData[MAX_MSGLEN];
+	uint8_t messageData[MAX_MSGLEN];
 
 	if( cls.state == CA_DISCONNECTED || cls.state == CA_GETTING_TICKET || cls.state == CA_CONNECTING || cls.state == CA_CINEMATIC )
 		return;

--- a/source/client/cl_serverlist.c
+++ b/source/client/cl_serverlist.c
@@ -196,7 +196,7 @@ void CL_WriteServerCache( void )
 void CL_ReadServerCache( void )
 {
 	int filelen, filehandle;
-	qbyte *buf = NULL;
+	uint8_t *buf = NULL;
 	char *ptr, *token;
 	netadr_t adr;
 	char adrString[64];
@@ -415,7 +415,7 @@ static void CL_ParseGetServersResponseMessage( msg_t *msg, qboolean extended )
 {
 	const char *header;
 	char adrString[64];
-	qbyte addr[16];
+	uint8_t addr[16];
 	unsigned short port;
 	netadr_t adr;
 

--- a/source/client/cl_sound.c
+++ b/source/client/cl_sound.c
@@ -521,7 +521,7 @@ void CL_SoundModule_AddLoopSound( struct sfx_s *sfx, int entnum, float fvol, flo
 * CL_SoundModule_RawSamples
 */
 void CL_SoundModule_RawSamples( unsigned int samples, unsigned int rate, 
-	unsigned short width, unsigned short channels, const qbyte *data, qboolean music )
+	unsigned short width, unsigned short channels, const uint8_t *data, qboolean music )
 {
 	if( se )
 		se->RawSamples( samples, rate, width, channels, data, music );
@@ -532,7 +532,7 @@ void CL_SoundModule_RawSamples( unsigned int samples, unsigned int rate,
 */
 void CL_SoundModule_PositionedRawSamples( int entnum, float fvol, float attenuation, 
 		unsigned int samples, unsigned int rate, 
-		unsigned short width, unsigned short channels, const qbyte *data )
+		unsigned short width, unsigned short channels, const uint8_t *data )
 {
 	if( entnum > max_spatialization_num ) {
 		max_spatialization_num = entnum;

--- a/source/client/client.h
+++ b/source/client/client.h
@@ -57,7 +57,7 @@ typedef struct
 	qboolean yuv;
 	unsigned int startTime;
 	unsigned int pauseTime;
-	qbyte *pic;
+	uint8_t *pic;
 	int aspect_numerator, aspect_denominator;
 	ref_yuv_t *cyuv;
 	float framerate;
@@ -84,7 +84,7 @@ typedef struct
 	int previousSnapNum;
 	int suppressCount;				// number of messages rate suppressed
 	snapshot_t *snapShots;			// [CMD_BACKUP]
-	qbyte *frames_areabits;
+	uint8_t *frames_areabits;
 
 	cmodel_state_t *cms;
 
@@ -440,10 +440,10 @@ void CL_SoundModule_StartGlobalSound( struct sfx_s *sfx, int channel, float fvol
 void CL_SoundModule_StartLocalSound( const char *s );
 void CL_SoundModule_AddLoopSound( struct sfx_s *sfx, int entnum, float fvol, float attenuation );
 void CL_SoundModule_RawSamples( unsigned int samples, unsigned int rate, 
-	unsigned short width, unsigned short channels, const qbyte *data, qboolean music );
+	unsigned short width, unsigned short channels, const uint8_t *data, qboolean music );
 void CL_SoundModule_PositionedRawSamples( int entnum, float fvol, float attenuation, 
 	unsigned int samples, unsigned int rate, 
-	unsigned short width, unsigned short channels, const qbyte *data );
+	unsigned short width, unsigned short channels, const uint8_t *data );
 unsigned int CL_SoundModule_GetRawSamplesLength( void );
 unsigned int CL_SoundModule_GetPositionedRawSamplesLength( int entnum );
 void CL_SoundModule_StartBackgroundTrack( const char *intro, const char *loop );

--- a/source/client/ftlib.c
+++ b/source/client/ftlib.c
@@ -65,7 +65,7 @@ static struct shader_s *CL_FTLibModule_RegisterPic( const char *name )
 	return re.RegisterPic( name );
 }
 
-static struct shader_s *CL_FTLibModule_RegisterRawPic( const char *name, int width, int height, qbyte *data )
+static struct shader_s *CL_FTLibModule_RegisterRawPic( const char *name, int width, int height, uint8_t *data )
 {
 	return re.RegisterRawPic( name, width, height, data );
 }

--- a/source/client/l10n.c
+++ b/source/client/l10n.c
@@ -317,7 +317,7 @@ static podict_t *L10n_LoadPODict( const char *filepath )
 	}
 
 	podict = ( podict_t * )L10n_Malloc( sizeof( *podict ) + length + 1 );
-	podict->buffer = ( char * )( ( qbyte * )podict + sizeof( *podict ) );
+	podict->buffer = ( char * )( ( uint8_t * )podict + sizeof( *podict ) );
 	FS_Read( podict->buffer, length, file );
 	podict->buffer[length] = '\0'; // safeguard
 	FS_FCloseFile( file );
@@ -348,7 +348,7 @@ static pofile_t *L10n_CreatePOFile( const char *filepath )
 	size_t filepath_size = strlen( filepath ) + 1;
 	pofile_t *pofile;
 	pofile = ( pofile_t * )L10n_Malloc( sizeof( *pofile ) + filepath_size );
-	pofile->path = ( char * )( ( qbyte * )pofile + sizeof( *pofile ) );
+	pofile->path = ( char * )( ( uint8_t * )pofile + sizeof( *pofile ) );
 	pofile->next = NULL;
 	pofile->dict = NULL;
 	memcpy( pofile->path, filepath, filepath_size );
@@ -412,7 +412,7 @@ static podomain_t *L10n_CreatePODomain( const char *name )
 	size_t name_size = strlen( name ) + 1;
 	podomain_t *podomain;
 	podomain = ( podomain_t * )L10n_Malloc( sizeof( *podomain ) + name_size );
-	podomain->name = ( char * )( ( qbyte * )podomain + sizeof( *podomain ) );
+	podomain->name = ( char * )( ( uint8_t * )podomain + sizeof( *podomain ) );
 	podomain->next = NULL;
 	podomain->pofiles_head = NULL;
 	memcpy( podomain->name, name, name_size );

--- a/source/client/snd_public.h
+++ b/source/client/snd_public.h
@@ -79,7 +79,7 @@ typedef struct
 	qboolean ( *FS_IsUrl )( const char *url );
 
 	unsigned int ( *Milliseconds )( void );
-	void ( *PageInMemory )( qbyte *buffer, int size );
+	void ( *PageInMemory )( uint8_t *buffer, int size );
 	void ( *Sleep )( unsigned int milliseconds );
 
 	// managed memory allocation
@@ -143,10 +143,10 @@ typedef struct
 	void ( *AddLoopSound )( struct sfx_s *sfx, int entnum, float fvol, float attenuation );
 
 	// cinema
-	void ( *RawSamples )( unsigned int samples, unsigned int rate, unsigned short width, unsigned short channels, const qbyte *data, qboolean music );
+	void ( *RawSamples )( unsigned int samples, unsigned int rate, unsigned short width, unsigned short channels, const uint8_t *data, qboolean music );
 	void ( *PositionedRawSamples )( int entnum, float fvol, float attenuation, 
 		unsigned int samples, unsigned int rate, 
-		unsigned short width, unsigned short channels, const qbyte *data );
+		unsigned short width, unsigned short channels, const uint8_t *data );
 	unsigned int ( *GetRawSamplesLength )( void );
 	unsigned int ( *GetPositionedRawSamplesLength )( int entnum );
 

--- a/source/ftlib/ftlib.c
+++ b/source/ftlib/ftlib.c
@@ -103,7 +103,7 @@ static qfontface_t *QFT_LoadFace( qfontfamily_t *family, unsigned int size, unsi
 	int line, numLines;
 	int linesPerImage;
 	int numImages, imageNum;
-	qbyte *tempRGBA = NULL;
+	uint8_t *tempRGBA = NULL;
 	qboolean clearImage;
 	qboolean hasKerning;
 	qttface_t *qttf = NULL;
@@ -189,7 +189,7 @@ static qfontface_t *QFT_LoadFace( qfontfamily_t *family, unsigned int size, unsi
 
 	// we are going to need this for kerning
 	qttf = FTLIB_Alloc( ftlibPool, sizeof( *qttf ) + (maxChar+1) * sizeof( FT_UInt ) );
-	qttf->gindices = ( FT_UInt * )( ( qbyte * )qttf + sizeof( *qttf ) );
+	qttf->gindices = ( FT_UInt * )( ( uint8_t * )qttf + sizeof( *qttf ) );
 	qttf->ftface = ftface;
 
 	// failed to find an unused slot, take a new one
@@ -229,7 +229,7 @@ static qfontface_t *QFT_LoadFace( qfontfamily_t *family, unsigned int size, unsi
 	imageNum = 0;
 	imageHeight = 0;
 	imagePitch = imageWidth * 4;
-	tempRGBA = ( qbyte * )FTLIB_Alloc( ftlibPool, imagePitch * FTLIB_MAX_FONT_IMAGE_HEIGHT );
+	tempRGBA = ( uint8_t * )FTLIB_Alloc( ftlibPool, imagePitch * FTLIB_MAX_FONT_IMAGE_HEIGHT );
 	clearImage = qtrue;
 	lastStartChar = minChar;
 
@@ -295,8 +295,8 @@ upload_image:
 		gindex = FT_Get_Char_Index( ftface, charcode );
 		qttf->gindices[charcode] = gindex;
 		if( gindex > 0 ) {
-			qbyte *dst, *src;
-			qbyte *dst_p, *src_p;
+			uint8_t *dst, *src;
+			uint8_t *dst_p, *src_p;
 			FT_Bitmap *bitmap;
 			unsigned int bitmap_width, bitmap_height;
 			unsigned int bitmap_left, bitmap_top;
@@ -448,7 +448,7 @@ void QFT_UnloadFace( qfontface_t *qfont )
 /*
 * QFT_LoadFamily
 */
-static void QFT_LoadFamily( const char *fileName, const qbyte *data, size_t dataSize, qboolean verbose )
+static void QFT_LoadFamily( const char *fileName, const uint8_t *data, size_t dataSize, qboolean verbose )
 {
 	FT_Face ftface;
 	int error;
@@ -509,7 +509,7 @@ static void QFT_LoadFamilyFromFile( const char *name, const char *fileName, qboo
 {
 	int fileNum;
 	int length;
-	qbyte *buffer;
+	uint8_t *buffer;
 
 	if( numFontFamilies == FTLIB_MAX_FONT_FAMILIES ) {
 		return;
@@ -520,7 +520,7 @@ static void QFT_LoadFamilyFromFile( const char *name, const char *fileName, qboo
 		return;
 	}
 
-	buffer = ( qbyte * )FTLIB_Alloc( ftlibPool, length );
+	buffer = ( uint8_t * )FTLIB_Alloc( ftlibPool, length );
 	trap_FS_Read( buffer, length, fileNum );
 
 	QFT_LoadFamily( name, buffer, length, verbose );

--- a/source/ftlib/ftlib_public.h
+++ b/source/ftlib/ftlib_public.h
@@ -79,11 +79,11 @@ typedef struct
 
 	// clock
 	unsigned int	( *Milliseconds )( void );
-	quint64			( *Microseconds )( void );
+	uint64_t			( *Microseconds )( void );
 
 	// renderer
 	struct shader_s *( *R_RegisterPic )( const char *name );
-	struct shader_s * ( *R_RegisterRawPic )( const char *name, int width, int height, qbyte *data );
+	struct shader_s * ( *R_RegisterRawPic )( const char *name, int width, int height, uint8_t *data );
 	void ( *R_DrawStretchPic )( int x, int y, int w, int h, float s1, float t1, float s2, float t2, const vec4_t color, const struct shader_s *shader );
 	void ( *R_Scissor )( int x, int y, int w, int h );
 	void ( *R_GetScissor )( int *x, int *y, int *w, int *h );

--- a/source/ftlib/ftlib_syscalls.h
+++ b/source/ftlib/ftlib_syscalls.h
@@ -166,7 +166,7 @@ static inline unsigned int trap_Milliseconds( void )
 	return FTLIB_IMPORT.Milliseconds();
 }
 
-static inline quint64 trap_Microseconds( void )
+static inline uint64_t trap_Microseconds( void )
 {
 	return FTLIB_IMPORT.Microseconds();
 }
@@ -177,7 +177,7 @@ static inline struct shader_s *trap_R_RegisterPic( const char *name )
 	return FTLIB_IMPORT.R_RegisterPic( name );
 }
 
-static inline struct shader_s *trap_R_RegisterRawPic( const char *name, int width, int height, qbyte *data )
+static inline struct shader_s *trap_R_RegisterRawPic( const char *name, int width, int height, uint8_t *data )
 {
 	return FTLIB_IMPORT.R_RegisterRawPic( name, width, height, data );
 }

--- a/source/game/ai/bot_spawn.cpp
+++ b/source/game/ai/bot_spawn.cpp
@@ -324,7 +324,7 @@ static void BOT_CreateUserinfo( char *userinfo, size_t userinfo_size, int bot_pe
 	//Info_SetValueForKey( userinfo, "skin", bot_skin );
 	Info_SetValueForKey( userinfo, "skin", "default" ); // JALFIXME
 	Info_SetValueForKey( userinfo, "hand", va( "%i", (int)( random()*2.5 ) ) );
-	Info_SetValueForKey( userinfo, "color", va( "%i %i %i", (qbyte)( random()*255 ), (qbyte)( random()*255 ), (qbyte)( random()*255 ) ) );
+	Info_SetValueForKey( userinfo, "color", va( "%i %i %i", (uint8_t)( random()*255 ), (uint8_t)( random()*255 ), (uint8_t)( random()*255 ) ) );
 }
 
 

--- a/source/game/g_ascript.cpp
+++ b/source/game/g_ascript.cpp
@@ -2790,7 +2790,7 @@ static bool asFunc_AppendToFile( asstring_t *path, asstring_t *data )
 static asstring_t *asFunc_LoadFile( asstring_t *path )
 {
 	int filelen, filehandle;
-	qbyte *buf = NULL;
+	uint8_t *buf = NULL;
 	asstring_t *data;
 
 	if( !path || !path->len )
@@ -2799,7 +2799,7 @@ static asstring_t *asFunc_LoadFile( asstring_t *path )
 	filelen = trap_FS_FOpenFile( path->buffer, &filehandle, FS_READ );
 	if( filehandle && filelen > 0 )
 	{
-		buf = ( qbyte * )G_Malloc( filelen + 1 );
+		buf = ( uint8_t * )G_Malloc( filelen + 1 );
 		filelen = trap_FS_Read( buf, filelen, filehandle );
 	}
 
@@ -3633,7 +3633,7 @@ bool G_ExecutionErrorReport( int error )
 static char *G_LoadScriptSection( const char *dir, const char *script, int sectionNum )
 {
 	char filename[MAX_QPATH];
-	qbyte *data;
+	uint8_t *data;
 	int length, filenum;
 	char *sectionName;
 
@@ -3661,7 +3661,7 @@ static char *G_LoadScriptSection( const char *dir, const char *script, int secti
 	}
 
 	//load the script data into memory
-	data = ( qbyte * )G_Malloc( length + 1 );
+	data = ( uint8_t * )G_Malloc( length + 1 );
 	trap_FS_Read( data, length, filenum );
 	trap_FS_FCloseFile( filenum );
 

--- a/source/game/g_awards.cpp
+++ b/source/game/g_awards.cpp
@@ -503,7 +503,7 @@ void G_PlayerAwardOfs( edict_t *ent, const char *awardMsg, int ofs, int limit, b
 			}
 		}
 
-		int *award = (int *)((qbyte *)&ent->r.client->resp.awardInfo + ofs);
+		int *award = (int *)((uint8_t *)&ent->r.client->resp.awardInfo + ofs);
 		if( *award >= limit ) {
 			return;
 		}

--- a/source/game/g_local.h
+++ b/source/game/g_local.h
@@ -1058,7 +1058,7 @@ typedef struct
 	int mh_control_award;
 	int ra_control_award;
 
-	qbyte combo[MAX_CLIENTS]; // combo management for award
+	uint8_t combo[MAX_CLIENTS]; // combo management for award
 	edict_t *lasthit;
 	unsigned int lasthit_time;
 
@@ -1074,7 +1074,7 @@ typedef struct
 typedef struct
 {
 	int buttons;
-	qbyte plrkeys; // used for displaying key icons
+	uint8_t plrkeys; // used for displaying key icons
 	int damageTaken;
 	vec3_t damageTakenDir;
 

--- a/source/game/g_misc.cpp
+++ b/source/game/g_misc.cpp
@@ -986,7 +986,7 @@ void SP_misc_particles( edict_t *ent )
 
 	if( ent->spawnflags & 8 ) // LIGHT
 	{
-		ent->s.light = COLOR_RGB( (qbyte)(ent->color[0] * 255), (qbyte)(ent->color[1] * 255), (qbyte)(ent->color[2] * 255) );
+		ent->s.light = COLOR_RGB( (uint8_t)(ent->color[0] * 255), (uint8_t)(ent->color[1] * 255), (uint8_t)(ent->color[2] * 255) );
 		if( !ent->s.light )
 			ent->s.light = COLOR_RGB( 255, 255, 255 );
 	}

--- a/source/game/g_spawn.cpp
+++ b/source/game/g_spawn.cpp
@@ -366,7 +366,7 @@ static char *ED_NewString( const char *string )
 static void ED_ParseField( char *key, char *value, edict_t *ent )
 {
 	const field_t *f;
-	qbyte *b;
+	uint8_t *b;
 	float v;
 	vec3_t vec;
 
@@ -376,9 +376,9 @@ static void ED_ParseField( char *key, char *value, edict_t *ent )
 		{
 			// found it
 			if( f->flags & FFL_SPAWNTEMP )
-				b = (qbyte *)&st;
+				b = (uint8_t *)&st;
 			else
-				b = (qbyte *)ent;
+				b = (uint8_t *)ent;
 
 			switch( f->type )
 			{

--- a/source/game/g_svcmds.cpp
+++ b/source/game/g_svcmds.cpp
@@ -134,8 +134,8 @@ static bool StringToFilter( char *s, ipfilter_t *f )
 {
 	char num[128];
 	int i, j;
-	qbyte b[4];
-	qbyte m[4];
+	uint8_t b[4];
+	uint8_t m[4];
 
 	for( i = 0; i < 4; i++ )
 	{
@@ -190,7 +190,7 @@ bool SV_FilterPacket( char *from )
 {
 	int i;
 	unsigned in;
-	qbyte m[4];
+	uint8_t m[4];
 	char *p;
 
 	if( !filterban->integer )
@@ -239,7 +239,7 @@ void SV_WriteIPList( void )
 	int file;
 	char name[MAX_QPATH];
 	char string[MAX_STRING_CHARS];
-	qbyte b[4] = { 0, 0, 0, 0 };
+	uint8_t b[4] = { 0, 0, 0, 0 };
 	int i;
 
 	Q_strncpyz( name, "listip.cfg", sizeof( name ) );
@@ -339,7 +339,7 @@ static void Cmd_RemoveIP_f( void )
 static void Cmd_ListIP_f( void )
 {
 	int i;
-	qbyte b[4];
+	uint8_t b[4];
 
 	G_Printf( "Filter list:\n" );
 	for( i = 0; i < numipfilters; i++ )

--- a/source/game/g_utils.cpp
+++ b/source/game/g_utils.cpp
@@ -68,7 +68,7 @@ static void G_Z_ClearZone( memzone_t *zone, int size )
 
 	// set the entire zone to one free block
 	zone->blocklist.next = zone->blocklist.prev = block =
-		(memblock_t *)( (qbyte *)zone + sizeof(memzone_t) );
+		(memblock_t *)( (uint8_t *)zone + sizeof(memzone_t) );
 	zone->blocklist.tag = 1;	// in use block
 	zone->blocklist.id = 0;
 	zone->blocklist.size = 0;
@@ -94,14 +94,14 @@ static void G_Z_Free( void *ptr, const char *filename, int fileline )
 	if (!ptr)
 		G_Error( "G_Z_Free: NULL pointer" );
 
-	block = (memblock_t *) ( (qbyte *)ptr - sizeof(memblock_t));
+	block = (memblock_t *) ( (uint8_t *)ptr - sizeof(memblock_t));
 	if( block->id != ZONEID )
 		G_Error( "G_Z_Free: freed a pointer without ZONEID (file %s at line %i)", filename, fileline );
 	if( block->tag == 0 )
 		G_Error( "G_Z_Free: freed a freed pointer (file %s at line %i)", filename, fileline );
 
 	// check the memory trash tester
-	if ( *(int *)((qbyte *)block + block->size - 4 ) != ZONEID )
+	if ( *(int *)((uint8_t *)block + block->size - 4 ) != ZONEID )
 		G_Error( "G_Z_Free: memory block wrote past end" );
 
 	zone = levelzone;
@@ -175,7 +175,7 @@ static void *G_Z_TagMalloc( int size, int tag, const char *filename, int filelin
 	if( extra > MINFRAGMENT )
 	{
 		// there will be a free fragment after the allocated block
-		newb = (memblock_t *) ((qbyte *)base + size );
+		newb = (memblock_t *) ((uint8_t *)base + size );
 		newb->size = extra;
 		newb->tag = 0;			// free block
 		newb->prev = base;
@@ -193,9 +193,9 @@ static void *G_Z_TagMalloc( int size, int tag, const char *filename, int filelin
 	base->id = ZONEID;
 
 	// marker for memory trash testing
-	*(int *)((qbyte *)base + base->size - 4) = ZONEID;
+	*(int *)((uint8_t *)base + base->size - 4) = ZONEID;
 
-	return (void *) ((qbyte *)base + sizeof(memblock_t));
+	return (void *) ((uint8_t *)base + sizeof(memblock_t));
 }
 
 /*
@@ -285,7 +285,7 @@ typedef struct g_poolstring_s
 	struct g_poolstring_s *hash_next;
 } g_poolstring_t;
 
-static qbyte *g_stringpool;
+static uint8_t *g_stringpool;
 static size_t g_stringpool_offset;
 static g_poolstring_t *g_stringpool_hash[STRINGPOOL_HASH_SIZE];
 
@@ -298,7 +298,7 @@ void G_StringPoolInit( void )
 {
 	memset( g_stringpool_hash, 0, sizeof( g_stringpool_hash ) );
 
-	g_stringpool = ( qbyte * )G_LevelMalloc( STRINGPOOL_SIZE );
+	g_stringpool = ( uint8_t * )G_LevelMalloc( STRINGPOOL_SIZE );
 	g_stringpool_offset = 0;
 }
 
@@ -552,7 +552,7 @@ edict_t *G_Find( edict_t *from, size_t fieldofs, const char *match )
 	{
 		if( !from->r.inuse )
 			continue;
-		s = *(char **) ( (qbyte *)from + fieldofs );
+		s = *(char **) ( (uint8_t *)from + fieldofs );
 		if( !s )
 			continue;
 		if( !Q_stricmp( s, match ) )
@@ -2072,7 +2072,7 @@ void G_PrecacheWeapondef( int weapon, firedef_t *firedef )
 #ifdef WEAPONDEFS_FROM_DISK
 
 #define WEAPONDEF_NUMPARMS 19
-static bool G_ParseFiredefFile( qbyte *buf, int weapon, firedef_t *firedef )
+static bool G_ParseFiredefFile( uint8_t *buf, int weapon, firedef_t *firedef )
 {
 	char *ptr, *token;
 	int count = 0;
@@ -2170,7 +2170,7 @@ static bool G_ParseFiredefFile( qbyte *buf, int weapon, firedef_t *firedef )
 static bool G_LoadFiredefFromFile( int weapon, firedef_t *firedef )
 {
 	int length, filenum;
-	qbyte *data;
+	uint8_t *data;
 	char filename[MAX_QPATH];
 
 	if( !firedef )

--- a/source/gameshared/q_angeliface.h
+++ b/source/gameshared/q_angeliface.h
@@ -77,8 +77,8 @@ public:
 	virtual bool Get(const asstring_t &key, void *value, int typeId) const = 0;
 
 	// Sets/Gets an integer number value for a key
-	virtual void Set(const asstring_t &key, qint64 &value) = 0;
-	virtual bool Get(const asstring_t &key, qint64 &value) const = 0;
+	virtual void Set(const asstring_t &key, int64_t &value) = 0;
+	virtual bool Get(const asstring_t &key, int64_t &value) const = 0;
 
 	// Sets/Gets a real number value for a key
 	virtual void Set(const asstring_t &key, double &value) = 0;

--- a/source/gameshared/q_arch.h
+++ b/source/gameshared/q_arch.h
@@ -410,12 +410,6 @@ typedef int socket_handle_t;
 
 //==============================================
 
-typedef uint8_t qbyte;
-typedef int64_t qint64;
-typedef uint64_t quint64;
-typedef intptr_t qintptr;
-typedef uintptr_t quintptr;
-
 typedef bool qboolean;
 #define qtrue true
 #define qfalse false

--- a/source/gameshared/q_comref.h
+++ b/source/gameshared/q_comref.h
@@ -60,8 +60,8 @@ enum
 // usercmd_t is sent to the server each client frame
 typedef struct usercmd_s
 {
-	qbyte msec;
-	qbyte buttons;
+	uint8_t msec;
+	uint8_t buttons;
 	short angles[3];
 	float forwardfrac, sidefrac, upfrac;
 	short forwardmove, sidemove, upmove;
@@ -444,7 +444,7 @@ typedef struct
 typedef struct
 {
 	qboolean all;
-	qbyte targets[MAX_CLIENTS/8];
+	uint8_t targets[MAX_CLIENTS/8];
 	size_t commandOffset;			// offset of the data in gamecommandsData
 } gcommand_t;
 
@@ -470,11 +470,11 @@ typedef struct
 	float viewheight;
 	float fov;					// horizontal field of view
 
-	qbyte weaponState;
+	uint8_t weaponState;
 
 	int inventory[MAX_ITEMS];
 	short stats[PS_MAX_STATS];	// fast status bar updates
-	qbyte plrkeys;				// infos on the pressed keys of chased player (self if not chasing)
+	uint8_t plrkeys;				// infos on the pressed keys of chased player (self if not chasing)
 } player_state_t;
 
 typedef struct

--- a/source/gameshared/q_math.h
+++ b/source/gameshared/q_math.h
@@ -66,7 +66,7 @@ typedef vec_t mat3_t[9];
 
 typedef vec_t dualquat_t[8];
 
-typedef qbyte byte_vec4_t[4];
+typedef uint8_t byte_vec4_t[4];
 
 // 0-2 are axial planes
 #define	PLANE_X		0

--- a/source/gameshared/q_shared.c
+++ b/source/gameshared/q_shared.c
@@ -219,7 +219,7 @@ int COM_FilePathLength( const char *in )
 
 short ShortSwap( short l )
 {
-	qbyte b1, b2;
+	uint8_t b1, b2;
 
 	b1 = l&255;
 	b2 = ( l>>8 )&255;
@@ -236,7 +236,7 @@ static short ShortNoSwap( short l )
 
 int LongSwap( int l )
 {
-	qbyte b1, b2, b3, b4;
+	uint8_t b1, b2, b3, b4;
 
 	b1 = l&255;
 	b2 = ( l>>8 )&255;
@@ -258,7 +258,7 @@ float FloatSwap( float f )
 	union
 	{
 		float f;
-		qbyte b[4];
+		uint8_t b[4];
 	} dat1, dat2;
 
 
@@ -284,7 +284,7 @@ static float FloatNoSwap( float f )
 */
 static void Swap_Init( void )
 {
-	qbyte swaptest[2] = { 1, 0 };
+	uint8_t swaptest[2] = { 1, 0 };
 
 	// set the byte swapping variables in a portable manner
 	if( *(short *)swaptest == 1 )

--- a/source/irc/irc_interface.h
+++ b/source/irc/irc_interface.h
@@ -206,7 +206,7 @@ typedef struct
 	unsigned int	(*SCR_GetScreenHeight)( void );
 	// clock
 	unsigned int	(*Milliseconds)(void);
-	quint64			(*Microseconds)(void);
+	uint64_t			(*Microseconds)(void);
 	// managed memory allocation
 	struct mempool_s *(*Mem_AllocPool)(const char *name, const char *filename, int fileline);	
 	void		*(*Mem_Alloc)(int size, const char *filename, int fileline);

--- a/source/irc/irc_logic.c
+++ b/source/irc/irc_logic.c
@@ -16,7 +16,7 @@ cvar_t *irc_ctcpReplies = NULL;
 
 static char *defaultChan_str = NULL;
 
-static const quint64 IRC_TRANSMIT_INTERVAL = 10;
+static const uint64_t IRC_TRANSMIT_INTERVAL = 10;
 static trie_t *chan_trie = NULL;
 
 static void Irc_Logic_Frame_f(void *frame);
@@ -293,7 +293,7 @@ static void Irc_Logic_ReadMessages(void) {
 }
 
 static void Irc_Logic_Frame_f(void *frame) {
-	const quint64 f = * (quint64*) frame;
+	const uint64_t f = * (uint64_t*) frame;
 	if (!(f % IRC_TRANSMIT_INTERVAL)) {
 		Irc_Logic_SendMessages();
 		Irc_Logic_ReadMessages();

--- a/source/irc/irc_protocol.c
+++ b/source/irc/irc_protocol.c
@@ -25,7 +25,7 @@ typedef struct irc_bucket_s {
 	irc_bucket_message_t *first_msg;	// pointer to first message in queue
 	unsigned int message_size;			// number of messages in bucket
 	unsigned int character_size;		// number of characters in bucket
-	quint64 last_refill;				// last refill timestamp
+	uint64_t last_refill;				// last refill timestamp
 	double message_token;
 	double character_token;
 } irc_bucket_t;
@@ -375,8 +375,8 @@ static void Irc_Proto_RefillBucket(void) {
 	const double characterBucketSize = Cvar_GetFloatValue(irc_characterBucketSize);
 	const double messageBucketRate = Cvar_GetFloatValue(irc_messageBucketRate);
 	const double characterBucketRate = Cvar_GetFloatValue(irc_characterBucketRate);
-	const quint64 micros = IRC_IMPORT.Microseconds();
-	const quint64 micros_delta = micros - irc_bucket.last_refill;
+	const uint64_t micros = IRC_IMPORT.Microseconds();
+	const uint64_t micros_delta = micros - irc_bucket.last_refill;
 	const double msg_delta = (micros_delta * messageBucketRate) / 1000000;
 	const double msg_new = irc_bucket.message_token + msg_delta;
 	const double char_delta = (micros_delta * characterBucketRate) / 1000000;

--- a/source/qalgo/hash.c
+++ b/source/qalgo/hash.c
@@ -68,7 +68,7 @@ unsigned int COM_HashKey( const char *name, int hashsize )
 * Adaptation of Paul Hsieh's incremental SuperFastHash function.
 * Initialize hash to some non-zero value for the first call, like len.
 */
-unsigned int COM_SuperFastHash( const qbyte * data, size_t len, unsigned int hash )
+unsigned int COM_SuperFastHash( const uint8_t * data, size_t len, unsigned int hash )
 {
 	unsigned int tmp;
 	unsigned int rem;
@@ -116,7 +116,7 @@ unsigned int COM_SuperFastHash( const qbyte * data, size_t len, unsigned int has
 * 
 * Com_SuperFastHash that takes a 64bit integer as an argument
 */
-unsigned int COM_SuperFastHash64BitInt( quint64 data )
+unsigned int COM_SuperFastHash64BitInt( uint64_t data )
 {
 	unsigned int hash;
 	unsigned int il, ih;

--- a/source/qalgo/hash.h
+++ b/source/qalgo/hash.h
@@ -23,4 +23,4 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 unsigned int COM_HashKey( const char *name, int hashsize );
 
 unsigned int COM_SuperFastHash( const unsigned char * data, size_t len, unsigned int hash );
-unsigned int COM_SuperFastHash64BitInt( quint64 data );
+unsigned int COM_SuperFastHash64BitInt( uint64_t data );

--- a/source/qcommon/anticheat.h
+++ b/source/qcommon/anticheat.h
@@ -29,7 +29,7 @@ typedef struct ac_import_s
 	void (*CL_ParseServerMessage)( msg_t *msg );
 	void (*CL_Netchan_Transmit)( msg_t *msg );
 
-	void (*MSG_Init)( msg_t *buf, qbyte *data, size_t length );
+	void (*MSG_Init)( msg_t *buf, uint8_t *data, size_t length );
 	void (*MSG_Clear)( msg_t *buf );
 	void *(*MSG_GetSpace)( msg_t *buf, size_t length );
 	void (*MSG_WriteData)( msg_t *msg, const void *data, size_t length );

--- a/source/qcommon/asyncstream.c
+++ b/source/qcommon/asyncstream.c
@@ -58,7 +58,7 @@ async_stream_module_t *AsyncStream_InitModule( const char *name, async_stream_al
 
 	// allocate and initialize module, store pointers
 	module = alloc_f( sizeof( *module ) + name_size, __FILE__, __LINE__ );
-	module->name = ( char * )(( qbyte * )module + sizeof( *module ));
+	module->name = ( char * )(( uint8_t * )module + sizeof( *module ));
 	Q_strncpyz( module->name, name, name_size );
 	module->alloc_f = alloc_f;
 	module->free_f = free_f;

--- a/source/qcommon/bsp.c
+++ b/source/qcommon/bsp.c
@@ -76,7 +76,7 @@ const bspFormatDesc_t *Q_FindBSPFormat( const bspFormatDesc_t *formats, const ch
 /*
 * Com_FindFormatDescriptor
 */
-const modelFormatDescr_t *Q_FindFormatDescriptor( const modelFormatDescr_t *formats, const qbyte *buf, const bspFormatDesc_t **bspFormat )
+const modelFormatDescr_t *Q_FindFormatDescriptor( const modelFormatDescr_t *formats, const uint8_t *buf, const bspFormatDesc_t **bspFormat )
 {
 	int i;
 	const modelFormatDescr_t *descr;
@@ -90,7 +90,7 @@ const modelFormatDescr_t *Q_FindFormatDescriptor( const modelFormatDescr_t *form
 			int version;
 
 			header = ( const char * )buf;
-			version = LittleLong( *((int *)((qbyte *)buf + descr->headerLen)) );
+			version = LittleLong( *((int *)((uint8_t *)buf + descr->headerLen)) );
 
 			// check whether any of specified formats matches the header/version combo
 			*bspFormat = Q_FindBSPFormat( descr->bspFormats, header, version );

--- a/source/qcommon/bsp.h
+++ b/source/qcommon/bsp.h
@@ -57,6 +57,6 @@ typedef struct
 extern const bspFormatDesc_t q3BSPFormats[];
 
 const bspFormatDesc_t *Q_FindBSPFormat( const bspFormatDesc_t *formats, const char *header, int version );
-const modelFormatDescr_t *Q_FindFormatDescriptor( const modelFormatDescr_t *formats, const qbyte *buf, const bspFormatDesc_t **bspFormat );
+const modelFormatDescr_t *Q_FindFormatDescriptor( const modelFormatDescr_t *formats, const uint8_t *buf, const bspFormatDesc_t **bspFormat );
 
 #endif // __BSP_H__

--- a/source/qcommon/cm_local.h
+++ b/source/qcommon/cm_local.h
@@ -163,7 +163,7 @@ struct cmodel_state_s
 	dvis_t *map_pvs, *map_phs;
 	int map_visdatasize;
 
-	qbyte nullrow[MAX_CM_LEAFS/8];
+	uint8_t nullrow[MAX_CM_LEAFS/8];
 
 	int numentitychars;
 	char map_entitystring_empty;
@@ -171,7 +171,7 @@ struct cmodel_state_s
 
 	int floodvalid;
 
-	qbyte *cmod_base;
+	uint8_t *cmod_base;
 
 	// cm_trace.c
 	cplane_t box_planes[6];

--- a/source/qcommon/cm_main.c
+++ b/source/qcommon/cm_main.c
@@ -225,11 +225,11 @@ cmodel_t *CM_LoadMap( cmodel_state_t *cms, const char *name, qboolean clientload
 	if( !buf )
 		Com_Error( ERR_DROP, "Couldn't load %s", name );
 
-	cms->checksum = md5_digest32( ( const qbyte * )buf, length );
+	cms->checksum = md5_digest32( ( const uint8_t * )buf, length );
 	*checksum = cms->checksum;
 
 	// call the apropriate loader
-	descr = Q_FindFormatDescriptor( cm_supportedformats, ( const qbyte * )buf, (const bspFormatDesc_t **)&bspFormat );
+	descr = Q_FindFormatDescriptor( cm_supportedformats, ( const uint8_t * )buf, (const bspFormatDesc_t **)&bspFormat );
 	if( !descr )
 		Com_Error( ERR_DROP, "CM_LoadMap: unknown fileid for %s", name );
 
@@ -243,7 +243,7 @@ cmodel_t *CM_LoadMap( cmodel_state_t *cms, const char *name, qboolean clientload
 
 	// store map format description in cvars
 	Cvar_ForceSet( "cm_mapHeader", header );
-	Cvar_ForceSet( "cm_mapVersion", va( "%i", LittleLong( *((int *)((qbyte *)buf + descr->headerLen)) ) ) );
+	Cvar_ForceSet( "cm_mapVersion", va( "%i", LittleLong( *((int *)((uint8_t *)buf + descr->headerLen)) ) ) );
 
 	Mem_TempFree( header );
 
@@ -274,7 +274,7 @@ cmodel_t *CM_LoadMap( cmodel_state_t *cms, const char *name, qboolean clientload
 char *CM_LoadMapMessage( char *name, char *message, int size )
 {
 	int file, len;
-	qbyte h_v[8];
+	uint8_t h_v[8];
 	char *data, *entitystring;
 	lump_t l;
 	qboolean isworld;
@@ -488,17 +488,17 @@ dvis_t *CM_PVSData( cmodel_state_t *cms )
 /*
 * CM_ClusterVS
 */
-static inline qbyte *CM_ClusterVS( int cluster, dvis_t *vis, qbyte *nullrow )
+static inline uint8_t *CM_ClusterVS( int cluster, dvis_t *vis, uint8_t *nullrow )
 {
 	if( cluster == -1 || !vis )
 		return nullrow;
-	return ( qbyte * )vis->data + cluster * vis->rowsize;
+	return ( uint8_t * )vis->data + cluster * vis->rowsize;
 }
 
 /*
 * CM_ClusterPVS
 */
-qbyte *CM_ClusterPVS( cmodel_state_t *cms, int cluster )
+uint8_t *CM_ClusterPVS( cmodel_state_t *cms, int cluster )
 {
 	return CM_ClusterVS( cluster, cms->map_pvs, cms->nullrow );
 }
@@ -627,7 +627,7 @@ qboolean CM_AreasConnected( cmodel_state_t *cms, int area1, int area2 )
 /*
 * CM_MergeAreaBits
 */
-static int CM_MergeAreaBits( cmodel_state_t *cms, qbyte *buffer, int area )
+static int CM_MergeAreaBits( cmodel_state_t *cms, uint8_t *buffer, int area )
 {
 	int i;
 
@@ -646,7 +646,7 @@ static int CM_MergeAreaBits( cmodel_state_t *cms, qbyte *buffer, int area )
 /*
 * CM_WriteAreaBits
 */
-int CM_WriteAreaBits( cmodel_state_t *cms, qbyte *buffer )
+int CM_WriteAreaBits( cmodel_state_t *cms, uint8_t *buffer )
 {
 	int i;
 	int rowsize, bytes;
@@ -661,7 +661,7 @@ int CM_WriteAreaBits( cmodel_state_t *cms, qbyte *buffer )
 	}
 	else
 	{
-		qbyte *row;
+		uint8_t *row;
 
 		memset( buffer, 0, bytes );
 
@@ -678,7 +678,7 @@ int CM_WriteAreaBits( cmodel_state_t *cms, qbyte *buffer )
 /*
 * CM_ReadAreaBits
 */
-void CM_ReadAreaBits( cmodel_state_t *cms, qbyte *buffer )
+void CM_ReadAreaBits( cmodel_state_t *cms, uint8_t *buffer )
 {
 	int i, j;
 	int rowsize;
@@ -688,7 +688,7 @@ void CM_ReadAreaBits( cmodel_state_t *cms, qbyte *buffer )
 	rowsize = CM_AreaRowSize( cms );
 	for( i = 0; i < cms->numareas; i++ )
 	{
-		qbyte *row;
+		uint8_t *row;
 
 		row = buffer + i * rowsize;
 		for( j = 0; j < cms->numareas; j++ )
@@ -741,7 +741,7 @@ void CM_ReadPortalState( cmodel_state_t *cms, int file )
 * Returns true if any leaf under headnode has a cluster that
 * is potentially visible
 */
-qboolean CM_HeadnodeVisible( cmodel_state_t *cms, int nodenum, qbyte *visbits )
+qboolean CM_HeadnodeVisible( cmodel_state_t *cms, int nodenum, uint8_t *visbits )
 {
 	int cluster;
 	cnode_t	*node;
@@ -767,12 +767,12 @@ qboolean CM_HeadnodeVisible( cmodel_state_t *cms, int nodenum, qbyte *visbits )
 * CM_MergePVS
 * Merge PVS at origin into out
 */
-void CM_MergePVS( cmodel_state_t *cms, vec3_t org, qbyte *out )
+void CM_MergePVS( cmodel_state_t *cms, vec3_t org, uint8_t *out )
 {
 	int leafs[128];
 	int i, j, count;
 	int longs;
-	qbyte *src;
+	uint8_t *src;
 	vec3_t mins, maxs;
 
 	for( i = 0; i < 3; i++ )
@@ -807,7 +807,7 @@ void CM_MergePVS( cmodel_state_t *cms, vec3_t org, qbyte *out )
 /*
 * CM_MergeVisSets
 */
-int CM_MergeVisSets( cmodel_state_t *cms, vec3_t org, qbyte *pvs, qbyte *areabits )
+int CM_MergeVisSets( cmodel_state_t *cms, vec3_t org, uint8_t *pvs, uint8_t *areabits )
 {
 	int area;
 

--- a/source/qcommon/cm_q3bsp.c
+++ b/source/qcommon/cm_q3bsp.c
@@ -189,7 +189,7 @@ static void CM_CreatePatch( cmodel_state_t *cms, cface_t *patch, cshaderref_t *s
 	cbrush_t *facets, *facet;
 	vec3_t *points;
 	vec3_t tverts[4];
-	qbyte *data;
+	uint8_t *data;
 	cplane_t *brushplanes;
 
 	// find the degree of subdivision in the u and v directions
@@ -263,7 +263,7 @@ static void CM_CreatePatch( cmodel_state_t *cms, cface_t *patch, cshaderref_t *s
 
 	if( patch->numfacets )
 	{
-		qbyte *data;
+		uint8_t *data;
 
 		data = Mem_Alloc( cms->mempool, patch->numfacets * sizeof( cbrush_t ) + totalsides * ( sizeof( cbrushside_t ) + sizeof( cplane_t ) ) );
 
@@ -860,7 +860,7 @@ void CM_LoadQ3BrushModel( cmodel_state_t *cms, void *parent, void *buf, bspForma
 	header = *(dheader_t *)buf;
 	for( i = 0; i < sizeof( dheader_t ) / 4; i++ )
 		( (int *)&header )[i] = LittleLong( ( (int *)&header )[i] );
-	cms->cmod_base = ( qbyte * )buf;
+	cms->cmod_base = ( uint8_t * )buf;
 
 	// load into heap
 	CMod_LoadSurfaces( cms, &header.lumps[LUMP_SHADERREFS] );

--- a/source/qcommon/cmd.c
+++ b/source/qcommon/cmd.c
@@ -502,7 +502,7 @@ static void Cmd_Exec_f( void )
 		Com_Printf( "Executing: %s\n", name );
 
 	Cbuf_InsertText( "\n" );
-	if (len >= 3 && ((qbyte)f[0] == 0xEF && (qbyte)f[1] == 0xBB && (qbyte)f[2] == 0xBF))
+	if (len >= 3 && ((uint8_t)f[0] == 0xEF && (uint8_t)f[1] == 0xBB && (uint8_t)f[2] == 0xBF))
 		Cbuf_InsertText( f+3 );	// skip Windows UTF-8 marker
 	else
 		Cbuf_InsertText( f );
@@ -610,7 +610,7 @@ static void Cmd_Alias_f_( qboolean archive )
 	else
 	{
 		a = Mem_ZoneMalloc( (int) ( sizeof( cmd_alias_t ) + len + 1 ) );
-		a->name = (char *) ( (qbyte *)a + sizeof( cmd_alias_t ) );
+		a->name = (char *) ( (uint8_t *)a + sizeof( cmd_alias_t ) );
 		strcpy( a->name, s );
 		Trie_Insert( cmd_alias_trie, s, a );
 	}
@@ -901,7 +901,7 @@ void Cmd_AddCommand( const char *cmd_name, xcommand_t function )
 	}
 
 	cmd = Mem_ZoneMalloc( (int)( sizeof( cmd_function_t ) + strlen( cmd_name ) + 1 ) );
-	cmd->name = (char *) ( (qbyte *)cmd + sizeof( cmd_function_t ) );
+	cmd->name = (char *) ( (uint8_t *)cmd + sizeof( cmd_function_t ) );
 	strcpy( cmd->name, cmd_name );
 	cmd->function = function;
 	cmd->completion_func = NULL;

--- a/source/qcommon/cmodel.h
+++ b/source/qcommon/cmodel.h
@@ -52,8 +52,8 @@ void CM_TransformedBoxTrace( cmodel_state_t *cms, trace_t *tr, vec3_t start, vec
 
 void CM_RoundUpToHullSize( cmodel_state_t *cms, vec3_t mins, vec3_t maxs, struct cmodel_s *cmodel );
 
-qbyte *CM_ClusterPVS( cmodel_state_t *cms, int cluster );
-qbyte *CM_ClusterPHS( cmodel_state_t *cms, int cluster );
+uint8_t *CM_ClusterPVS( cmodel_state_t *cms, int cluster );
+uint8_t *CM_ClusterPHS( cmodel_state_t *cms, int cluster );
 int CM_ClusterRowSize( cmodel_state_t *cms );
 int CM_ClusterRowLongs( cmodel_state_t *cms );
 int CM_AreaRowSize( cmodel_state_t *cms );
@@ -69,16 +69,16 @@ int CM_LeafArea( cmodel_state_t *cms, int leafnum );
 void CM_SetAreaPortalState( cmodel_state_t *cms, int area1, int area2, qboolean open );
 qboolean CM_AreasConnected( cmodel_state_t *cms, int area1, int area2 );
 
-int CM_WriteAreaBits( cmodel_state_t *cms, qbyte *buffer );
-void CM_ReadAreaBits( cmodel_state_t *cms, qbyte *buffer );
-qboolean CM_HeadnodeVisible( cmodel_state_t *cms, int headnode, qbyte *visbits );
+int CM_WriteAreaBits( cmodel_state_t *cms, uint8_t *buffer );
+void CM_ReadAreaBits( cmodel_state_t *cms, uint8_t *buffer );
+qboolean CM_HeadnodeVisible( cmodel_state_t *cms, int headnode, uint8_t *visbits );
 
 void CM_WritePortalState( cmodel_state_t *cms, int file );
 void CM_ReadPortalState( cmodel_state_t *cms, int file );
 
-void CM_MergePVS( cmodel_state_t *cms, vec3_t org, qbyte *out );
-void CM_MergePHS( cmodel_state_t *cms, int cluster, qbyte *out );
-int CM_MergeVisSets( cmodel_state_t *cms, vec3_t org, qbyte *pvs, qbyte *areabits );
+void CM_MergePVS( cmodel_state_t *cms, vec3_t org, uint8_t *out );
+void CM_MergePHS( cmodel_state_t *cms, int cluster, uint8_t *out );
+int CM_MergeVisSets( cmodel_state_t *cms, vec3_t org, uint8_t *pvs, uint8_t *areabits );
 
 //
 cmodel_state_t *CM_New( void *mempool );

--- a/source/qcommon/common.c
+++ b/source/qcommon/common.c
@@ -87,7 +87,7 @@ DYNVARS
 static dynvar_get_status_t Com_Sys_Uptime_f( void **val )
 {
 	static char buf[32];
-	const quint64 us = Sys_Microseconds();
+	const uint64_t us = Sys_Microseconds();
 	const unsigned int h = us / 3600000000u;
 	const unsigned int min = ( us / 60000000 ) % 60;
 	const unsigned int sec = ( us / 1000000 ) % 60;
@@ -558,7 +558,7 @@ void Info_Print( char *s )
 */
 int paged_total;
 
-void Com_PageInMemory( qbyte *buffer, int size )
+void Com_PageInMemory( uint8_t *buffer, int size )
 {
 	int i;
 
@@ -577,7 +577,7 @@ void Com_AddPakToPureList( purelist_t **purelist, const char *pakname, const uns
 	const size_t len = strlen( pakname ) + 1;
 
 	purefile = ( purelist_t* )Mem_Alloc( mempool ? mempool : zoneMemPool, sizeof( purelist_t ) + len );
-	purefile->filename = ( char * )(( qbyte * )purefile + sizeof( *purefile ));
+	purefile->filename = ( char * )(( uint8_t * )purefile + sizeof( *purefile ));
 	memcpy( purefile->filename, pakname, len );
 	purefile->checksum = checksum;
 	purefile->next = *purelist;
@@ -1075,7 +1075,7 @@ void Qcommon_Init( int argc, char **argv )
 void Qcommon_Frame( unsigned int realmsec )
 {
 	static dynvar_t	*frametick = NULL;
-	static quint64 fc = 0;
+	static uint64_t fc = 0;
 	char *s;
 	int time_before = 0, time_between = 0, time_after = 0;
 	static unsigned int gamemsec;

--- a/source/qcommon/cvar.c
+++ b/source/qcommon/cvar.c
@@ -190,7 +190,7 @@ cvar_t *Cvar_Get( const char *var_name, const char *var_value, cvar_flag_t flags
 	}
 
 	var = Mem_ZoneMalloc( (int)( sizeof( *var ) + strlen( var_name ) + 1 ) );
-	var->name = (char *)( (qbyte *)var + sizeof( *var ) );
+	var->name = (char *)( (uint8_t *)var + sizeof( *var ) );
 	strcpy( var->name, var_name );
 	var->dvalue = ZoneCopyString( (char *) var_value );
 	var->string = ZoneCopyString( (char *) var_value );

--- a/source/qcommon/files.c
+++ b/source/qcommon/files.c
@@ -185,12 +185,12 @@ can be transparently merged from several sources.
 
 */
 
-static inline unsigned int LittleLongRaw( const qbyte *raw )
+static inline unsigned int LittleLongRaw( const uint8_t *raw )
 {
 	return ( raw[3] << 24 ) | ( raw[2] << 16 ) | ( raw[1] << 8 ) | raw[0];
 }
 
-static inline unsigned short LittleShortRaw( const qbyte *raw )
+static inline unsigned short LittleShortRaw( const uint8_t *raw )
 {
 	return ( raw[1] << 8 ) | raw[0];
 }
@@ -672,7 +672,7 @@ const char *FS_FirstExtension( const char *filename, const char *extensions[], i
 	for( i = 0; i < num_extensions; i++ )
 	{
 		if( i )
-			filenames[i] = ( char * )( ( qbyte * )filenames[0] + filename_size * i );
+			filenames[i] = ( char * )( ( uint8_t * )filenames[0] + filename_size * i );
 		else
 			filenames[i] = ( char* )Mem_TempMalloc( filename_size * num_extensions );
 		Q_strncpyz( filenames[i], filename, filename_size );
@@ -1249,7 +1249,7 @@ void FS_FCloseFile( int file )
 /*
 * FS_ReadStream
 */
-static int FS_ReadStream( qbyte *buf, size_t len, filehandle_t *fh )
+static int FS_ReadStream( uint8_t *buf, size_t len, filehandle_t *fh )
 {
 	size_t numb;
 	
@@ -1265,7 +1265,7 @@ static int FS_ReadStream( qbyte *buf, size_t len, filehandle_t *fh )
 * 
 * Properly handles partial reads, used by FS_Read and FS_Seek
 */
-static int FS_ReadPK3File( qbyte *buf, size_t len, filehandle_t *fh )
+static int FS_ReadPK3File( uint8_t *buf, size_t len, filehandle_t *fh )
 {
 	zipEntry_t *zipEntry;
 	int error, flush;
@@ -1315,7 +1315,7 @@ static int FS_ReadPK3File( qbyte *buf, size_t len, filehandle_t *fh )
 * 
 * Properly handles partial reads
 */
-static int FS_ReadFile( qbyte *buf, size_t len, filehandle_t *fh )
+static int FS_ReadFile( uint8_t *buf, size_t len, filehandle_t *fh )
 {
 	return (int)fread( buf, 1, len, fh->fstream );
 }
@@ -1337,13 +1337,13 @@ int FS_Read( void *buffer, size_t len, int file )
 	fh = FS_FileHandleForNum( file );
 
 	if( fh->zipEntry )
-		total = FS_ReadPK3File( ( qbyte * )buffer, len, fh );
+		total = FS_ReadPK3File( ( uint8_t * )buffer, len, fh );
 	else if( fh->streamHandle )
-		total = FS_ReadStream( (qbyte *)buffer, len, fh );
+		total = FS_ReadStream( (uint8_t *)buffer, len, fh );
 	else if( fh->gzstream )
 		total = gzread( fh->gzstream, buffer, len );
 	else if( fh->fstream )
-		total = FS_ReadFile( ( qbyte * )buffer, len, fh );
+		total = FS_ReadFile( ( uint8_t * )buffer, len, fh );
 	else
 		return 0;
 
@@ -1391,7 +1391,7 @@ int FS_Write( const void *buffer, size_t len, int file )
 {
 	filehandle_t *fh;
 	size_t written;
-	qbyte *buf;
+	uint8_t *buf;
 
 	fh = FS_FileHandleForNum( file );
 	if( fh->zipEntry )
@@ -1403,7 +1403,7 @@ int FS_Write( const void *buffer, size_t len, int file )
 	if( !fh->fstream )
 		return 0;
 
-	buf = ( qbyte * )buffer;
+	buf = ( uint8_t * )buffer;
 	if( !buf )
 		return 0;
 
@@ -1443,7 +1443,7 @@ int FS_Seek( int file, int offset, int whence )
 	zipEntry_t *zipEntry;
 	int error, currentOffset;
 	size_t remaining, block;
-	qbyte buf[FS_ZIP_BUFSIZE * 4];
+	uint8_t buf[FS_ZIP_BUFSIZE * 4];
 
 	fh = FS_FileHandleForNum( file );
 
@@ -1626,7 +1626,7 @@ int	FS_GetCompressionLevel( int file )
 */
 int FS_LoadFileExt( const char *path, void **buffer, void *stack, size_t stackSize, const char *filename, int fileline )
 {
-	qbyte *buf;
+	uint8_t *buf;
 	unsigned int len;
 	int fhandle;
 
@@ -1648,9 +1648,9 @@ int FS_LoadFileExt( const char *path, void **buffer, void *stack, size_t stackSi
 	}
 
 	if( stack && ( stackSize > len ) )
-		buf = ( qbyte* )stack;
+		buf = ( uint8_t* )stack;
 	else
-		buf = ( qbyte* )_Mem_AllocExt( tempMemPool, len + 1, 0, 0, 0, 0, filename, fileline );
+		buf = ( uint8_t* )_Mem_AllocExt( tempMemPool, len + 1, 0, 0, 0, 0, filename, fileline );
 	buf[len] = 0;
 	*buffer = buf;
 
@@ -1667,7 +1667,7 @@ int FS_LoadFileExt( const char *path, void **buffer, void *stack, size_t stackSi
 */
 int FS_LoadBaseFileExt( const char *path, void **buffer, void *stack, size_t stackSize, const char *filename, int fileline )
 {
-	qbyte *buf;
+	uint8_t *buf;
 	unsigned int len;
 	int fhandle;
 
@@ -1689,9 +1689,9 @@ int FS_LoadBaseFileExt( const char *path, void **buffer, void *stack, size_t sta
 	}
 
 	if( stack && ( stackSize > len ) )
-		buf = ( qbyte* )stack;
+		buf = ( uint8_t* )stack;
 	else
-		buf = ( qbyte* )_Mem_AllocExt( tempMemPool, len + 1, 0, 0, 0, 0, filename, fileline );
+		buf = ( uint8_t* )_Mem_AllocExt( tempMemPool, len + 1, 0, 0, 0, 0, filename, fileline );
 	buf[len] = 0;
 	*buffer = buf;
 
@@ -1722,7 +1722,7 @@ void FS_FreeBaseFile( void *buffer )
 */
 unsigned FS_ChecksumAbsoluteFile( const char *filename )
 {
-	qbyte buffer[FS_MAX_BLOCK_SIZE];
+	uint8_t buffer[FS_MAX_BLOCK_SIZE];
 	int left, length, filenum;
 	md5_byte_t digest[16];
 	md5_state_t state;
@@ -1931,7 +1931,7 @@ qboolean FS_RemoveFile( const char *filename )
 qboolean _FS_CopyFile( const char *src, const char *dst, qboolean base, qboolean absolute )
 {
 	int srcnum, dstnum, length, result, l;
-	qbyte buffer[FS_MAX_BLOCK_SIZE];
+	uint8_t buffer[FS_MAX_BLOCK_SIZE];
 
 	length = _FS_FOpenFile( src, &srcnum, FS_READ, base );
 	if( length == -1 )
@@ -2133,7 +2133,7 @@ static void FS_ReadPackManifest( pack_t *pack )
 		pack->manifest = ( char* )FS_Malloc( size + 1 );
 
 		// read the file into memory
-		FS_Read( ( qbyte * )pack->manifest, size, file );
+		FS_Read( ( uint8_t * )pack->manifest, size, file );
 		FS_FCloseFile( file );
 
 		// compress (get rid of comments, etc)
@@ -2389,8 +2389,8 @@ static pack_t *FS_LoadPK3File( const char *packfilename, qboolean silent )
 
 	pack = ( pack_t* )FS_Malloc( (int)( sizeof( pack_t ) + numFiles * sizeof( packfile_t ) + namesLen) );
 	pack->filename = FS_CopyString( packfilename );
-	pack->files = ( packfile_t * )( ( qbyte * )pack + sizeof( pack_t ) );
-	pack->fileNames = names = ( char * )( ( qbyte * )pack->files + numFiles * sizeof( packfile_t ) );
+	pack->files = ( packfile_t * )( ( uint8_t * )pack + sizeof( pack_t ) );
+	pack->fileNames = names = ( char * )( ( uint8_t * )pack->files + numFiles * sizeof( packfile_t ) );
 	pack->numFiles = numFiles;
 	pack->sysHandle = handle;
 	pack->vfsHandle = vfsHandle;

--- a/source/qcommon/library.c
+++ b/source/qcommon/library.c
@@ -216,7 +216,7 @@ static void Com_LoadGameLibraryManifest( const char *libname, char *manifest )
 void *Com_LoadGameLibrary( const char *basename, const char *apifuncname, void **handle, void *parms, qboolean pure, char *manifest )
 {
 	static int randomizer = 0; // random part of tempmodules dir, always the same for one launch of Warsow
-	static qint64 randomizer_time;
+	static int64_t randomizer_time;
 	const char *temppath;
 	char *tempname, *libname;
 	int libname_size;

--- a/source/qcommon/msg.c
+++ b/source/qcommon/msg.c
@@ -30,7 +30,7 @@ Handles byte ordering and avoids alignment errors
 */
 #define MAX_MSG_STRING_CHARS	2048
 
-void MSG_Init( msg_t *msg, qbyte *data, size_t length )
+void MSG_Init( msg_t *msg, uint8_t *data, size_t length )
 {
 	memset( msg, 0, sizeof( *msg ) );
 	msg->data = data;
@@ -68,7 +68,7 @@ void MSG_WriteData( msg_t *msg, const void *data, size_t length )
 #if 0
 	unsigned int i;
 	for( i = 0; i < length; i++ )
-		MSG_WriteByte( msg, ( (qbyte *)data )[i] );
+		MSG_WriteByte( msg, ( (uint8_t *)data )[i] );
 #else
 	MSG_CopyData( msg, data, length );
 #endif
@@ -81,14 +81,14 @@ void MSG_CopyData( msg_t *buf, const void *data, size_t length )
 
 void MSG_WriteChar( msg_t *msg, int c )
 {
-	qbyte *buf = ( qbyte* )MSG_GetSpace( msg, 1 );
+	uint8_t *buf = ( uint8_t* )MSG_GetSpace( msg, 1 );
 	buf[0] = ( char )c;
 }
 
 void MSG_WriteByte( msg_t *msg, int c )
 {
-	qbyte *buf = ( qbyte* )MSG_GetSpace( msg, 1 );
-	buf[0] = ( qbyte )( c&0xff );
+	uint8_t *buf = ( uint8_t* )MSG_GetSpace( msg, 1 );
+	buf[0] = ( uint8_t )( c&0xff );
 }
 
 void MSG_WriteShort( msg_t *msg, int c )
@@ -99,10 +99,10 @@ void MSG_WriteShort( msg_t *msg, int c )
 
 void MSG_WriteInt3( msg_t *msg, int c )
 {
-	qbyte *buf = ( qbyte* )MSG_GetSpace( msg, 3 );
-	buf[0] = ( qbyte )( c&0xff );
-	buf[1] = ( qbyte )( ( c>>8 )&0xff );
-	buf[2] = ( qbyte )( ( c>>16 )&0xff );
+	uint8_t *buf = ( uint8_t* )MSG_GetSpace( msg, 3 );
+	buf[0] = ( uint8_t )( c&0xff );
+	buf[1] = ( uint8_t )( ( c>>8 )&0xff );
+	buf[2] = ( uint8_t )( ( c>>16 )&0xff );
 }
 
 void MSG_WriteLong( msg_t *msg, int c )
@@ -231,7 +231,7 @@ void MSG_ReadData( msg_t *msg, void *data, size_t length )
 	unsigned int i;
 
 	for( i = 0; i < length; i++ )
-		( (qbyte *)data )[i] = MSG_ReadByte( msg );
+		( (uint8_t *)data )[i] = MSG_ReadByte( msg );
 
 }
 
@@ -440,7 +440,7 @@ void MSG_WriteDeltaEntity( entity_state_t *from, entity_state_t *to, msg_t *msg,
 
 	if( bits & U_TYPE )
 	{
-		qbyte ttype = 0;
+		uint8_t ttype = 0;
 		ttype = to->type & ~ET_INVERSE;
 		if( to->linearProjectile )
 			ttype |= ET_INVERSE;
@@ -517,39 +517,39 @@ void MSG_WriteDeltaEntity( entity_state_t *from, entity_state_t *to, msg_t *msg,
 	}
 
 	if( bits & U_SOUND )
-		MSG_WriteShort( msg, (qbyte)to->sound );
+		MSG_WriteShort( msg, (uint8_t)to->sound );
 
 	if( bits & U_EVENT )
 	{
 		if( !to->eventParms[0] )
 		{
-			MSG_WriteByte( msg, (qbyte)( to->events[0] & ~EV_INVERSE ) );
+			MSG_WriteByte( msg, (uint8_t)( to->events[0] & ~EV_INVERSE ) );
 		}
 		else
 		{
-			MSG_WriteByte( msg, (qbyte)( to->events[0] | EV_INVERSE ) );
-			MSG_WriteByte( msg, (qbyte)to->eventParms[0] );
+			MSG_WriteByte( msg, (uint8_t)( to->events[0] | EV_INVERSE ) );
+			MSG_WriteByte( msg, (uint8_t)to->eventParms[0] );
 		}
 	}
 	if( bits & U_EVENT2 )
 	{
 		if( !to->eventParms[1] )
 		{
-			MSG_WriteByte( msg, (qbyte)( to->events[1] & ~EV_INVERSE ) );
+			MSG_WriteByte( msg, (uint8_t)( to->events[1] & ~EV_INVERSE ) );
 		}
 		else
 		{
-			MSG_WriteByte( msg, (qbyte)( to->events[1] | EV_INVERSE ) );
-			MSG_WriteByte( msg, (qbyte)to->eventParms[1] );
+			MSG_WriteByte( msg, (uint8_t)( to->events[1] | EV_INVERSE ) );
+			MSG_WriteByte( msg, (uint8_t)to->eventParms[1] );
 		}
 	}
 
 	if( bits & U_ATTENUATION )
-		MSG_WriteByte( msg, (qbyte)(to->attenuation * 16) );
+		MSG_WriteByte( msg, (uint8_t)(to->attenuation * 16) );
 
 	if( bits & U_WEAPON )
 	{
-		qbyte tweapon = 0;
+		uint8_t tweapon = 0;
 		tweapon = to->weapon & ~ET_INVERSE;
 		if( to->teleported )
 			tweapon |= ET_INVERSE;
@@ -582,27 +582,27 @@ int MSG_ReadEntityBits( msg_t *msg, unsigned *bits )
 	unsigned b, total;
 	int number;
 
-	total = (qbyte)MSG_ReadByte( msg );
+	total = (uint8_t)MSG_ReadByte( msg );
 	if( total & U_MOREBITS1 )
 	{
-		b = (qbyte)MSG_ReadByte( msg );
+		b = (uint8_t)MSG_ReadByte( msg );
 		total |= ( b<<8 )&0x0000FF00;
 	}
 	if( total & U_MOREBITS2 )
 	{
-		b = (qbyte)MSG_ReadByte( msg );
+		b = (uint8_t)MSG_ReadByte( msg );
 		total |= ( b<<16 )&0x00FF0000;
 	}
 	if( total & U_MOREBITS3 )
 	{
-		b = (qbyte)MSG_ReadByte( msg );
+		b = (uint8_t)MSG_ReadByte( msg );
 		total |= ( b<<24 )&0xFF000000;
 	}
 
 	if( total & U_NUMBER16 )
 		number = MSG_ReadShort( msg );
 	else
-		number = (qbyte)MSG_ReadByte( msg );
+		number = (uint8_t)MSG_ReadByte( msg );
 
 	*bits = total;
 
@@ -623,8 +623,8 @@ void MSG_ReadDeltaEntity( msg_t *msg, entity_state_t *from, entity_state_t *to, 
 
 	if( bits & U_TYPE )
 	{
-		qbyte ttype;
-		ttype = (qbyte)MSG_ReadByte( msg );
+		uint8_t ttype;
+		ttype = (uint8_t)MSG_ReadByte( msg );
 		to->type = ttype & ~ET_INVERSE;
 		to->linearProjectile = ( ttype & ET_INVERSE ) ? qtrue : qfalse;
 	}
@@ -638,7 +638,7 @@ void MSG_ReadDeltaEntity( msg_t *msg, entity_state_t *from, entity_state_t *to, 
 		to->modelindex2 = MSG_ReadShort( msg );
 
 	if( bits & U_FRAME8 )
-		to->frame = (qbyte)MSG_ReadByte( msg );
+		to->frame = (uint8_t)MSG_ReadByte( msg );
 	if( bits & U_FRAME16 )
 		to->frame = MSG_ReadShort( msg );
 
@@ -652,7 +652,7 @@ void MSG_ReadDeltaEntity( msg_t *msg, entity_state_t *from, entity_state_t *to, 
 	if( ( bits & ( U_EFFECTS8|U_EFFECTS16 ) ) == ( U_EFFECTS8|U_EFFECTS16 ) )
 		to->effects = MSG_ReadLong( msg );
 	else if( bits & U_EFFECTS8 )
-		to->effects = (qbyte)MSG_ReadByte( msg );
+		to->effects = (uint8_t)MSG_ReadByte( msg );
 	else if( bits & U_EFFECTS16 )
 		to->effects = MSG_ReadShort( msg );
 
@@ -698,9 +698,9 @@ void MSG_ReadDeltaEntity( msg_t *msg, entity_state_t *from, entity_state_t *to, 
 
 	if( bits & U_EVENT )
 	{
-		int event = (qbyte)MSG_ReadByte( msg );
+		int event = (uint8_t)MSG_ReadByte( msg );
 		if( event & EV_INVERSE )
-			to->eventParms[0] = (qbyte)MSG_ReadByte( msg );
+			to->eventParms[0] = (uint8_t)MSG_ReadByte( msg );
 		else
 			to->eventParms[0] = 0;
 		to->events[0] = ( event & ~EV_INVERSE );
@@ -713,9 +713,9 @@ void MSG_ReadDeltaEntity( msg_t *msg, entity_state_t *from, entity_state_t *to, 
 
 	if( bits & U_EVENT2 )
 	{
-		int event = (qbyte)MSG_ReadByte( msg );
+		int event = (uint8_t)MSG_ReadByte( msg );
 		if( event & EV_INVERSE )
-			to->eventParms[1] = (qbyte)MSG_ReadByte( msg );
+			to->eventParms[1] = (uint8_t)MSG_ReadByte( msg );
 		else
 			to->eventParms[1] = 0;
 		to->events[1] = ( event & ~EV_INVERSE );
@@ -728,14 +728,14 @@ void MSG_ReadDeltaEntity( msg_t *msg, entity_state_t *from, entity_state_t *to, 
 
 	if( bits & U_ATTENUATION )
 	{
-		qbyte attenuation = MSG_ReadByte( msg );
+		uint8_t attenuation = MSG_ReadByte( msg );
 		to->attenuation = (float)attenuation / 16.0;
 	}
 
 	if( bits & U_WEAPON )
 	{
-		qbyte tweapon;
-		tweapon = (qbyte)MSG_ReadByte( msg );
+		uint8_t tweapon;
+		tweapon = (uint8_t)MSG_ReadByte( msg );
 		to->weapon = tweapon & ~ET_INVERSE;
 		to->teleported = ( tweapon & ET_INVERSE ) ? qtrue : qfalse;
 	}
@@ -752,7 +752,7 @@ void MSG_ReadDeltaEntity( msg_t *msg, entity_state_t *from, entity_state_t *to, 
 	}
 
 	if( bits & U_TEAM )
-		to->team = (qbyte)MSG_ReadByte( msg );
+		to->team = (uint8_t)MSG_ReadByte( msg );
 }
 
 

--- a/source/qcommon/net.c
+++ b/source/qcommon/net.c
@@ -51,7 +51,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 typedef struct
 {
-	qbyte data[MAX_MSGLEN];
+	uint8_t data[MAX_MSGLEN];
 	int datalen;
 } loopmsg_t;
 
@@ -69,7 +69,7 @@ static qboolean	net_initialized = qfalse;
 
 #define MAX_IPS 16
 static int numIP;
-static qbyte localIP[MAX_IPS][4];
+static uint8_t localIP[MAX_IPS][4];
 
 /*
 =============================================================================
@@ -539,7 +539,7 @@ static int NET_TCP_Get( const socket_t *socket, netadr_t *address, void *data, s
 static int NET_TCP_GetPacket( const socket_t *socket, netadr_t *address, msg_t *message )
 {
 	int ret;
-	qbyte buffer[MAX_PACKETLEN + 4];
+	uint8_t buffer[MAX_PACKETLEN + 4];
 	int len;
 
 	assert( socket && socket->open && socket->connected && socket->type == SOCKET_TCP );

--- a/source/qcommon/net_chan.c
+++ b/source/qcommon/net_chan.c
@@ -91,10 +91,10 @@ static cvar_t *net_showfragments;
 * 
 * Sends an out-of-band datagram
 */
-void Netchan_OutOfBand( const socket_t *socket, const netadr_t *address, size_t length, const qbyte *data )
+void Netchan_OutOfBand( const socket_t *socket, const netadr_t *address, size_t length, const uint8_t *data )
 {
 	msg_t send;
-	qbyte send_buf[MAX_PACKETLEN];
+	uint8_t send_buf[MAX_PACKETLEN];
 
 	// write the packet header
 	MSG_Init( &send, send_buf, sizeof( send_buf ) );
@@ -121,7 +121,7 @@ void Netchan_OutOfBandPrint( const socket_t *socket, const netadr_t *address, co
 	Q_vsnprintfz( string, sizeof( string ), format, argptr );
 	va_end( argptr );
 
-	Netchan_OutOfBand( socket, address, sizeof( char ) * (int)strlen( string ), (qbyte *)string );
+	Netchan_OutOfBand( socket, address, sizeof( char ) * (int)strlen( string ), (uint8_t *)string );
 }
 
 /*
@@ -141,7 +141,7 @@ void Netchan_Setup( netchan_t *chan, const socket_t *socket, const netadr_t *add
 }
 
 
-static qbyte msg_process_data[MAX_MSGLEN];
+static uint8_t msg_process_data[MAX_MSGLEN];
 
 //=============================================================
 // Zlib compression
@@ -161,7 +161,7 @@ Upon exit, destLen is the actual size of the compressed buffer.
 compress2 returns Z_OK if success, Z_MEM_ERROR if there was not enough memory, Z_BUF_ERROR if there
 was not enough room in the output buffer, Z_STREAM_ERROR if the level parameter is invalid.
 */
-static int Netchan_ZLibCompressChunk( const qbyte *source, unsigned long sourceLen, qbyte *dest, unsigned long destLen,
+static int Netchan_ZLibCompressChunk( const uint8_t *source, unsigned long sourceLen, uint8_t *dest, unsigned long destLen,
 									 int level, int wbits )
 {
 	int result, zlerror;
@@ -207,7 +207,7 @@ This function can be used to decompress a whole file at once if the input file i
 uncompress returns Z_OK if success, Z_MEM_ERROR if there was not enough memory, Z_BUF_ERROR if
 there was not enough room in the output buffer, or Z_DATA_ERROR if the input data was corrupted.
 */
-static int Netchan_ZLibDecompressChunk( const qbyte *source, unsigned long sourceLen, qbyte *dest, unsigned long destLen,
+static int Netchan_ZLibDecompressChunk( const uint8_t *source, unsigned long sourceLen, uint8_t *dest, unsigned long destLen,
 									   int wbits )
 {
 	int result, zlerror;
@@ -240,7 +240,7 @@ static int Netchan_ZLibDecompressChunk( const qbyte *source, unsigned long sourc
 }
 #else // ALT_ZLIB_COMPRESSION
 
-int Netchan_ZLibDecompressChunk( qbyte *in, int inlen, qbyte *out, int outlen, int wbits )
+int Netchan_ZLibDecompressChunk( uint8_t *in, int inlen, uint8_t *out, int outlen, int wbits )
 {
 	z_stream zs;
 	int result;
@@ -280,7 +280,7 @@ int Netchan_ZLibDecompressChunk( qbyte *in, int inlen, qbyte *out, int outlen, i
 	return zs.total_out;
 }
 
-int Netchan_ZLibCompressChunk( qbyte *in, int len_in, qbyte *out, int max_len_out, int method, int wbits )
+int Netchan_ZLibCompressChunk( uint8_t *in, int len_in, uint8_t *out, int max_len_out, int method, int wbits )
 {
 	z_stream zs;
 	int result;
@@ -406,7 +406,7 @@ static void Netchan_DropAllFragments( netchan_t *chan )
 qboolean Netchan_TransmitNextFragment( netchan_t *chan )
 {
 	msg_t send;
-	qbyte send_buf[MAX_PACKETLEN];
+	uint8_t send_buf[MAX_PACKETLEN];
 	int fragmentLength;
 	qboolean last;
 
@@ -498,7 +498,7 @@ qboolean Netchan_PushAllFragments( netchan_t *chan )
 qboolean Netchan_Transmit( netchan_t *chan, msg_t *msg )
 {
 	msg_t send;
-	qbyte send_buf[MAX_PACKETLEN];
+	uint8_t send_buf[MAX_PACKETLEN];
 
 	assert( msg );
 

--- a/source/qcommon/patch.c
+++ b/source/qcommon/patch.c
@@ -162,13 +162,13 @@ PATCH_EVALUATE_DECL(type)													\
 
 PATCH_EVALUATE_BODY(vec_t)
 
-PATCH_EVALUATE_BODY(qbyte)
+PATCH_EVALUATE_BODY(uint8_t)
 
 /*
 * Patch_RemoveLinearColumnsRows
 */
 void Patch_RemoveLinearColumnsRows( vec_t *verts, int comp, int *pwidth, int *pheight,
-	int numattribs, qbyte * const *attribs, const int *attribsizes )
+	int numattribs, uint8_t * const *attribs, const int *attribsizes )
 {
 	int i, j, k, l;
 	const vec_t *v0, *v1, *v2;

--- a/source/qcommon/patch.h
+++ b/source/qcommon/patch.h
@@ -23,7 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 	(const type *p, int *numcp, const int *tess, type *dest, int comp, int stride)
 
 PATCH_EVALUATE_DECL(vec_t);
-PATCH_EVALUATE_DECL(qbyte);
+PATCH_EVALUATE_DECL(uint8_t);
 
 #define Patch_Evaluate(type,comp,p,numcp,tess,dest,stride)				\
 	Patch_Evaluate_##type(p,numcp,tess,dest,comp,stride)
@@ -31,4 +31,4 @@ PATCH_EVALUATE_DECL(qbyte);
 void Patch_GetFlatness( float maxflat, const float *points, int comp, const int *patch_cp, int *flat );
 
 void Patch_RemoveLinearColumnsRows( vec_t *verts, int comp, int *pwidth, int *pheight,
-	int numattribs, qbyte * const *attribs, const int *attribsizes );
+	int numattribs, uint8_t * const *attribs, const int *attribsizes );

--- a/source/qcommon/qcommon.h
+++ b/source/qcommon/qcommon.h
@@ -54,7 +54,7 @@ struct fatvis_s;
 
 typedef struct
 {
-	qbyte *data;
+	uint8_t *data;
 	size_t maxsize;
 	size_t cursize;
 	size_t readcount;
@@ -62,7 +62,7 @@ typedef struct
 } msg_t;
 
 // msg.c
-void MSG_Init( msg_t *buf, qbyte *data, size_t length );
+void MSG_Init( msg_t *buf, uint8_t *data, size_t length );
 void MSG_Clear( msg_t *buf );
 void *MSG_GetSpace( msg_t *buf, size_t length );
 void MSG_WriteData( msg_t *msg, const void *data, size_t length );
@@ -191,9 +191,9 @@ void Info_Print( char *s );
 
 /* crc.h */
 void CRC_Init( unsigned short *crcvalue );
-void CRC_ProcessByte( unsigned short *crcvalue, qbyte data );
+void CRC_ProcessByte( unsigned short *crcvalue, uint8_t data );
 unsigned short CRC_Value( unsigned short crcvalue );
-unsigned short CRC_Block( qbyte *start, int count );
+unsigned short CRC_Block( uint8_t *start, int count );
 
 /*
 ==============================================================
@@ -546,13 +546,13 @@ typedef enum
 
 typedef struct netadr_ipv4_s
 {
-	qbyte ip [4];
+	uint8_t ip [4];
 	unsigned short port;
 } netadr_ipv4_t;
 
 typedef struct netadr_ipv6_s
 {
-	qbyte ip [16];
+	uint8_t ip [16];
 	unsigned short port;
 	unsigned long scope_id;
 } netadr_ipv6_t;
@@ -674,14 +674,14 @@ typedef struct
 	// incoming fragment assembly buffer
 	int fragmentSequence;
 	size_t fragmentLength;
-	qbyte fragmentBuffer[MAX_MSGLEN];
+	uint8_t fragmentBuffer[MAX_MSGLEN];
 
 	// outgoing fragment buffer
 	// we need to space out the sending of large fragmented messages
 	qboolean unsentFragments;
 	size_t unsentFragmentStart;
 	size_t unsentLength;
-	qbyte unsentBuffer[MAX_MSGLEN];
+	uint8_t unsentBuffer[MAX_MSGLEN];
 	qboolean unsentIsCompressed;
 
 	qboolean fatal_error;
@@ -699,7 +699,7 @@ qboolean Netchan_PushAllFragments( netchan_t *chan );
 qboolean Netchan_TransmitNextFragment( netchan_t *chan );
 int Netchan_CompressMessage( msg_t *msg );
 int Netchan_DecompressMessage( msg_t *msg );
-void Netchan_OutOfBand( const socket_t *socket, const netadr_t *address, size_t length, const qbyte *data );
+void Netchan_OutOfBand( const socket_t *socket, const netadr_t *address, size_t length, const uint8_t *data );
 void Netchan_OutOfBandPrint( const socket_t *socket, const netadr_t *address, const char *format, ... );
 int Netchan_GamePort( void );
 
@@ -830,7 +830,7 @@ void	    Com_SetServerState( int state );
 struct cmodel_state_s *Com_ServerCM( unsigned *checksum );
 void		Com_SetServerCM( struct cmodel_state_s *cms, unsigned checksum );
 
-void	    Com_PageInMemory( qbyte *buffer, int size );
+void	    Com_PageInMemory( uint8_t *buffer, int size );
 
 unsigned int Com_DaysSince1900( void );
 
@@ -949,7 +949,7 @@ void	Sys_InitDynvars( void );
 void	Sys_AppActivate( void );
 
 unsigned int	Sys_Milliseconds( void );
-quint64		Sys_Microseconds( void );
+uint64_t		Sys_Microseconds( void );
 void		Sys_Sleep( unsigned int millis );
 
 char	*Sys_ConsoleInput( void );

--- a/source/qcommon/snap_demos.c
+++ b/source/qcommon/snap_demos.c
@@ -147,7 +147,7 @@ void SNAP_BeginDemoRecording( int demofile, unsigned int spawncount, unsigned in
 {
 	unsigned int i;
 	msg_t msg;
-	qbyte msg_buffer[MAX_MSGLEN];
+	uint8_t msg_buffer[MAX_MSGLEN];
 	purelist_t *purefile;
 	entity_state_t nullstate;
 	entity_state_t *base;
@@ -327,7 +327,7 @@ void SNAP_WriteDemoMetaData( const char *filename, const char *meta_data, size_t
 	char tmpn[256];
 	int filenum, filelen;
 	msg_t msg;
-	qbyte msg_buffer[MAX_MSGLEN];
+	uint8_t msg_buffer[MAX_MSGLEN];
 	void *compressed_msg;
 
 	MSG_Init( &msg, msg_buffer, sizeof( msg_buffer ) );

--- a/source/qcommon/snap_read.c
+++ b/source/qcommon/snap_read.c
@@ -69,7 +69,7 @@ FRAME PARSING
 static void SNAP_ParseDeltaGameState( msg_t *msg, snapshot_t *oldframe, snapshot_t *newframe )
 {
 	short statbits;
-	qbyte bits;
+	uint8_t bits;
 	int i;
 	game_state_t *gameState;
 
@@ -85,7 +85,7 @@ static void SNAP_ParseDeltaGameState( msg_t *msg, snapshot_t *oldframe, snapshot
 
 	//memcpy( gameState, deltaGameState, sizeof( game_state_t ) );
 
-	bits = (qbyte)MSG_ReadByte( msg );
+	bits = (uint8_t)MSG_ReadByte( msg );
 	statbits = MSG_ReadShort( msg );
 
 	if( bits )
@@ -122,20 +122,20 @@ static void SNAP_ParsePlayerstate( msg_t *msg, player_state_t *oldstate, player_
 	else
 		memset( state, 0, sizeof( *state ) );
 
-	flags = (qbyte)MSG_ReadByte( msg );
+	flags = (uint8_t)MSG_ReadByte( msg );
 	if( flags & PS_MOREBITS1 )
 	{
-		b = (qbyte)MSG_ReadByte( msg );
+		b = (uint8_t)MSG_ReadByte( msg );
 		flags |= b<<8;
 	}
 	if( flags & PS_MOREBITS2 )
 	{
-		b = (qbyte)MSG_ReadByte( msg );
+		b = (uint8_t)MSG_ReadByte( msg );
 		flags |= b<<16;
 	}
 	if( flags & PS_MOREBITS3 )
 	{
-		b = (qbyte)MSG_ReadByte( msg );
+		b = (uint8_t)MSG_ReadByte( msg );
 		flags |= b<<24;
 	}
 
@@ -143,7 +143,7 @@ static void SNAP_ParsePlayerstate( msg_t *msg, player_state_t *oldstate, player_
 	// parse the pmove_state_t
 	//
 	if( flags & PS_M_TYPE )
-		state->pmove.pm_type = (qbyte)MSG_ReadByte( msg );
+		state->pmove.pm_type = (uint8_t)MSG_ReadByte( msg );
 
 	if( flags & PS_M_ORIGIN0 )
 		state->pmove.origin[0] = ( (float)MSG_ReadInt3( msg )*( 1.0/PM_VECTOR_SNAP ) );
@@ -160,7 +160,7 @@ static void SNAP_ParsePlayerstate( msg_t *msg, player_state_t *oldstate, player_
 		state->pmove.velocity[2] = ( (float)MSG_ReadInt3( msg )*( 1.0/PM_VECTOR_SNAP ) );
 
 	if( flags & PS_M_TIME )
-		state->pmove.pm_time = (qbyte)MSG_ReadByte( msg );
+		state->pmove.pm_time = (uint8_t)MSG_ReadByte( msg );
 
 	if( flags & PS_M_FLAGS )
 		state->pmove.pm_flags = MSG_ReadShort( msg );
@@ -213,18 +213,18 @@ static void SNAP_ParsePlayerstate( msg_t *msg, player_state_t *oldstate, player_
 		state->pmove.gravity = MSG_ReadShort( msg );
 
 	if( flags & PS_WEAPONSTATE )
-		state->weaponState = (qbyte)MSG_ReadByte( msg );
+		state->weaponState = (uint8_t)MSG_ReadByte( msg );
 
 	if( flags & PS_FOV )
-		state->fov = (qbyte)MSG_ReadByte( msg );
+		state->fov = (uint8_t)MSG_ReadByte( msg );
 
 	if( flags & PS_POVNUM )
-		state->POVnum = (qbyte)MSG_ReadByte( msg );
+		state->POVnum = (uint8_t)MSG_ReadByte( msg );
 	if( state->POVnum == 0 )
 		Com_Error( ERR_DROP, "SNAP_ParsePlayerstate: Invalid POVnum %i", state->POVnum );
 
 	if( flags & PS_PLAYERNUM )
-		state->playerNum = (qbyte)MSG_ReadByte( msg );
+		state->playerNum = (uint8_t)MSG_ReadByte( msg );
 	if( state->playerNum >= MAX_CLIENTS )
 		Com_Error( ERR_DROP, "SNAP_ParsePlayerstate: Invalid playerNum %i", state->playerNum );
 
@@ -462,7 +462,7 @@ static snapshot_t *SNAP_ParseFrameHeader( msg_t *msg, snapshot_t *newframe, int 
 {
 	int len, pos;
 	int areabytes;
-	qbyte *areabits;
+	uint8_t *areabits;
 	unsigned int serverTime;
 	int flags, snapNum, supCnt;
 

--- a/source/qcommon/snap_write.c
+++ b/source/qcommon/snap_write.c
@@ -128,7 +128,7 @@ static void SNAP_WriteDeltaGameStateToClient( client_snapshot_t *from, client_sn
 {
 	int i;
 	short statbits;
-	qbyte bits;
+	uint8_t bits;
 	game_state_t *gameState, *deltaGameState;
 	game_state_t dummy;
 
@@ -383,13 +383,13 @@ static void SNAP_WritePlayerstateToClient( player_state_t *ops, player_state_t *
 		MSG_WriteByte( msg, ps->weaponState );
 
 	if( pflags & PS_FOV )
-		MSG_WriteByte( msg, (qbyte)ps->fov );
+		MSG_WriteByte( msg, (uint8_t)ps->fov );
 
 	if( pflags & PS_POVNUM )
-		MSG_WriteByte( msg, (qbyte)ps->POVnum );
+		MSG_WriteByte( msg, (uint8_t)ps->POVnum );
 
 	if( pflags & PS_PLAYERNUM )
-		MSG_WriteByte( msg, (qbyte)ps->playerNum );
+		MSG_WriteByte( msg, (uint8_t)ps->playerNum );
 
 	if( pflags & PS_VIEWHEIGHT )
 		MSG_WriteChar( msg, (char)ps->viewheight );
@@ -433,7 +433,7 @@ static void SNAP_WritePlayerstateToClient( player_state_t *ops, player_state_t *
 		for( i = 0; i < MAX_ITEMS; i++ )
 		{
 			if( invstatbits[i>>5] & ( 1<<(i&31) ) )
-				MSG_WriteByte( msg, (qbyte)ps->inventory[i] );
+				MSG_WriteByte( msg, (uint8_t)ps->inventory[i] );
 		}
 	}
 
@@ -470,7 +470,7 @@ static void SNAP_WriteMultiPOVCommands( ginfo_t *gi, client_t *client, msg_t *ms
 	char *command;
 	int maxnumtargets, numtargets, maxtarget;
 	unsigned int framenum;
-	qbyte targets[MAX_CLIENTS/8];
+	uint8_t targets[MAX_CLIENTS/8];
 
 	// find the first command to send from every client
 	maxnumtargets = maxtarget = 0;
@@ -763,7 +763,7 @@ Build a client frame structure
 * The client will interpolate the view position,
 * so we can't use a single PVS point
 */
-static void SNAP_FatPVS( cmodel_state_t *cms, vec3_t org, qbyte *fatpvs )
+static void SNAP_FatPVS( cmodel_state_t *cms, vec3_t org, uint8_t *fatpvs )
 {
 	memset( fatpvs, 0, CM_ClusterRowSize( cms ) );
 	CM_MergePVS( cms, org, fatpvs );
@@ -772,7 +772,7 @@ static void SNAP_FatPVS( cmodel_state_t *cms, vec3_t org, qbyte *fatpvs )
 /*
 * SNAP_BitsCullEntity
 */
-static qboolean SNAP_BitsCullEntity( cmodel_state_t *cms, edict_t *ent, qbyte *bits, int max_clusters )
+static qboolean SNAP_BitsCullEntity( cmodel_state_t *cms, edict_t *ent, uint8_t *bits, int max_clusters )
 {
 	int i, l;
 
@@ -895,9 +895,9 @@ static qboolean SNAP_SnapCullSoundEntity( cmodel_state_t *cms, edict_t *ent, vec
 /*
 * SNAP_SnapCullEntity
 */
-static qboolean SNAP_SnapCullEntity( cmodel_state_t *cms, edict_t *ent, edict_t *clent, client_snapshot_t *frame, vec3_t vieworg, qbyte *fatpvs )
+static qboolean SNAP_SnapCullEntity( cmodel_state_t *cms, edict_t *ent, edict_t *clent, client_snapshot_t *frame, vec3_t vieworg, uint8_t *fatpvs )
 {
-	qbyte *areabits;
+	uint8_t *areabits;
 	qboolean snd_cull_only;
 	qboolean snd_culled;
 
@@ -959,7 +959,7 @@ static qboolean SNAP_SnapCullEntity( cmodel_state_t *cms, edict_t *ent, edict_t 
 /*
 * SNAP_BuildSnapEntitiesList
 */
-static void SNAP_BuildSnapEntitiesList( cmodel_state_t *cms, ginfo_t *gi, edict_t *clent, vec3_t vieworg, vec3_t skyorg, qbyte *fatpvs, client_snapshot_t *frame, snapshotEntityNumbers_t *entsList )
+static void SNAP_BuildSnapEntitiesList( cmodel_state_t *cms, ginfo_t *gi, edict_t *clent, vec3_t vieworg, vec3_t skyorg, uint8_t *fatpvs, client_snapshot_t *frame, snapshotEntityNumbers_t *entsList )
 {
 	int leafnum = -1, clusternum = -1, clientarea = -1;
 	int entNum;
@@ -1124,7 +1124,7 @@ void SNAP_BuildClientFrameSnap( cmodel_state_t *cms, ginfo_t *gi, unsigned int f
 			Mem_Free( frame->areabits );
 			frame->areabits = NULL;
 		}
-		frame->areabits = (qbyte*)Mem_Alloc( mempool, numareas );
+		frame->areabits = (uint8_t*)Mem_Alloc( mempool, numareas );
 	}
 
 	// grab the current player_state_t

--- a/source/qcommon/snap_write.h
+++ b/source/qcommon/snap_write.h
@@ -27,5 +27,5 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #undef EDICT_NUM
 #undef NUM_FOR_EDICT
 
-#define EDICT_NUM( n ) ( (edict_t *)( (qbyte *)gi->edicts + gi->edict_size*( n ) ) )
-#define NUM_FOR_EDICT( e ) ( ( (qbyte *)( e )-(qbyte *)gi->edicts ) / gi->edict_size )
+#define EDICT_NUM( n ) ( (edict_t *)( (uint8_t *)gi->edicts + gi->edict_size*( n ) ) )
+#define NUM_FOR_EDICT( e ) ( ( (uint8_t *)( e )-(uint8_t *)gi->edicts ) / gi->edict_size )

--- a/source/qcommon/sys_library.h
+++ b/source/qcommon/sys_library.h
@@ -23,7 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 qboolean Sys_Library_Close( void *lib );
 const char *Sys_Library_GetFullName( const char *name );
-const char *Sys_Library_GetGameLibPath( const char *name, qint64 randomizer_time, int randomizer );
+const char *Sys_Library_GetGameLibPath( const char *name, int64_t randomizer_time, int randomizer );
 void *Sys_Library_Open( const char *name );
 void *Sys_Library_ProcAddress( void *lib, const char *apifuncname );
 const char *Sys_Library_ErrorString( void );

--- a/source/qcommon/sys_vfs_zip.c
+++ b/source/qcommon/sys_vfs_zip.c
@@ -53,12 +53,12 @@ static int sys_vfs_zip_numvfs;
 static sys_vfs_zip_vfs_t *sys_vfs_zip_files;
 static trie_t *sys_vfs_zip_trie;
 
-static inline unsigned int LittleLongRaw( const qbyte *raw )
+static inline unsigned int LittleLongRaw( const uint8_t *raw )
 {
 	return ( raw[3] << 24 ) | ( raw[2] << 16 ) | ( raw[1] << 8 ) | raw[0];
 }
 
-static inline unsigned short LittleShortRaw( const qbyte *raw )
+static inline unsigned short LittleShortRaw( const uint8_t *raw )
 {
 	return ( raw[1] << 8 ) | raw[0];
 }

--- a/source/ref_gl/r_alias.c
+++ b/source/ref_gl/r_alias.c
@@ -82,8 +82,8 @@ static void Mod_AliasBuildMeshesForFrame0( model_t *mod )
 		size *= mesh->numverts;
 
 		mesh->xyzArray = ( vec4_t * )Mod_Malloc( mod, size );
-		mesh->normalsArray = ( vec4_t * )( ( qbyte * )mesh->xyzArray + mesh->numverts * sizeof( vec4_t ) );
-		mesh->sVectorsArray = ( vec4_t * )( ( qbyte * )mesh->normalsArray + mesh->numverts * sizeof( vec4_t ) );
+		mesh->normalsArray = ( vec4_t * )( ( uint8_t * )mesh->xyzArray + mesh->numverts * sizeof( vec4_t ) );
+		mesh->sVectorsArray = ( vec4_t * )( ( uint8_t * )mesh->normalsArray + mesh->numverts * sizeof( vec4_t ) );
 
 		for( i = 0; i < mesh->numverts; i++ )
 		{
@@ -145,7 +145,7 @@ void Mod_LoadAliasMD3Model( model_t *mod, model_t *parent, void *buffer, bspForm
 {
 	int version, i, j, l;
 	int bufsize, numverts;
-	qbyte *buf;
+	uint8_t *buf;
 	dmd3header_t *pinmodel;
 	dmd3frame_t *pinframe;
 	dmd3tag_t *pintag;
@@ -205,12 +205,12 @@ void Mod_LoadAliasMD3Model( model_t *mod, model_t *parent, void *buffer, bspForm
 	bufsize = poutmodel->numframes * ( sizeof( maliasframe_t ) + sizeof( maliastag_t ) * poutmodel->numtags ) +
 		poutmodel->nummeshes * sizeof( maliasmesh_t ) + 
 		poutmodel->nummeshes * sizeof( drawSurfaceAlias_t );
-	buf = ( qbyte * )Mod_Malloc( mod, bufsize );
+	buf = ( uint8_t * )Mod_Malloc( mod, bufsize );
 
 	//
 	// load the frames
 	//
-	pinframe = ( dmd3frame_t * )( ( qbyte * )pinmodel + LittleLong( pinmodel->ofs_frames ) );
+	pinframe = ( dmd3frame_t * )( ( uint8_t * )pinmodel + LittleLong( pinmodel->ofs_frames ) );
 	poutframe = poutmodel->frames = ( maliasframe_t * )buf; buf += sizeof( maliasframe_t ) * poutmodel->numframes;
 	for( i = 0; i < poutmodel->numframes; i++, pinframe++, poutframe++ )
 	{
@@ -228,7 +228,7 @@ void Mod_LoadAliasMD3Model( model_t *mod, model_t *parent, void *buffer, bspForm
 	//
 	// load the tags
 	//
-	pintag = ( dmd3tag_t * )( ( qbyte * )pinmodel + LittleLong( pinmodel->ofs_tags ) );
+	pintag = ( dmd3tag_t * )( ( uint8_t * )pinmodel + LittleLong( pinmodel->ofs_tags ) );
 	pouttag = poutmodel->tags = ( maliastag_t * )buf; buf += sizeof( maliastag_t ) * poutmodel->numframes * poutmodel->numtags;
 	for( i = 0; i < poutmodel->numframes; i++ )
 	{
@@ -268,7 +268,7 @@ void Mod_LoadAliasMD3Model( model_t *mod, model_t *parent, void *buffer, bspForm
 	//
 	// load meshes
 	//
-	pinmesh = ( dmd3mesh_t * )( ( qbyte * )pinmodel + LittleLong( pinmodel->ofs_meshes ) );
+	pinmesh = ( dmd3mesh_t * )( ( uint8_t * )pinmodel + LittleLong( pinmodel->ofs_meshes ) );
 	poutmesh = poutmodel->meshes = ( maliasmesh_t * )buf; buf += sizeof( maliasmesh_t ) * poutmodel->nummeshes;
 	for( i = 0; i < poutmodel->nummeshes; i++, poutmesh++ )
 	{
@@ -304,12 +304,12 @@ void Mod_LoadAliasMD3Model( model_t *mod, model_t *parent, void *buffer, bspForm
 		bufsize = ALIGN( sizeof( maliasskin_t ) * poutmesh->numskins, sizeof( vec_t ) ) +
 			numverts * ( sizeof( vec2_t ) + sizeof( maliasvertex_t ) * poutmodel->numframes ) +
 			poutmesh->numtris * sizeof( elem_t ) * 3;
-		buf = ( qbyte * )Mod_Malloc( mod, bufsize );
+		buf = ( uint8_t * )Mod_Malloc( mod, bufsize );
 
 		//
 		// load the skins
 		//
-		pinskin = ( dmd3skin_t * )( ( qbyte * )pinmesh + LittleLong( inmesh.ofs_skins ) );
+		pinskin = ( dmd3skin_t * )( ( uint8_t * )pinmesh + LittleLong( inmesh.ofs_skins ) );
 		poutskin = poutmesh->skins = ( maliasskin_t * )buf;
 		buf += ALIGN( sizeof( maliasskin_t ) * poutmesh->numskins, sizeof( vec_t ) );
 		for( j = 0; j < poutmesh->numskins; j++, pinskin++, poutskin++ ) {
@@ -320,7 +320,7 @@ void Mod_LoadAliasMD3Model( model_t *mod, model_t *parent, void *buffer, bspForm
 		//
 		// load the texture coordinates
 		//
-		pincoord = ( dmd3coord_t * )( ( qbyte * )pinmesh + LittleLong( inmesh.ofs_tcs ) );
+		pincoord = ( dmd3coord_t * )( ( uint8_t * )pinmesh + LittleLong( inmesh.ofs_tcs ) );
 		poutcoord = poutmesh->stArray = ( vec2_t * )buf; buf += poutmesh->numverts * sizeof( vec2_t );
 		for( j = 0; j < poutmesh->numverts; j++, pincoord++ )
 		{
@@ -332,7 +332,7 @@ void Mod_LoadAliasMD3Model( model_t *mod, model_t *parent, void *buffer, bspForm
 		//
 		// load the vertexes and normals
 		//
-		pinvert = ( dmd3vertex_t * )( ( qbyte * )pinmesh + LittleLong( inmesh.ofs_verts ) );
+		pinvert = ( dmd3vertex_t * )( ( uint8_t * )pinmesh + LittleLong( inmesh.ofs_verts ) );
 		poutvert = poutmesh->vertexes = ( maliasvertex_t * )buf;
 		buf += poutmesh->numverts * sizeof( maliasvertex_t ) * poutmodel->numframes;
 		for( l = 0, poutframe = poutmodel->frames; l < poutmodel->numframes; l++, poutframe++, pinvert += poutmesh->numverts, poutvert += poutmesh->numverts )
@@ -360,7 +360,7 @@ void Mod_LoadAliasMD3Model( model_t *mod, model_t *parent, void *buffer, bspForm
 		//
 		// load the elems
 		//
-		pinelem = ( unsigned int * )( ( qbyte * )pinmesh + LittleLong( inmesh.ofs_elems ) );
+		pinelem = ( unsigned int * )( ( uint8_t * )pinmesh + LittleLong( inmesh.ofs_elems ) );
 		poutelem = poutmesh->elems = ( elem_t * )buf;
 		for( j = 0; j < poutmesh->numtris; j++, pinelem += 3, poutelem += 3 )
 		{
@@ -373,7 +373,7 @@ void Mod_LoadAliasMD3Model( model_t *mod, model_t *parent, void *buffer, bspForm
 			poutelem[2] = (elem_t)LittleLong( inelem[2] );
 		}
 
-		pinmesh = ( dmd3mesh_t * )( ( qbyte * )pinmesh + LittleLong( inmesh.meshsize ) );
+		pinmesh = ( dmd3mesh_t * )( ( uint8_t * )pinmesh + LittleLong( inmesh.meshsize ) );
 	}
 
 	//

--- a/source/ref_gl/r_backend_local.h
+++ b/source/ref_gl/r_backend_local.h
@@ -138,8 +138,8 @@ typedef struct r_backend_s
 
 	const superLightStyle_t *superLightStyle;
 
-	qbyte entityColor[4];
-	qbyte entityOutlineColor[4];
+	uint8_t entityColor[4];
+	uint8_t entityOutlineColor[4];
 	entity_t nullEnt;
 
 	const mfog_t *fog, *texFog, *colorFog;

--- a/source/ref_gl/r_cin.c
+++ b/source/ref_gl/r_cin.c
@@ -33,7 +33,7 @@ typedef struct r_cinhandle_s
 	struct cinematics_s	*cin;
 	image_t			*image;
 	int				width, height;
-	qbyte			*pic;
+	uint8_t			*pic;
 	qboolean		new_frame;
 	qboolean		yuv;
 	ref_yuv_t		*cyuv;
@@ -68,7 +68,7 @@ static qboolean R_RunCin( r_cinhandle_t *h )
 
 	if( h->yuv ) {
 		h->cyuv = ri.CIN_ReadNextFrameYUV( h->cin, &h->width, &h->height, NULL, NULL, &redraw );
-		h->pic = ( qbyte * )h->cyuv;
+		h->pic = ( uint8_t * )h->cyuv;
 	}
 	else {
 		h->pic = ri.CIN_ReadNextFrame( h->cin, &h->width, &h->height, NULL, NULL, &redraw );
@@ -93,7 +93,7 @@ static image_t *R_ResampleCinematicFrame( r_cinhandle_t *handle )
 		int i;
 
 		if( !handle->yuv_images[0] ) {
-			qbyte *fake_data[1] = { NULL };
+			uint8_t *fake_data[1] = { NULL };
 			const char *letters[3] = { "y", "u", "v" };
 
 			for( i = 0; i < 3; i++ ) {

--- a/source/ref_gl/r_glimp.h
+++ b/source/ref_gl/r_glimp.h
@@ -149,7 +149,7 @@ typedef struct
 	int			_extMarker;
 
 	//
-	// only qbytes must follow the extensionsBoolMarker
+	// only uint8_ts must follow the extensionsBoolMarker
 	//
 
 	char		draw_range_elements

--- a/source/ref_gl/r_image.c
+++ b/source/ref_gl/r_image.c
@@ -385,10 +385,10 @@ enum
 	NUM_IMAGE_BUFFERS
 };
 
-static qbyte *r_screenShotBuffer;
+static uint8_t *r_screenShotBuffer;
 static size_t r_screenShotBufferSize;
 
-static qbyte *r_imageBuffers[NUM_QGL_CONTEXTS][NUM_IMAGE_BUFFERS];
+static uint8_t *r_imageBuffers[NUM_QGL_CONTEXTS][NUM_IMAGE_BUFFERS];
 static size_t r_imageBufSize[NUM_QGL_CONTEXTS][NUM_IMAGE_BUFFERS];
 
 #define R_PrepareImageBuffer(ctx,buffer,size) _R_PrepareImageBuffer(ctx,buffer,size,__FILE__,__LINE__)
@@ -396,7 +396,7 @@ static size_t r_imageBufSize[NUM_QGL_CONTEXTS][NUM_IMAGE_BUFFERS];
 /*
 * R_PrepareImageBuffer
 */
-static qbyte *_R_PrepareImageBuffer( int ctx, int buffer, size_t size, 
+static uint8_t *_R_PrepareImageBuffer( int ctx, int buffer, size_t size, 
 	const char *filename, int fileline )
 {
 	if( r_imageBufSize[ctx][buffer] < size )
@@ -434,7 +434,7 @@ void R_FreeImageBuffers( void )
 /*
 * R_SwapBlueRed
 */
-static void R_SwapBlueRed( qbyte *data, int width, int height, int samples, int alignment )
+static void R_SwapBlueRed( uint8_t *data, int width, int height, int samples, int alignment )
 {
 	int i, j, k, padding;
 
@@ -470,7 +470,7 @@ static void R_EndianSwap16BitImage( unsigned short *data, int width, int height 
 /*
 * R_AllocImageBufferCb
 */
-static qbyte *_R_AllocImageBufferCb( void *ptr, size_t size, const char *filename, int linenum )
+static uint8_t *_R_AllocImageBufferCb( void *ptr, size_t size, const char *filename, int linenum )
 {
 	loaderCbInfo_t *cbinfo = ptr;
 	return _R_PrepareImageBuffer( cbinfo->ctx, cbinfo->side, size, filename, linenum );
@@ -480,7 +480,7 @@ static qbyte *_R_AllocImageBufferCb( void *ptr, size_t size, const char *filenam
 * R_ReadImageFromDisk
 */
 static int R_ReadImageFromDisk( int ctx, char *pathname, size_t pathname_size, 
-	qbyte **pic, int *width, int *height, int *flags, int side )
+	uint8_t **pic, int *width, int *height, int *flags, int side )
 {
 	const char *extension;
 	int samples;
@@ -606,11 +606,11 @@ static int R_ScaledImageSize( int width, int height, int *scaledWidth, int *scal
 /*
 * R_FlipTexture
 */
-static void R_FlipTexture( const qbyte *in, qbyte *out, int width, int height, 
+static void R_FlipTexture( const uint8_t *in, uint8_t *out, int width, int height, 
 	int samples, qboolean flipx, qboolean flipy, qboolean flipdiagonal )
 {
 	int i, x, y;
-	const qbyte *p, *line;
+	const uint8_t *p, *line;
 	int row_inc = ( flipy ? -samples : samples ) * width, col_inc = ( flipx ? -samples : samples );
 	int row_ofs = ( flipy ? ( height - 1 ) * width * samples : 0 ), col_ofs = ( flipx ? ( width - 1 ) * samples : 0 );
 
@@ -636,15 +636,15 @@ static void R_FlipTexture( const qbyte *in, qbyte *out, int width, int height,
 /*
 * R_ResampleTexture
 */
-static void R_ResampleTexture( int ctx, const qbyte *in, int inwidth, int inheight, qbyte *out, 
+static void R_ResampleTexture( int ctx, const uint8_t *in, int inwidth, int inheight, uint8_t *out, 
 	int outwidth, int outheight, int samples, int alignment )
 {
 	int i, j, k;
 	int inwidthS, outwidthS;
 	unsigned int frac, fracstep;
-	const qbyte *inrow, *inrow2, *pix1, *pix2, *pix3, *pix4;
+	const uint8_t *inrow, *inrow2, *pix1, *pix2, *pix3, *pix4;
 	unsigned *p1, *p2;
-	qbyte *opix;
+	uint8_t *opix;
 
 	if( inwidth == outwidth && inheight == outheight )
 	{
@@ -758,13 +758,13 @@ static void R_ResampleTexture16( int ctx, const unsigned short *in, int inwidth,
 * 
 * Operates in place, quartering the size of the texture
 */
-static void R_MipMap( qbyte *in, int width, int height, int samples, int alignment )
+static void R_MipMap( uint8_t *in, int width, int height, int samples, int alignment )
 {
 	int i, j, k;
 	int instride = ALIGN( width * samples, alignment );
 	int outwidth, outheight, outpadding;
-	qbyte *out = in;
-	qbyte *next;
+	uint8_t *out = in;
+	uint8_t *next;
 	int inofs;
 
 	outwidth = width >> 1;
@@ -993,7 +993,7 @@ static void R_SetupTexParameters( int flags )
 /*
 * R_Upload32
 */
-static void R_Upload32( int ctx, qbyte **data, int layer,
+static void R_Upload32( int ctx, uint8_t **data, int layer,
 	int x, int y, int width, int height,
 	int flags, int *upload_width, int *upload_height, int samples,
 	qboolean subImage, qboolean noScale )
@@ -1001,7 +1001,7 @@ static void R_Upload32( int ctx, qbyte **data, int layer,
 	int i, comp, format, type;
 	int target;
 	int numTextures;
-	qbyte *scaled = NULL;
+	uint8_t *scaled = NULL;
 	int scaledWidth, scaledHeight;
 
 	assert( samples );
@@ -1020,7 +1020,7 @@ static void R_Upload32( int ctx, qbyte **data, int layer,
 	{
 		if( flags & ( IT_FLIPX|IT_FLIPY|IT_FLIPDIAGONAL ) )
 		{
-			qbyte *temp = R_PrepareImageBuffer( ctx, TEXTURE_FLIPPING_BUF0, width * height * samples );
+			uint8_t *temp = R_PrepareImageBuffer( ctx, TEXTURE_FLIPPING_BUF0, width * height * samples );
 			R_FlipTexture( data[0], temp, width, height, samples, 
 				(flags & IT_FLIPX) ? qtrue : qfalse, 
 				(flags & IT_FLIPY) ? qtrue : qfalse, 
@@ -1065,7 +1065,7 @@ static void R_Upload32( int ctx, qbyte **data, int layer,
 	{
 		for( i = 0; i < numTextures; i++, target++ )
 		{
-			qbyte *mip;
+			uint8_t *mip;
 
 			if( !scaled )
 				scaled = R_PrepareImageBuffer( ctx, TEXTURE_RESAMPLING_BUF, 
@@ -1074,7 +1074,7 @@ static void R_Upload32( int ctx, qbyte **data, int layer,
 			// resample the texture
 			mip = scaled;
 			if( data && data[i] )
-				R_ResampleTexture( ctx, data[i], width, height, (qbyte*)mip, scaledWidth, scaledHeight, samples, 1 );
+				R_ResampleTexture( ctx, data[i], width, height, (uint8_t*)mip, scaledWidth, scaledHeight, samples, 1 );
 			else
 				mip = NULL;
 
@@ -1179,7 +1179,7 @@ static int R_MipCount( int width, int height )
 *
 * Loads a 16/24/32-bit image or cubemap (faces are consecutive) with mipmaps.
 */
-static void R_UploadMipmapped( int ctx, qbyte **data,
+static void R_UploadMipmapped( int ctx, uint8_t **data,
 	int width, int height, int mipLevels, int flags,
 	int *upload_width, int *upload_height,
 	int format, int type )
@@ -1189,11 +1189,11 @@ static void R_UploadMipmapped( int ctx, qbyte **data,
 	int rMask = 0, gMask = 0, bMask = 0, aMask = 0;
 	int scaledWidth, scaledHeight;
 	int mip;
-	qbyte *scaled = NULL;
+	uint8_t *scaled = NULL;
 	int faces, faceSize = 0;
 	int target, comp;
 	int mips;
-	qbyte *face;
+	uint8_t *face;
 	int oldWidth = 0, oldHeight = 0;
 
 	switch( type )
@@ -1370,10 +1370,10 @@ typedef struct ktx_header_s
 static qboolean R_LoadKTX( int ctx, image_t *image, void ( *bind )( const image_t * ) )
 {
 	int i, j;
-	qbyte *buffer;
+	uint8_t *buffer;
 	ktx_header_t *header;
 	qboolean swapEndian;
-	qbyte *data;
+	uint8_t *data;
 
 	R_LoadFile( image->name, ( void ** )&buffer );
 	if( !buffer )
@@ -1461,9 +1461,9 @@ static qboolean R_LoadKTX( int ctx, image_t *image, void ( *bind )( const image_
 		{
 			int inSize = ( ( ALIGN( header->pixelWidth, 4 ) * ALIGN( header->pixelHeight, 4 ) ) >> 4 ) * 8;
 			int outSize = ALIGN( header->pixelWidth * 3, 4 ) * header->pixelHeight;
-			qbyte *in = data + sizeof( int );
-			qbyte *decompressed = R_PrepareImageBuffer( ctx, TEXTURE_LOADING_BUF0, outSize * header->numberOfFaces );
-			qbyte *out = decompressed;
+			uint8_t *in = data + sizeof( int );
+			uint8_t *decompressed = R_PrepareImageBuffer( ctx, TEXTURE_LOADING_BUF0, outSize * header->numberOfFaces );
+			uint8_t *out = decompressed;
 			for( i = 0; i < header->numberOfFaces; ++i )
 			{
 				DecompressETC1( in, header->pixelWidth, header->pixelHeight, out, glConfig.ext.bgra ? qtrue : qfalse );
@@ -1478,7 +1478,7 @@ static qboolean R_LoadKTX( int ctx, image_t *image, void ( *bind )( const image_
 		{
 			int target;
 			int faceSize;
-			qbyte *in;
+			uint8_t *in;
 
 			R_TextureTarget( image->flags, &target );
 
@@ -1515,7 +1515,7 @@ static qboolean R_LoadKTX( int ctx, image_t *image, void ( *bind )( const image_
 	{
 		int mips = ( image->flags & IT_NOMIPMAP ) ? 1 :
 			min( header->numberOfMipmapLevels, R_MipCount( header->pixelWidth, header->pixelHeight ) );
-		qbyte *images[32];
+		uint8_t *images[32];
 		int mipWidth = header->pixelWidth, mipHeight = header->pixelHeight;
 
 		for( i = 0; i < mips; ++i )
@@ -1611,7 +1611,7 @@ static qboolean R_LoadImageFromDisk( int ctx, image_t *image, void (*bind)(const
 	if( flags & IT_CUBEMAP )
 	{
 		int i, j;
-		qbyte *pic[6];
+		uint8_t *pic[6];
 		struct cubemapSufAndFlip
 		{
 			char *suf; int flags;
@@ -1658,7 +1658,7 @@ static qboolean R_LoadImageFromDisk( int ctx, image_t *image, void (*bind)(const
 					if( cubemapSides[i][j].flags & ( IT_FLIPX|IT_FLIPY|IT_FLIPDIAGONAL ) )
 					{
 						int flags = cubemapSides[i][j].flags;
-						qbyte *temp = R_PrepareImageBuffer( ctx,
+						uint8_t *temp = R_PrepareImageBuffer( ctx,
 							TEXTURE_FLIPPING_BUF0+j, width * height * samples );
 						R_FlipTexture( pic[j], temp, width, height, 4, 
 							(flags & IT_FLIPX) ? qtrue : qfalse, 
@@ -1697,7 +1697,7 @@ static qboolean R_LoadImageFromDisk( int ctx, image_t *image, void (*bind)(const
 	}
 	else
 	{
-		qbyte *pic = NULL;
+		uint8_t *pic = NULL;
 
 		Q_strncatz( pathname, ".tga", pathsize );
 		samples = R_ReadImageFromDisk( ctx, pathname, pathsize, &pic, &width, &height, &flags, 0 );
@@ -1773,7 +1773,7 @@ static image_t *R_CreateImage( const char *name, int width, int height, int laye
 	int name_len = strlen( name );
 	unsigned hash;
 
-	hash = COM_SuperFastHash( ( const qbyte *)name, name_len, name_len );
+	hash = COM_SuperFastHash( ( const uint8_t *)name, name_len, name_len );
 
 	image = R_LinkPic( hash );
 	if( !image ) {
@@ -1803,7 +1803,7 @@ static image_t *R_CreateImage( const char *name, int width, int height, int laye
 /*
 * R_LoadImage
 */
-image_t *R_LoadImage( const char *name, qbyte **pic, int width, int height, int flags, int samples )
+image_t *R_LoadImage( const char *name, uint8_t **pic, int width, int height, int flags, int samples )
 {
 	image_t *image;
 
@@ -1880,7 +1880,7 @@ static void R_FreeImage( image_t *image )
 /*
 * R_ReplaceImage
 */
-void R_ReplaceImage( image_t *image, qbyte **pic, int width, int height, int flags, int samples )
+void R_ReplaceImage( image_t *image, uint8_t **pic, int width, int height, int flags, int samples )
 {
 	assert( image );
 	assert( image->texnum );
@@ -1905,7 +1905,7 @@ void R_ReplaceImage( image_t *image, qbyte **pic, int width, int height, int fla
 /*
 * R_ReplaceSubImage
 */
-void R_ReplaceSubImage( image_t *image, int layer, int x, int y, qbyte **pic, int width, int height )
+void R_ReplaceSubImage( image_t *image, int layer, int x, int y, uint8_t **pic, int width, int height )
 {
 	assert( image );
 	assert( image->texnum );
@@ -1921,7 +1921,7 @@ void R_ReplaceSubImage( image_t *image, int layer, int x, int y, qbyte **pic, in
 /*
 * R_ReplaceImageLayer
 */
-void R_ReplaceImageLayer( image_t *image, int layer, qbyte **pic )
+void R_ReplaceImageLayer( image_t *image, int layer, uint8_t **pic )
 {
 	assert( image );
 	assert( image->texnum );
@@ -1946,7 +1946,7 @@ image_t	*R_FindImage( const char *name, const char *suffix, int flags )
 	unsigned int len, key;
 	image_t	*image, *hnode;
 	char *pathname;
-	qbyte *empty_data[6] = { NULL, NULL, NULL, NULL, NULL, NULL };
+	uint8_t *empty_data[6] = { NULL, NULL, NULL, NULL, NULL, NULL };
 
 	if( !name || !name[0] )
 		return NULL; //	ri.Com_Error (ERR_DROP, "R_FindImage: NULL name");
@@ -1989,7 +1989,7 @@ image_t	*R_FindImage( const char *name, const char *suffix, int flags )
 	pathname[len] = 0;
 
 	// look for it
-	key = COM_SuperFastHash( ( const qbyte *)pathname, len, len ) % IMAGES_HASH_SIZE;
+	key = COM_SuperFastHash( ( const uint8_t *)pathname, len, len ) % IMAGES_HASH_SIZE;
 	hnode = &images_hash_headnode[key];
 	for( image = hnode->prev; image != hnode; image = image->prev )
 	{
@@ -2035,7 +2035,7 @@ void R_ScreenShot( const char *filename, int x, int y, int width, int height, in
 	qboolean flipx, qboolean flipy, qboolean flipdiagonal, qboolean silent )
 {
 	size_t size, buf_size;
-	qbyte *buffer, *flipped, *rgb, *rgba;
+	uint8_t *buffer, *flipped, *rgb, *rgba;
 	r_imginfo_t imginfo;
 	const char *extension;
 
@@ -2126,8 +2126,8 @@ void R_ScreenShot( const char *filename, int x, int y, int width, int height, in
 static void R_InitNoTexture( int *w, int *h, int *flags, int *samples )
 {
 	int x, y;
-	qbyte *data;
-	qbyte dottexture[8][8] =
+	uint8_t *data;
+	uint8_t dottexture[8][8] =
 	{
 		{ 0, 0, 0, 0, 0, 0, 0, 0 },
 		{ 0, 0, 1, 1, 0, 0, 0, 0 },
@@ -2162,9 +2162,9 @@ static void R_InitNoTexture( int *w, int *h, int *flags, int *samples )
 /*
 * R_InitSolidColorTexture
 */
-static qbyte *R_InitSolidColorTexture( int *w, int *h, int *flags, int *samples, int color )
+static uint8_t *R_InitSolidColorTexture( int *w, int *h, int *flags, int *samples, int color )
 {
-	qbyte *data;
+	uint8_t *data;
 
 	//
 	// solid color texture
@@ -2187,7 +2187,7 @@ static void R_InitParticleTexture( int *w, int *h, int *flags, int *samples )
 	int x, y;
 	int dx2, dy, d;
 	float dd2;
-	qbyte *data;
+	uint8_t *data;
 
 	//
 	// particle texture
@@ -2232,7 +2232,7 @@ static void R_InitWhiteCubemapTexture( int *w, int *h, int *flags, int *samples 
 	*samples = 3;
 
 	for( i = 0; i < 6; i++ ) {
-		qbyte *data;
+		uint8_t *data;
 		data = R_PrepareImageBuffer( QGL_CONTEXT_MAIN, TEXTURE_LOADING_BUF0+i, 1 * 1 * 3 );
 		data[0] = data[1] = data[2] = 255;
 	}
@@ -2259,7 +2259,7 @@ static void R_InitGreyTexture( int *w, int *h, int *flags, int *samples )
 */
 static void R_InitBlankBumpTexture( int *w, int *h, int *flags, int *samples )
 {
-	qbyte *data = R_InitSolidColorTexture( w, h, flags, samples, 128 );
+	uint8_t *data = R_InitSolidColorTexture( w, h, flags, samples, 128 );
 
 /*
 	data[0] = 128;	// normal X
@@ -2276,7 +2276,7 @@ static void R_InitCoronaTexture( int *w, int *h, int *flags, int *samples )
 {
 	int x, y, a;
 	float dx, dy;
-	qbyte *data;
+	uint8_t *data;
 
 	//
 	// light corona texture
@@ -2370,7 +2370,7 @@ void R_InitViewportTexture( image_t **texture, const char *name, int id,
 	// create a new texture or update the old one
 	if( !( *texture ) || ( *texture )->width != width || ( *texture )->height != height )
 	{
-		qbyte *data = NULL;
+		uint8_t *data = NULL;
 
 		if( !*texture ) {
 			char uploadName[128];
@@ -2507,7 +2507,7 @@ static void R_InitStretchRawTexture( void )
 	unsigned hash;
 
 	// reserve a dummy texture slot
-	hash = COM_SuperFastHash( ( const qbyte *)name, name_len, name_len );
+	hash = COM_SuperFastHash( ( const uint8_t *)name, name_len, name_len );
 	rawtexture = R_LinkPic( hash );
 
 	assert( rawtexture );
@@ -2539,7 +2539,7 @@ static void R_InitStretchRawYUVTextures( void )
 		int name_len = strlen( name[i] );
 		unsigned hash;
 
-		hash = COM_SuperFastHash( ( const qbyte *)name, name_len, name_len );
+		hash = COM_SuperFastHash( ( const uint8_t *)name, name_len, name_len );
 		rawtexture = R_LinkPic( hash );
 
 		assert( rawtexture );

--- a/source/ref_gl/r_image.h
+++ b/source/ref_gl/r_image.h
@@ -92,12 +92,12 @@ void R_ScreenShot( const char *filename, int x, int y, int width, int height, in
 void R_TextureMode( char *string );
 void R_AnisotropicFilter( int value );
 
-image_t *R_LoadImage( const char *name, qbyte **pic, int width, int height, int flags, int samples );
+image_t *R_LoadImage( const char *name, uint8_t **pic, int width, int height, int flags, int samples );
 image_t	*R_FindImage( const char *name, const char *suffix, int flags );
 image_t *R_CreateArrayImage( const char *name, int width, int height, int layers, int flags, int samples );
-void R_ReplaceImage( image_t *image, qbyte **pic, int width, int height, int flags, int samples );
-void R_ReplaceSubImage( image_t *image, int layer, int x, int y, qbyte **pic, int width, int height );
-void R_ReplaceImageLayer( image_t *image, int layer, qbyte **pic );
+void R_ReplaceImage( image_t *image, uint8_t **pic, int width, int height, int flags, int samples );
+void R_ReplaceSubImage( image_t *image, int layer, int x, int y, uint8_t **pic, int width, int height );
+void R_ReplaceImageLayer( image_t *image, int layer, uint8_t **pic );
 
 void R_BeginAviDemo( void );
 void R_WriteAviFrame( int frame, qboolean scissor );

--- a/source/ref_gl/r_imagelib.c
+++ b/source/ref_gl/r_imagelib.c
@@ -122,7 +122,7 @@ typedef struct _TargaHeader
 
 #undef WRITEPIXEL
 #define WRITEPIXEL	WRITEPIXEL24
-static void tga_comp_cm24( qbyte *pout, qbyte *pin, qbyte palette[256][4], int size )
+static void tga_comp_cm24( uint8_t *pout, uint8_t *pin, uint8_t palette[256][4], int size )
 {
 	int header, pixelcount;
 	int blue, green, red;
@@ -131,7 +131,7 @@ static void tga_comp_cm24( qbyte *pout, qbyte *pin, qbyte palette[256][4], int s
 	WRITELOOP_COMP_1;
 }
 
-static void tga_cm24( qbyte *pout, qbyte *pin, qbyte palette[256][4], int size )
+static void tga_cm24( uint8_t *pout, uint8_t *pin, uint8_t palette[256][4], int size )
 {
 	int blue, green, red;
 	int i;
@@ -153,7 +153,7 @@ static void tga_cm24( qbyte *pout, qbyte *pin, qbyte palette[256][4], int size )
 
 #undef WRITEPIXEL
 #define WRITEPIXEL	WRITEPIXEL32
-static void tga_comp_cm32( qbyte *pout, qbyte *pin, qbyte palette[256][4], int size )
+static void tga_comp_cm32( uint8_t *pout, uint8_t *pin, uint8_t palette[256][4], int size )
 {
 	int header, pixelcount;
 	int blue, green, red, alpha;
@@ -162,7 +162,7 @@ static void tga_comp_cm32( qbyte *pout, qbyte *pin, qbyte palette[256][4], int s
 	WRITELOOP_COMP_1;
 }
 
-static void tga_cm32( qbyte *pout, qbyte *pin, qbyte palette[256][4], int size )
+static void tga_cm32( uint8_t *pout, uint8_t *pin, uint8_t palette[256][4], int size )
 {
 	int blue, green, red, alpha;
 	int i;
@@ -182,7 +182,7 @@ static void tga_cm32( qbyte *pout, qbyte *pin, qbyte palette[256][4], int size )
 
 #undef WRITEPIXEL
 #define WRITEPIXEL	WRITEPIXEL24
-static void tga_comp_rgb24( qbyte *pout, qbyte *pin, int size )
+static void tga_comp_rgb24( uint8_t *pout, uint8_t *pin, int size )
 {
 	int header, pixelcount;
 	int blue, green, red;
@@ -211,7 +211,7 @@ static void tga_comp_rgb24( qbyte *pout, qbyte *pin, int size )
 	}
 }
 
-static void tga_rgb24( qbyte *pout, qbyte *pin, int size )
+static void tga_rgb24( uint8_t *pout, uint8_t *pin, int size )
 {
 	memcpy( pout, pin, size * 3 );
 }
@@ -229,7 +229,7 @@ static void tga_rgb24( qbyte *pout, qbyte *pin, int size )
 		*((int*)a) = pix;	\
 		a += 4;
 
-static void tga_comp_rgb32( qbyte *pout, qbyte *pin, int size )
+static void tga_comp_rgb32( uint8_t *pout, uint8_t *pin, int size )
 {
 	int header, pixelcount;
 	int blue, green, red, alpha;
@@ -256,7 +256,7 @@ static void tga_comp_rgb32( qbyte *pout, qbyte *pin, int size )
 	}
 }
 
-static void tga_rgb32( qbyte *pout, qbyte *pin, int size )
+static void tga_rgb32( uint8_t *pout, uint8_t *pin, int size )
 {
 	memcpy( pout, pin, size * 4 );
 }
@@ -268,7 +268,7 @@ static void tga_rgb32( qbyte *pout, qbyte *pin, int size )
 
 #undef WRITEPIXEL
 #define WRITEPIXEL	WRITEPIXEL24
-static void tga_comp_grey( qbyte *pout, qbyte *pin, int size )
+static void tga_comp_grey( uint8_t *pout, uint8_t *pin, int size )
 {
 	int header, pixelcount;
 	int blue, green, red;
@@ -277,7 +277,7 @@ static void tga_comp_grey( qbyte *pout, qbyte *pin, int size )
 	WRITELOOP_COMP_1;
 }
 
-static void tga_grey( qbyte *pout, qbyte *pin, int size )
+static void tga_grey( uint8_t *pout, uint8_t *pin, int size )
 {
 	int i, a;
 
@@ -293,11 +293,11 @@ static void tga_grey( qbyte *pout, qbyte *pin, int size )
 /*
 * LoadTGA
 */
-r_imginfo_t LoadTGA( const char *name, qbyte *(*allocbuf)( void *, size_t, const char *, int ), void *uptr )
+r_imginfo_t LoadTGA( const char *name, uint8_t *(*allocbuf)( void *, size_t, const char *, int ), void *uptr )
 {
 	int i, j, columns, rows, samples;
-	qbyte *buf_p, *buffer, *pixbuf, *targa_rgba;
-	qbyte palette[256][4];
+	uint8_t *buf_p, *buffer, *pixbuf, *targa_rgba;
+	uint8_t palette[256][4];
 	TargaHeader targa_header;
 	r_imginfo_t imginfo;
 
@@ -462,8 +462,8 @@ r_imginfo_t LoadTGA( const char *name, qbyte *(*allocbuf)( void *, size_t, const
 	{
 		// Flip the image vertically
 		int rowsize = columns * samples;
-		qbyte *row1, *row2;
-		qbyte *tmpLine = alloca( rowsize );
+		uint8_t *row1, *row2;
+		uint8_t *tmpLine = alloca( rowsize );
 
 		for( i = 0, j = rows - 1; i < j; i++, j-- )
 		{
@@ -499,7 +499,7 @@ qboolean WriteTGA( const char *name, r_imginfo_t *info, int quality )
 {
 	int file, i, c, temp;
 	int width, height, samples;
-	qbyte header[18], *buffer;
+	uint8_t header[18], *buffer;
 	qboolean bgr;
 
 	if( ri.FS_FOpenFile( name, &file, FS_WRITE ) == -1 )
@@ -603,10 +603,10 @@ void q_jpeg_mem_src( j_decompress_ptr cinfo, unsigned char *mem, unsigned long l
 /*
 * LoadJPG
 */
-r_imginfo_t LoadJPG( const char *name, qbyte *(*allocbuf)( void *, size_t, const char *, int ), void *uptr )
+r_imginfo_t LoadJPG( const char *name, uint8_t *(*allocbuf)( void *, size_t, const char *, int ), void *uptr )
 {
 	unsigned int i, length, samples, widthXsamples;
-	qbyte *img, *scan, *buffer, *line, *jpg_rgb;
+	uint8_t *img, *scan, *buffer, *line, *jpg_rgb;
 	struct q_jpeg_error_mgr jerr;
 	struct jpeg_decompress_struct cinfo;
 	r_imginfo_t imginfo;
@@ -691,7 +691,7 @@ static void q_jpg_init_destination(j_compress_ptr cinfo)
 static boolean q_jpg_write_buf_to_disk(j_compress_ptr cinfo)
 {
 	int written = JPEG_OUTPUT_BUFFER_SIZE - cinfo->dest->free_in_buffer;
-	qbyte *buffer = ( qbyte * )cinfo->dest->next_output_byte - written;
+	uint8_t *buffer = ( uint8_t * )cinfo->dest->next_output_byte - written;
 	int file = *((int *)(buffer + JPEG_OUTPUT_BUFFER_SIZE));
 	if( ri.FS_Write( buffer, JPEG_OUTPUT_BUFFER_SIZE, file ) == 0 ) {
 		return FALSE;
@@ -794,7 +794,7 @@ PNG LOADING
 */
 
 typedef struct {
-	qbyte *data;
+	uint8_t *data;
 	size_t size;
 	size_t curptr;
 } q_png_iobuf_t;
@@ -831,10 +831,10 @@ static void q_png_user_read_fn( png_structp png_ptr, unsigned char *data, size_t
 /*
 * LoadPNG
 */
-r_imginfo_t LoadPNG( const char *name, qbyte *(*allocbuf)( void *, size_t, const char *, int ), void *uptr )
+r_imginfo_t LoadPNG( const char *name, uint8_t *(*allocbuf)( void *, size_t, const char *, int ), void *uptr )
 {
-	qbyte *img;
-	qbyte *png_data;
+	uint8_t *img;
+	uint8_t *png_data;
 	size_t png_datasize;
 	q_png_iobuf_t io;
 	png_structp png_ptr = NULL;
@@ -991,14 +991,14 @@ static const int q_etc1_modifierTable[] =
 
 static const int q_etc1_lookup[] = { 0, 1, 2, 3, -4, -3, -2, -1 };
 
-static void q_etc1_subblock( qbyte *out, int stride, qboolean bgr, int r, int g, int b,
+static void q_etc1_subblock( uint8_t *out, int stride, qboolean bgr, int r, int g, int b,
 	const int *table, unsigned int low, qboolean second, qboolean flipped )
 {
 	int baseX = 0, baseY = 0;
 	int i;
 	int x, y;
 	int k, delta;
-	qbyte *q;
+	uint8_t *q;
 	if( second )
 	{
 		if( flipped )
@@ -1036,7 +1036,7 @@ static void q_etc1_subblock( qbyte *out, int stride, qboolean bgr, int r, int g,
 	}
 }
 
-static void q_etc1_block( const qbyte *in, qbyte *out, int stride, qboolean bgr )
+static void q_etc1_block( const uint8_t *in, uint8_t *out, int stride, qboolean bgr )
 {
 	unsigned int high = ( in[0] << 24 ) | ( in[1] << 16 ) | ( in[2] << 8 ) | in[3];
 	unsigned int low = ( in[4] << 24 ) | ( in[5] << 16 ) | ( in[6] << 8 ) | in[7];
@@ -1080,10 +1080,10 @@ static void q_etc1_block( const qbyte *in, qbyte *out, int stride, qboolean bgr 
 		low, qtrue, flipped );
 }
 
-void DecompressETC1( const qbyte *in, int width, int height, qbyte *out, qboolean bgr )
+void DecompressETC1( const uint8_t *in, int width, int height, uint8_t *out, qboolean bgr )
 {
 	int stride = ALIGN( width, 4 ) * 3;
-	qbyte *uncompressed = alloca( 4 * stride );
+	uint8_t *uncompressed = alloca( 4 * stride );
 	int i, j, rows, rowSize = width * 3, rowSizeAligned = ALIGN( rowSize, 4 );
 	for( i = 0; i < height; i += 4 )
 	{

--- a/source/ref_gl/r_imagelib.h
+++ b/source/ref_gl/r_imagelib.h
@@ -36,17 +36,17 @@ typedef struct
 	int height;
 	int samples;
 	r_imgcomp_t comp;
-	qbyte *pixels;
+	uint8_t *pixels;
 } r_imginfo_t;
 
-r_imginfo_t LoadTGA( const char *name, qbyte *(*allocbuf)( void *, size_t, const char *, int ), void *uptr );
+r_imginfo_t LoadTGA( const char *name, uint8_t *(*allocbuf)( void *, size_t, const char *, int ), void *uptr );
 qboolean WriteTGA( const char *name, r_imginfo_t *info, int quality );
 
-r_imginfo_t LoadJPG( const char *name, qbyte *(*allocbuf)( void *, size_t, const char *, int ), void *uptr );
+r_imginfo_t LoadJPG( const char *name, uint8_t *(*allocbuf)( void *, size_t, const char *, int ), void *uptr );
 qboolean WriteJPG( const char *name, r_imginfo_t *info, int quality );
 
-r_imginfo_t LoadPNG( const char *name, qbyte *(*allocbuf)( void *, size_t, const char *, int ), void *uptr );
+r_imginfo_t LoadPNG( const char *name, uint8_t *(*allocbuf)( void *, size_t, const char *, int ), void *uptr );
 
-void DecompressETC1( const qbyte *in, int width, int height, qbyte *out, qboolean bgr );
+void DecompressETC1( const uint8_t *in, int width, int height, uint8_t *out, qboolean bgr );
 
 #endif // R_IMAGELIB_H

--- a/source/ref_gl/r_light.c
+++ b/source/ref_gl/r_light.c
@@ -372,7 +372,7 @@ LIGHTMAP ALLOCATION
 
 #define MAX_LIGHTMAP_IMAGES		1024
 
-static qbyte *r_lightmapBuffer;
+static uint8_t *r_lightmapBuffer;
 static int r_lightmapBufferSize;
 static image_t *r_lightmapTextures[MAX_LIGHTMAP_IMAGES];
 static int r_numUploadedLightmaps;
@@ -381,10 +381,10 @@ static int r_maxLightmapBlockSize;
 /*
 * R_BuildLightmap
 */
-static void R_BuildLightmap( int w, int h, qboolean deluxe, const qbyte *data, qbyte *dest, int blockWidth )
+static void R_BuildLightmap( int w, int h, qboolean deluxe, const uint8_t *data, uint8_t *dest, int blockWidth )
 {
 	int x, y;
-	qbyte *rgba;
+	uint8_t *rgba;
 	int bits = mapConfig.pow2MapOvrbr;
 
 	if( !data || (r_fullbright->integer && !deluxe) )
@@ -426,9 +426,9 @@ static void R_BuildLightmap( int w, int h, qboolean deluxe, const qbyte *data, q
 					normalized[0] = normalized[1] = normalized[2] = bound( 0, grey, 1 );
 				}
 
-				rgba[0] = ( qbyte )( normalized[0] * 255 );
-				rgba[1] = ( qbyte )( normalized[1] * 255 );
-				rgba[2] = ( qbyte )( normalized[2] * 255 );
+				rgba[0] = ( uint8_t )( normalized[0] * 255 );
+				rgba[1] = ( uint8_t )( normalized[1] * 255 );
+				rgba[2] = ( uint8_t )( normalized[2] * 255 );
 			}
 		}
 	}
@@ -437,7 +437,7 @@ static void R_BuildLightmap( int w, int h, qboolean deluxe, const qbyte *data, q
 /*
 * R_UploadLightmap
 */
-static int R_UploadLightmap( const char *name, qbyte *data, int w, int h )
+static int R_UploadLightmap( const char *name, uint8_t *data, int w, int h )
 {
 	image_t *image;
 	char uploadName[128];
@@ -452,7 +452,7 @@ static int R_UploadLightmap( const char *name, qbyte *data, int w, int h )
 
 	Q_snprintfz( uploadName, sizeof( uploadName ), "%s%i", name, r_numUploadedLightmaps );
 
-	image = R_LoadImage( uploadName, (qbyte **)( &data ), w, h, 
+	image = R_LoadImage( uploadName, (uint8_t **)( &data ), w, h, 
 		IT_CLAMP|IT_NOPICMIP|IT_NOMIPMAP|IT_NOCOMPRESS, LIGHTMAP_BYTES );
 	r_lightmapTextures[r_numUploadedLightmaps] = image;
 
@@ -463,10 +463,10 @@ static int R_UploadLightmap( const char *name, qbyte *data, int w, int h )
 * R_PackLightmaps
 */
 static int R_PackLightmaps( int num, int w, int h, int size, int stride, qboolean deluxe, 
-	const char *name, const qbyte *data, mlightmapRect_t *rects )
+	const char *name, const uint8_t *data, mlightmapRect_t *rects )
 {
 	int i, x, y, root;
-	qbyte *block;
+	uint8_t *block;
 	int lightmapNum;
 	int rectX, rectY, rectW, rectH, rectSize;
 	int maxX, maxY, max, xStride;
@@ -599,7 +599,7 @@ static int R_PackLightmaps( int num, int w, int h, int size, int stride, qboolea
 /*
 * R_BuildLightmaps
 */
-void R_BuildLightmaps( model_t *mod, int numLightmaps, int w, int h, const qbyte *data, mlightmapRect_t *rects )
+void R_BuildLightmaps( model_t *mod, int numLightmaps, int w, int h, const uint8_t *data, mlightmapRect_t *rects )
 {
 	int i, j, p;
 	int numBlocks = numLightmaps;
@@ -650,7 +650,7 @@ void R_BuildLightmaps( model_t *mod, int numLightmaps, int w, int h, const qbyte
 
 	if( mapConfig.lightmapArrays )
 	{
-		int numLayers = min( glConfig.maxTextureLayers, 256 ); // layer index is a qbyte
+		int numLayers = min( glConfig.maxTextureLayers, 256 ); // layer index is a uint8_t
 		int layer = 0;
 		int lightmapNum = 0;
 		image_t *image = NULL;
@@ -786,7 +786,7 @@ void R_InitLightStyles( model_t *mod )
 * R_AddSuperLightStyle
 */
 superLightStyle_t *R_AddSuperLightStyle( model_t *mod, const int *lightmaps,
-	const qbyte *lightmapStyles, const qbyte *vertexStyles, mlightmapRect_t **lmRects )
+	const uint8_t *lightmapStyles, const uint8_t *vertexStyles, mlightmapRect_t **lmRects )
 {
 	unsigned int i, j;
 	superLightStyle_t *sls;

--- a/source/ref_gl/r_local.h
+++ b/source/ref_gl/r_local.h
@@ -411,9 +411,9 @@ extern cvar_t *vid_multiscreen_head;
 
 //====================================================================
 
-void R_NormToLatLong( const vec_t *normal, qbyte latlong[2] );
-void R_LatLongToNorm( const qbyte latlong[2], vec3_t out );
-void R_LatLongToNorm4( const qbyte latlong[2], vec4_t out );
+void R_NormToLatLong( const vec_t *normal, uint8_t latlong[2] );
+void R_LatLongToNorm( const uint8_t latlong[2], vec3_t out );
+void R_LatLongToNorm4( const uint8_t latlong[2], vec4_t out );
 
 //====================================================================
 
@@ -499,10 +499,10 @@ unsigned int R_AddSurfaceDlighbits( const msurface_t *surf, unsigned int checkDl
 void		R_AddDynamicLights( unsigned int dlightbits, int state );
 void		R_LightForOrigin( const vec3_t origin, vec3_t dir, vec4_t ambient, vec4_t diffuse, float radius, qboolean noWorldLight );
 void		R_LightForOrigin2( const vec3_t origin, vec3_t dir, vec4_t ambient, vec4_t diffuse, float radius );
-void		R_BuildLightmaps( model_t *mod, int numLightmaps, int w, int h, const qbyte *data, mlightmapRect_t *rects );
+void		R_BuildLightmaps( model_t *mod, int numLightmaps, int w, int h, const uint8_t *data, mlightmapRect_t *rects );
 void		R_InitLightStyles( model_t *mod );
 superLightStyle_t	*R_AddSuperLightStyle( model_t *mod, const int *lightmaps, 
-	const qbyte *lightmapStyles, const qbyte *vertexStyles, mlightmapRect_t **lmRects );
+	const uint8_t *lightmapStyles, const uint8_t *vertexStyles, mlightmapRect_t **lmRects );
 void		R_SortSuperLightStyles( model_t *mod );
 void		R_TouchLightmapImages( model_t *mod );
 
@@ -571,7 +571,7 @@ void		R_DrawStretchPic( int x, int y, int w, int h, float s1, float t1, float s2
 void		R_DrawRotatedStretchPic( int x, int y, int w, int h, float s1, float t1, float s2, float t2, 
 	float angle, const vec4_t color, const shader_t *shader );
 void		R_DrawStretchRaw( int x, int y, int w, int h, int cols, int rows, 
-	float s1, float t1, float s2, float t2, qbyte *data );
+	float s1, float t1, float s2, float t2, uint8_t *data );
 void		R_DrawStretchRawYUVBuiltin( int x, int y, int w, int h, float s1, float t1, float s2, float t2, 
 	ref_img_plane_t *yuv, image_t **yuvTextures, int flip );
 void		R_DrawStretchRawYUV( int x, int y, int w, int h, 

--- a/source/ref_gl/r_main.c
+++ b/source/ref_gl/r_main.c
@@ -349,7 +349,7 @@ void R_SetCustomColor( int num, int r, int g, int b )
 {
 	if( num < 0 || num >= NUM_CUSTOMCOLORS )
 		return;
-	Vector4Set( r_customColors[num], (qbyte)r, (qbyte)g, (qbyte)b, 255 );
+	Vector4Set( r_customColors[num], (uint8_t)r, (uint8_t)g, (uint8_t)b, 255 );
 }
 /*
 * R_GetCustomColor
@@ -760,7 +760,7 @@ void R_DrawStretchPic( int x, int y, int w, int h, float s1, float t1, float s2,
 * Passing NULL for data redraws last uploaded frame
 */
 void R_DrawStretchRaw( int x, int y, int w, int h, int cols, int rows, 
-	float s1, float t1, float s2, float t2, qbyte *data )
+	float s1, float t1, float s2, float t2, uint8_t *data )
 {
 	float h_scale, v_scale;
 
@@ -770,7 +770,7 @@ void R_DrawStretchRaw( int x, int y, int w, int h, int cols, int rows,
 
 	if( data ) {
 		if( rsh.rawTexture->width != cols || rsh.rawTexture->height != rows ) {
-			qbyte *nodata[1] = { NULL };
+			uint8_t *nodata[1] = { NULL };
 			R_ReplaceImage( rsh.rawTexture, nodata, cols, rows, rsh.rawTexture->flags, 3 );
 		}
 		R_ReplaceSubImage( rsh.rawTexture, 0, 0, 0, &data, cols, rows );
@@ -822,7 +822,7 @@ void R_DrawStretchRawYUVBuiltin( int x, int y, int w, int h,
 		int i;
 
 		for( i = 0; i < 3; i++ ) {
-			qbyte *data = yuv[i].data;
+			uint8_t *data = yuv[i].data;
 			int flags = yuvTextures[i]->flags;
 			int stride = yuv[i].stride;
 			int height = yuv[i].height;
@@ -835,7 +835,7 @@ void R_DrawStretchRawYUVBuiltin( int x, int y, int w, int h,
 			}
 
 			if( yuvTextures[i]->width != stride || yuvTextures[i]->height != height ) {
-				qbyte *nodata[1] = { NULL };
+				uint8_t *nodata[1] = { NULL };
 				R_ReplaceImage( yuvTextures[i], nodata, stride, height, flags, 1 );
 			}
 			R_ReplaceSubImage( yuvTextures[i], 0, 0, 0, &data, stride, height );
@@ -1149,7 +1149,7 @@ static void R_SetupViewMatrices( void )
 static void R_Clear( int bitMask )
 {
 	int bits;
-	qbyte *envColor = rsh.worldModel && !( rn.refdef.rdflags & RDF_NOWORLDMODEL ) && rsh.worldBrushModel->globalfog ?
+	uint8_t *envColor = rsh.worldModel && !( rn.refdef.rdflags & RDF_NOWORLDMODEL ) && rsh.worldBrushModel->globalfog ?
 		rsh.worldBrushModel->globalfog->shader->fog_color : mapConfig.environmentColor;
 	qboolean rgbShadow = ( rn.renderFlags & RF_SHADOWMAPVIEW ) && rn.fbColorAttachment != NULL ? qtrue : qfalse;
 
@@ -1585,7 +1585,7 @@ void R_BeginFrame( float cameraSeparation, qboolean forceClear, qboolean forceVs
 
 	if( r_clear->integer || forceClear )
 	{
-		const qbyte *color = mapConfig.environmentColor;
+		const uint8_t *color = mapConfig.environmentColor;
 		RB_Clear( GL_COLOR_BUFFER_BIT, 
 			color[0]*( 1.0/255.0 ), color[1]*( 1.0/255.0 ), color[2]*( 1.0/255.0 ), 1 );
 	}
@@ -1937,7 +1937,7 @@ struct cinematics_s *R_GetShaderCinematic( shader_t *shader )
 /*
 * R_NormToLatLong
 */
-void R_NormToLatLong( const vec_t *normal, qbyte latlong[2] )
+void R_NormToLatLong( const vec_t *normal, uint8_t latlong[2] )
 {
 	float flatlong[2];
 
@@ -1949,7 +1949,7 @@ void R_NormToLatLong( const vec_t *normal, qbyte latlong[2] )
 /*
 * R_LatLongToNorm4
 */
-void R_LatLongToNorm4( const qbyte latlong[2], vec4_t out )
+void R_LatLongToNorm4( const uint8_t latlong[2], vec4_t out )
 {
 	static float * const sinTable = rsh.sinTableByte;
 	float sin_a, sin_b, cos_a, cos_b;
@@ -1965,7 +1965,7 @@ void R_LatLongToNorm4( const qbyte latlong[2], vec4_t out )
 /*
 * R_LatLongToNorm
 */
-void R_LatLongToNorm( const qbyte latlong[2], vec3_t out )
+void R_LatLongToNorm( const uint8_t latlong[2], vec3_t out )
 {
 	vec4_t t;
 	R_LatLongToNorm4( latlong, t );
@@ -1990,7 +1990,7 @@ char *R_CopyString_( const char *in, const char *filename, int fileline )
 */
 int R_LoadFile_( const char *path, void **buffer, const char *filename, int fileline )
 {
-	qbyte *buf;
+	uint8_t *buf;
 	unsigned int len;
 	int fhandle;
 
@@ -2012,7 +2012,7 @@ int R_LoadFile_( const char *path, void **buffer, const char *filename, int file
 		return len;
 	}
 
-	buf = ( qbyte *)ri.Mem_AllocExt( r_mempool, len + 1, 16, 0, filename, fileline );
+	buf = ( uint8_t *)ri.Mem_AllocExt( r_mempool, len + 1, 16, 0, filename, fileline );
 	buf[len] = 0;
 	*buffer = buf;
 

--- a/source/ref_gl/r_mesh.h
+++ b/source/ref_gl/r_mesh.h
@@ -36,8 +36,8 @@ typedef struct mesh_s
 	byte_vec4_t			*lmlayersArray[( MAX_LIGHTMAPS + 3 ) / 4];
 	byte_vec4_t			*colorsArray[MAX_LIGHTMAPS];
 
-	qbyte				*blendIndices;
-	qbyte				*blendWeights;
+	uint8_t				*blendIndices;
+	uint8_t				*blendWeights;
 
 	unsigned short		numElems;
 	elem_t				*elems;

--- a/source/ref_gl/r_model.c
+++ b/source/ref_gl/r_model.c
@@ -33,7 +33,7 @@ model_t *Mod_LoadModel( model_t *mod, qboolean crash );
 static void R_InitMapConfig( const char *model );
 static void R_FinishMapConfig( const model_t *mod );
 
-static qbyte mod_novis[MAX_MAP_LEAFS/8];
+static uint8_t mod_novis[MAX_MAP_LEAFS/8];
 
 #define	MAX_MOD_KNOWN	512*MOD_MAX_LODS
 static model_t mod_known[MAX_MOD_KNOWN];
@@ -92,17 +92,17 @@ mleaf_t *Mod_PointInLeaf( vec3_t p, model_t *model )
 /*
 * Mod_ClusterVS
 */
-static inline qbyte *Mod_ClusterVS( int cluster, dvis_t *vis )
+static inline uint8_t *Mod_ClusterVS( int cluster, dvis_t *vis )
 {
 	if( cluster < 0 || !vis )
 		return mod_novis;
-	return ( (qbyte *)vis->data + cluster*vis->rowsize );
+	return ( (uint8_t *)vis->data + cluster*vis->rowsize );
 }
 
 /*
 * Mod_ClusterPVS
 */
-qbyte *Mod_ClusterPVS( int cluster, model_t *model )
+uint8_t *Mod_ClusterPVS( int cluster, model_t *model )
 {
 	return Mod_ClusterVS( cluster, (( mbrushmodel_t * )model->extradata)->pvs );
 }
@@ -328,11 +328,11 @@ static void Mod_SetupSubmodels( model_t *mod )
 static int Mod_CreateSubmodelBufferObjects( model_t *mod, unsigned int modnum, size_t *vbo_total_size )
 {
 	unsigned int i, j, k;
-	qbyte *visdata = NULL;
-	qbyte *areadata = NULL;
+	uint8_t *visdata = NULL;
+	uint8_t *areadata = NULL;
 	unsigned int rowbytes, rowlongs;
 	int areabytes;
-	qbyte *arearow;
+	uint8_t *arearow;
 	int *longrow, *longrow2;
 	mmodel_t *bm;
 	mbrushmodel_t *loadbmodel;
@@ -373,8 +373,8 @@ static int Mod_CreateSubmodelBufferObjects( model_t *mod, unsigned int modnum, s
 
 		// build visibility data for each face, based on what leafs
 		// this face belongs to (visible from)
-		visdata = ( qbyte * )Mod_Malloc( mod, rowlongs * 4 * loadbmodel->numsurfaces );
-		areadata = ( qbyte * )Mod_Malloc( mod, areabytes * loadbmodel->numsurfaces );
+		visdata = ( uint8_t * )Mod_Malloc( mod, rowlongs * 4 * loadbmodel->numsurfaces );
+		areadata = ( uint8_t * )Mod_Malloc( mod, areabytes * loadbmodel->numsurfaces );
 
 		for( pleaf = loadbmodel->visleafs, leaf = *pleaf; leaf; leaf = *pleaf++ )
 		{
@@ -968,7 +968,7 @@ model_t *Mod_ForName( const char *name, qboolean crash )
 		return NULL;
 
 	// call the apropriate loader
-	descr = Q_FindFormatDescriptor( mod_supportedformats, ( const qbyte * )buf, (const bspFormatDesc_t **)&bspFormat );
+	descr = Q_FindFormatDescriptor( mod_supportedformats, ( const uint8_t * )buf, (const bspFormatDesc_t **)&bspFormat );
 	if( !descr )
 	{
 		ri.Com_DPrintf( S_COLOR_YELLOW "Mod_NumForName: unknown fileid for %s", mod->name );

--- a/source/ref_gl/r_model.h
+++ b/source/ref_gl/r_model.h
@@ -126,10 +126,10 @@ typedef struct mleaf_s
 
 typedef struct
 {
-	qbyte			ambient[MAX_LIGHTMAPS][3];
-	qbyte			diffuse[MAX_LIGHTMAPS][3];
-	qbyte			styles[MAX_LIGHTMAPS];
-	qbyte			direction[2];
+	uint8_t			ambient[MAX_LIGHTMAPS][3];
+	uint8_t			diffuse[MAX_LIGHTMAPS][3];
+	uint8_t			styles[MAX_LIGHTMAPS];
+	uint8_t			direction[2];
 } mgridlight_t;
 
 typedef struct
@@ -207,7 +207,7 @@ ALIAS MODELS
 typedef struct
 {
 	short			point[3];
-	qbyte			latlong[2];				// use bytes to keep 8-byte alignment
+	uint8_t			latlong[2];				// use bytes to keep 8-byte alignment
 } maliasvertex_t;
 
 typedef struct
@@ -292,16 +292,16 @@ typedef struct
 
 typedef struct
 {
-	qbyte			indices[SKM_MAX_WEIGHTS];
-	qbyte			weights[SKM_MAX_WEIGHTS];
+	uint8_t			indices[SKM_MAX_WEIGHTS];
+	uint8_t			weights[SKM_MAX_WEIGHTS];
 } mskblend_t;
 
 typedef struct mskmesh_s
 {
 	char			*name;
 
-	qbyte			*blendIndices;
-	qbyte			*blendWeights;
+	uint8_t			*blendIndices;
+	uint8_t			*blendWeights;
 
 	unsigned int	numverts;
 	vec4_t			*xyzArray;
@@ -353,8 +353,8 @@ typedef struct mskmodel_s
 	vec4_t			*normalsArray;
 	vec2_t			*stArray;
 	vec4_t			*sVectorsArray;
-	qbyte			*blendIndices;
-	qbyte			*blendWeights;
+	uint8_t			*blendIndices;
+	uint8_t			*blendWeights;
 
 	unsigned int	numblends;
 	mskblend_t		*blends;
@@ -417,7 +417,7 @@ struct model_s *R_RegisterModel( const char *name );
 void		Mod_ClearAll( void );
 model_t		*Mod_ForName( const char *name, qboolean crash );
 mleaf_t		*Mod_PointInLeaf( float *p, model_t *model );
-qbyte		*Mod_ClusterPVS( int cluster, model_t *model );
+uint8_t		*Mod_ClusterPVS( int cluster, model_t *model );
 
 unsigned int Mod_Handle( const model_t *mod );
 model_t		*Mod_ForHandle( unsigned int elem );

--- a/source/ref_gl/r_program.c
+++ b/source/ref_gl/r_program.c
@@ -1756,8 +1756,8 @@ void RP_ProgramList_f( void )
 */
 void RP_UpdateShaderUniforms( int elem, 
 	float shaderTime, 
-	const vec3_t entOrigin, const vec3_t entDist, const qbyte *entityColor, 
-	const qbyte *constColor, const float *rgbGenFuncArgs, const float *alphaGenFuncArgs,
+	const vec3_t entOrigin, const vec3_t entDist, const uint8_t *entityColor, 
+	const uint8_t *constColor, const float *rgbGenFuncArgs, const float *alphaGenFuncArgs,
 	const mat4_t texMatrix )
 {
 	GLfloat m[9];

--- a/source/ref_gl/r_program.h
+++ b/source/ref_gl/r_program.h
@@ -20,7 +20,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #ifndef R_PROGRAM_H
 #define R_PROGRAM_H
 
-typedef quint64 r_glslfeat_t;
+typedef uint64_t r_glslfeat_t;
 
 #define GLSL_BIT(x)							(1ULL << (x))
 #define GLSL_BITS_VERSION					9
@@ -190,8 +190,8 @@ int	RP_GetProgramObject( int elem );
 
 void RP_UpdateShaderUniforms( int elem, 
 	float shaderTime, 
-	const vec3_t entOrigin, const vec3_t entDist, const qbyte *entityColor, 
-	const qbyte *constColor, const float *rgbGenFuncArgs, const float *alphaGenFuncArgs,
+	const vec3_t entOrigin, const vec3_t entDist, const uint8_t *entityColor, 
+	const uint8_t *constColor, const float *rgbGenFuncArgs, const float *alphaGenFuncArgs,
 	const mat4_t texMatrix );
 
 void RP_UpdateViewUniforms( int elem, 

--- a/source/ref_gl/r_public.h
+++ b/source/ref_gl/r_public.h
@@ -61,7 +61,7 @@ typedef struct
 	void ( *Cmd_SetCompletionFunc )( const char *cmd_name, char **( *completion_func )( const char *partial ) );
 
 	unsigned int ( *Sys_Milliseconds )( void );
-	quint64 ( *Sys_Microseconds )( void );
+	uint64_t ( *Sys_Microseconds )( void );
 	void ( *Sys_Sleep )( unsigned int milliseconds );
 
 	int ( *FS_FOpenFile )( const char *filename, int *filenum, int mode );
@@ -87,7 +87,7 @@ typedef struct
 
 	struct cinematics_s *( *CIN_Open )( const char *name, unsigned int start_time, qboolean loop, qboolean *yuv, float *framerate );
 	qboolean ( *CIN_NeedNextFrame )( struct cinematics_s *cin, unsigned int curtime );
-	qbyte *( *CIN_ReadNextFrame )( struct cinematics_s *cin, int *width, int *height, 
+	uint8_t *( *CIN_ReadNextFrame )( struct cinematics_s *cin, int *width, int *height, 
 		int *aspect_numerator, int *aspect_denominator, qboolean *redraw );
 	ref_yuv_t *( *CIN_ReadNextFrameYUV )( struct cinematics_s *cin, int *width, int *height, 
 		int *aspect_numerator, int *aspect_denominator, qboolean *redraw );
@@ -149,7 +149,7 @@ typedef struct
 	void		( *RegisterWorldModel )( const char *model, const dvis_t *pvsData );
 	struct model_s *( *RegisterModel )( const char *name );
 	struct shader_s *( *RegisterPic )( const char *name );
-	struct shader_s *( *RegisterRawPic )( const char *name, int width, int height, qbyte *data );
+	struct shader_s *( *RegisterRawPic )( const char *name, int width, int height, uint8_t *data );
 	struct shader_s *( *RegisterLevelshot )( const char *name, struct shader_s *defaultShader, qboolean *matchesDefault );
 	struct shader_s *( *RegisterSkin )( const char *name );
 	struct skinfile_s *( *RegisterSkinFile )( const char *name );
@@ -172,7 +172,7 @@ typedef struct
 
 	// Passing NULL for data redraws last uploaded frame
 	void		( *DrawStretchRaw )( int x, int y, int w, int h, int cols, int rows, 
-									float s1, float t1, float s2, float t2, qbyte *data );
+									float s1, float t1, float s2, float t2, uint8_t *data );
 
 	// Passing NULL for yuv redraws last uploaded frame
 	void		( *DrawStretchRawYUV )( int x, int y, int w, int h, 

--- a/source/ref_gl/r_q3bsp.c
+++ b/source/ref_gl/r_q3bsp.c
@@ -62,13 +62,13 @@ BRUSHMODEL LOADING
 ===============================================================================
 */
 
-static qbyte *mod_base;
+static uint8_t *mod_base;
 static mbrushmodel_t *loadbmodel;
 
 /*
 * Mod_CheckDeluxemaps
 */
-static void Mod_CheckDeluxemaps( const lump_t *l, qbyte *lmData )
+static void Mod_CheckDeluxemaps( const lump_t *l, uint8_t *lmData )
 {
 	int i, j;
 	int surfaces, lightmap;
@@ -183,7 +183,7 @@ static void Mod_LoadVertexes( const lump_t *l )
 	int i, count, j;
 	dvertex_t *in;
 	float *out_xyz, *out_normals, *out_st, *out_lmst;
-	qbyte *buffer, *out_colors;
+	uint8_t *buffer, *out_colors;
 	size_t bufSize;
 	vec3_t color;
 	float div = ( 1 << mapConfig.overbrightBits ) * (mapConfig.lightingIntensity ? mapConfig.lightingIntensity : 1.0f) / 255.0f;
@@ -249,9 +249,9 @@ static void Mod_LoadVertexes( const lump_t *l )
 				color[0] = color[1] = color[2] = bound( 0, grey, 1 );
 			}
 
-			out_colors[0] = ( qbyte )( color[0] * 255 );
-			out_colors[1] = ( qbyte )( color[1] * 255 );
-			out_colors[2] = ( qbyte )( color[2] * 255 );
+			out_colors[0] = ( uint8_t )( color[0] * 255 );
+			out_colors[1] = ( uint8_t )( color[1] * 255 );
+			out_colors[2] = ( uint8_t )( color[2] * 255 );
 			out_colors[3] = in->color[3];
 		}
 	}
@@ -265,7 +265,7 @@ static void Mod_LoadVertexes_RBSP( const lump_t *l )
 	int i, count, j;
 	rdvertex_t *in;
 	float *out_xyz, *out_normals, *out_st, *out_lmst[MAX_LIGHTMAPS];
-	qbyte *buffer, *out_colors[MAX_LIGHTMAPS];
+	uint8_t *buffer, *out_colors[MAX_LIGHTMAPS];
 	size_t bufSize;
 	vec3_t color;
 	float div = ( 1 << mapConfig.overbrightBits ) * (mapConfig.lightingIntensity ? mapConfig.lightingIntensity : 1.0f) / 255.0f;
@@ -334,9 +334,9 @@ static void Mod_LoadVertexes_RBSP( const lump_t *l )
 					color[0] = color[1] = color[2] = bound( 0, grey, 1 );
 				}
 
-				out_colors[j][0] = ( qbyte )( color[0] * 255 );
-				out_colors[j][1] = ( qbyte )( color[1] * 255 );
-				out_colors[j][2] = ( qbyte )( color[2] * 255 );
+				out_colors[j][0] = ( uint8_t )( color[0] * 255 );
+				out_colors[j][1] = ( uint8_t )( color[1] * 255 );
+				out_colors[j][2] = ( uint8_t )( color[2] * 255 );
 				out_colors[j][3] = in->color[j][3];
 			}
 		}
@@ -361,7 +361,7 @@ static void Mod_LoadSubmodels( const lump_t *l )
 	out = Mod_Malloc( loadmodel, count*sizeof( *out ) );
 
 	mod_inline = Mod_Malloc( loadmodel, count*( sizeof( *mod_inline )+sizeof( *bmodel ) ) );
-	loadmodel->extradata = bmodel = ( mbrushmodel_t * )( ( qbyte * )mod_inline + count*sizeof( *mod_inline ) );
+	loadmodel->extradata = bmodel = ( mbrushmodel_t * )( ( uint8_t * )mod_inline + count*sizeof( *mod_inline ) );
 
 	loadbmodel = bmodel;
 	loadbmodel->submodels = out;
@@ -477,7 +477,7 @@ static int Mod_AddUpdatePatchGroup( const rdface_t *in )
 static mesh_t *Mod_CreateMeshForSurface( const rdface_t *in, msurface_t *out, int faceNum )
 {
 	mesh_t *mesh = NULL;
-	qbyte *buffer;
+	uint8_t *buffer;
 	size_t bufSize, bufPos = 0;
 
 	switch( out->facetype )
@@ -490,7 +490,7 @@ static mesh_t *Mod_CreateMeshForSurface( const rdface_t *in, msurface_t *out, in
 			int inFirstVert;
 			qboolean hasLightmap[MAX_LIGHTMAPS];
 			int numattribs = 0;
-			qbyte *attribs[2 + MAX_LIGHTMAPS * 2];
+			uint8_t *attribs[2 + MAX_LIGHTMAPS * 2];
 			int attribsizes[2 + MAX_LIGHTMAPS * 2];
 			elem_t *elems;
 
@@ -536,7 +536,7 @@ static mesh_t *Mod_CreateMeshForSurface( const rdface_t *in, msurface_t *out, in
 			for( j = 0; j < MAX_LIGHTMAPS && in->vertexStyles[j] != 255; j++ )
 				bufSize += numVerts * sizeof( byte_vec4_t );
 			bufSize = ALIGN( bufSize, sizeof( elem_t ) ) + numElems * sizeof( elem_t );
-			buffer = ( qbyte * )Mod_Malloc( loadmodel, bufSize );
+			buffer = ( uint8_t * )Mod_Malloc( loadmodel, bufSize );
 			bufPos = 0;
 
 			mesh = ( mesh_t * )buffer; bufPos += MESH_T_SIZE_ALIGNED;
@@ -551,12 +551,12 @@ static mesh_t *Mod_CreateMeshForSurface( const rdface_t *in, msurface_t *out, in
 			Patch_Evaluate( vec_t, 3, loadmodel_xyz_array[inFirstVert], 
 				patch_cp, step, mesh->xyzArray[0], 4 );
 
-			attribs[numattribs] = ( qbyte * )mesh->normalsArray[0];
+			attribs[numattribs] = ( uint8_t * )mesh->normalsArray[0];
 			attribsizes[numattribs++] = sizeof( vec4_t );
 			Patch_Evaluate( vec_t, 3, loadmodel_normals_array[inFirstVert],
 				patch_cp, step, mesh->normalsArray[0], 4 );
 
-			attribs[numattribs] = ( qbyte * )mesh->stArray[0];
+			attribs[numattribs] = ( uint8_t * )mesh->stArray[0];
 			attribsizes[numattribs++] = sizeof( vec2_t );
 			Patch_Evaluate( vec_t, 2, loadmodel_st_array[inFirstVert], 
 				patch_cp, step, mesh->stArray[0], 0 );
@@ -564,7 +564,7 @@ static mesh_t *Mod_CreateMeshForSurface( const rdface_t *in, msurface_t *out, in
 			for( j = 0; j < MAX_LIGHTMAPS && hasLightmap[j]; j++ )
 			{
 				mesh->lmstArray[j] = ( vec2_t * )( buffer + bufPos ); bufPos += numVerts * sizeof( vec2_t );
-				attribs[numattribs] = ( qbyte * )mesh->lmstArray[j];
+				attribs[numattribs] = ( uint8_t * )mesh->lmstArray[j];
 				attribsizes[numattribs++] = sizeof( vec2_t );
 				Patch_Evaluate( vec_t, 2, loadmodel_lmst_array[j][inFirstVert], 
 					patch_cp, step, mesh->lmstArray[j][0], 0 );
@@ -585,9 +585,9 @@ static mesh_t *Mod_CreateMeshForSurface( const rdface_t *in, msurface_t *out, in
 			for( j = 0; j < MAX_LIGHTMAPS && in->vertexStyles[j] != 255; j++ )
 			{
 				mesh->colorsArray[j] = ( byte_vec4_t * )( buffer + bufPos ); bufPos += numVerts * sizeof( byte_vec4_t );
-				attribs[numattribs] = ( qbyte * )mesh->colorsArray[j];
+				attribs[numattribs] = ( uint8_t * )mesh->colorsArray[j];
 				attribsizes[numattribs++] = sizeof( byte_vec4_t );
-				Patch_Evaluate( qbyte, 4, loadmodel_colors_array[j][inFirstVert], 
+				Patch_Evaluate( uint8_t, 4, loadmodel_colors_array[j][inFirstVert], 
 					patch_cp, step, mesh->colorsArray[j][0], 0 );
 			}
 
@@ -753,7 +753,7 @@ static mesh_t *Mod_CreateMeshForSurface( const rdface_t *in, msurface_t *out, in
 				bufSize = ALIGN( bufSize, 16 ) + sizeof( cplane_t );
 			bufSize = ALIGN( bufSize, 16 ) + numFoliageInstances * sizeof( instancePoint_t );
 
-			buffer = ( qbyte * )Mod_Malloc( loadmodel, bufSize );
+			buffer = ( uint8_t * )Mod_Malloc( loadmodel, bufSize );
 			bufPos = 0;
 
 			mesh = ( mesh_t * )buffer; bufPos += MESH_T_SIZE_ALIGNED;
@@ -865,7 +865,7 @@ static inline void Mod_LoadFaceCommon( const rdface_t *in, msurface_t *out, int 
 	int shadernum, fognum;
 	mlightmapRect_t *lmRects[MAX_LIGHTMAPS];
 	int lightmaps[MAX_LIGHTMAPS];
-	qbyte lightmapStyles[MAX_LIGHTMAPS], vertexStyles[MAX_LIGHTMAPS];
+	uint8_t lightmapStyles[MAX_LIGHTMAPS], vertexStyles[MAX_LIGHTMAPS];
 
 	out->facetype = LittleLong( in->facetype );
 
@@ -1261,7 +1261,7 @@ static void Mod_LoadLeafs( const lump_t *l, const lump_t *msLump )
 	dleaf_t	*in;
 	mleaf_t	*out;
 	size_t size;
-	qbyte *buffer;
+	uint8_t *buffer;
 	qboolean badBounds;
 	int *inMarkSurfaces;
 	int numMarkSurfaces, firstMarkSurface;
@@ -1326,7 +1326,7 @@ static void Mod_LoadLeafs( const lump_t *l, const lump_t *msLump )
 		numFragmentSurfaces = numMarkSurfaces;
 
 		size = ((numVisSurfaces + 1) + (numFragmentSurfaces + 1)) * sizeof( msurface_t * );
-		buffer = ( qbyte * )Mod_Malloc( loadmodel, size );
+		buffer = ( uint8_t * )Mod_Malloc( loadmodel, size );
 
 		out->firstVisSurface = ( msurface_t ** )buffer;
 		buffer += ( numVisSurfaces + 1 ) * sizeof( msurface_t * );
@@ -1639,11 +1639,11 @@ static void Mod_ApplySuperStylesToFace( const rdface_t *in, msurface_t *out )
 {
 	int j, k;
 	float *lmArray;
-	qbyte *lmlayersArray;
+	uint8_t *lmlayersArray;
 	mesh_t *mesh = out->mesh;
 	mlightmapRect_t *lmRects[MAX_LIGHTMAPS];
 	int lightmaps[MAX_LIGHTMAPS];
-	qbyte lightmapStyles[MAX_LIGHTMAPS], vertexStyles[MAX_LIGHTMAPS];
+	uint8_t lightmapStyles[MAX_LIGHTMAPS], vertexStyles[MAX_LIGHTMAPS];
 
 	for( j = 0; j < MAX_LIGHTMAPS; j++ )
 	{
@@ -1719,7 +1719,7 @@ static void Mod_Finish( const lump_t *faces, const lump_t *light, vec3_t gridSiz
 	
 	// outline color
 	for( i = 0; i < 3; i++ )
-		mapConfig.outlineColor[i] = (qbyte)(bound( 0, outline[i]*255.0f, 255 ));
+		mapConfig.outlineColor[i] = (uint8_t)(bound( 0, outline[i]*255.0f, 255 ));
 	mapConfig.outlineColor[3] = 255;
 
 	R_SortSuperLightStyles( loadmodel );
@@ -1853,7 +1853,7 @@ void Mod_LoadQ3BrushModel( model_t *mod, model_t *parent, void *buffer, bspForma
 	mod_bspFormat = format;
 
 	header = (dheader_t *)buffer;
-	mod_base = (qbyte *)header;
+	mod_base = (uint8_t *)header;
 
 	// swap all the lumps
 	for( i = 0; i < sizeof( dheader_t )/4; i++ )

--- a/source/ref_gl/r_register.c
+++ b/source/ref_gl/r_register.c
@@ -1188,7 +1188,7 @@ static void R_GfxInfo_f( void )
 static unsigned R_GLVersionHash( const char *vendorString, 
 	const char *rendererString, const char *versionString )
 {
-	qbyte *tmp;
+	uint8_t *tmp;
 	size_t csize;
 	size_t tmp_size, pos;
 	unsigned hash;

--- a/source/ref_gl/r_shader.c
+++ b/source/ref_gl/r_shader.c
@@ -1725,7 +1725,7 @@ static void Shader_MakeCache( const char *filename )
 	char *token, *buf, *temp = NULL;
 	const char *ptr;
 	shadercache_t *cache;
-	qbyte *cacheMemBuf;
+	uint8_t *cacheMemBuf;
 	size_t cacheMemSize;
 
 	pathNameSize = strlen( "scripts/" ) + strlen( filename ) + 1;
@@ -1781,7 +1781,7 @@ static void Shader_MakeCache( const char *filename )
 
 		cache = ( shadercache_t * )cacheMemBuf; cacheMemBuf += sizeof( shadercache_t ) + strlen( token ) + 1;
 		cache->hash_next = shadercache_hash[key];
-		cache->name = ( char * )( (qbyte *)cache + sizeof( shadercache_t ) );
+		cache->name = ( char * )( (uint8_t *)cache + sizeof( shadercache_t ) );
 		strcpy( cache->name, token );
 		shadercache_hash[key] = cache;
 
@@ -1812,7 +1812,7 @@ static unsigned int Shader_GetCache( const char *name, shadercache_t **cache )
 	*cache = NULL;
 
 	len = strlen( name );
-	key = COM_SuperFastHash( ( const qbyte * )name, len, len ) % SHADERCACHE_HASH_SIZE;
+	key = COM_SuperFastHash( ( const uint8_t * )name, len, len ) % SHADERCACHE_HASH_SIZE;
 	for( c = shadercache_hash[key]; c; c = c->hash_next )
 	{
 		if( !Q_stricmp( c->name, name ) )
@@ -2220,7 +2220,7 @@ static void Shader_Finish( shader_t *s )
 	size_t size = 0, bufferOffset = 0;
 
 	shaderpass_t *pass;
-	qbyte *buffer;
+	uint8_t *buffer;
 	size_t deformvKeyLen;
 
 	deformvKeyLen = strlen( r_shaderDeformvKey );
@@ -2663,7 +2663,7 @@ create_default:
 			s->flags = SHADER_CULL_FRONT|SHADER_DEPTHWRITE;
 			s->numpasses = 1;
 			s->passes = ( shaderpass_t * )( data );
-			s->passes[0].rgbgen.args = ( float * )((qbyte *)data + ALIGN( sizeof( shaderpass_t ), 16 ));
+			s->passes[0].rgbgen.args = ( float * )((uint8_t *)data + ALIGN( sizeof( shaderpass_t ), 16 ));
 			s->name = ( char * )( s->passes[0].rgbgen.args + 4 );
 			strcpy( s->name, shortname );
 
@@ -2744,7 +2744,7 @@ shader_t *R_LoadShader( const char *name, shaderType_e type, qboolean forceDefau
 		return NULL;
 
 	// test if already loaded
-	key = COM_SuperFastHash( ( const qbyte *)shortname, nameLength, nameLength ) % SHADERS_HASH_SIZE;
+	key = COM_SuperFastHash( ( const uint8_t *)shortname, nameLength, nameLength ) % SHADERS_HASH_SIZE;
 	hnode = &r_shaders_hash_headnode[key];
 
 	// scan all instances of the same shader for exact match of the type
@@ -2799,7 +2799,7 @@ shader_t *R_RegisterPic( const char *name )
 *
 * Registers default 2D shader with base image provided as RGBA data.
 */
-shader_t *R_RegisterRawPic( const char *name, int width, int height, qbyte *data )
+shader_t *R_RegisterRawPic( const char *name, int width, int height, uint8_t *data )
 {
 	shader_t *s;
 

--- a/source/ref_gl/r_shader.h
+++ b/source/ref_gl/r_shader.h
@@ -250,7 +250,7 @@ typedef struct shader_s
 	deformv_t			*deforms;
 	char				*deformsKey;
 
-	qbyte				fog_color[4];
+	uint8_t				fog_color[4];
 	float				fog_dist, fog_clearDist;
 
 	unsigned int		cin;
@@ -286,7 +286,7 @@ shader_t	*R_LoadShader( const char *name, shaderType_e type, qboolean forceDefau
 
 shader_t	*R_RegisterShader( const char *name, shaderType_e type );
 shader_t	*R_RegisterPic( const char *name );
-shader_t	*R_RegisterRawPic( const char *name, int width, int height, qbyte *data );
+shader_t	*R_RegisterRawPic( const char *name, int width, int height, uint8_t *data );
 shader_t	*R_RegisterLevelshot( const char *name, shader_t *defaultShader, qboolean *matchesDefault );
 shader_t	*R_RegisterSkin( const char *name );
 shader_t	*R_RegisterVideo( const char *name );

--- a/source/ref_gl/r_shadow.h
+++ b/source/ref_gl/r_shadow.h
@@ -33,7 +33,7 @@ typedef struct shadowGroup_s
 
 	vec3_t				origin;
 	float				radius;
-	qbyte				*vis;
+	uint8_t				*vis;
 
 	vec3_t				lightDir;
 	vec4_t				lightAmbient;

--- a/source/ref_gl/r_skm.c
+++ b/source/ref_gl/r_skm.c
@@ -124,7 +124,7 @@ static int Mod_SkeletalModel_AddBlend( mskmodel_t *model, const mskblend_t *newb
 	for( i = 0; i < SKM_MAX_WEIGHTS; i++ ) {
 		for( j = i + 1; j < SKM_MAX_WEIGHTS; j++ ) {
 			if( t.weights[i] < t.weights[j] ) {
-				qbyte bi, bw;
+				uint8_t bi, bw;
 				bi = t.indices[i];
 				bw = t.weights[i];
 				t.indices[i] = t.indices[j];
@@ -158,9 +158,9 @@ void Mod_LoadSkeletalModel( model_t *mod, const model_t *parent, void *buffer, b
 {
 	unsigned int i, j, k;
 	size_t filesize;
-	qbyte *pbase;
+	uint8_t *pbase;
 	size_t memsize;
-	qbyte *pmem;
+	uint8_t *pmem;
 	iqmheader_t *header;
 	char *texts;
 	iqmvertexarray_t *vas, va;
@@ -173,7 +173,7 @@ void Mod_LoadSkeletalModel( model_t *mod, const model_t *parent, void *buffer, b
 	iqmmesh_t *inmeshes, inmesh;
 	iqmbounds_t *inbounds, inbound;
 	float *vposition, *vtexcoord, *vnormal, *vtangent;
-	qbyte *vblendindices_byte, *vblendweights_byte;
+	uint8_t *vblendindices_byte, *vblendweights_byte;
 	int *vblendindexes_int;
 	float *vblendweights_float;
 	mskmodel_t *poutmodel;
@@ -245,7 +245,7 @@ void Mod_LoadSkeletalModel( model_t *mod, const model_t *parent, void *buffer, b
 		goto error;
 	}
 
-	pbase = ( qbyte * )buffer;
+	pbase = ( uint8_t * )buffer;
 	filesize = header->filesize;
 
 	// check data offsets against the filesize
@@ -340,7 +340,7 @@ void Mod_LoadSkeletalModel( model_t *mod, const model_t *parent, void *buffer, b
 				if( va.size != SKM_MAX_WEIGHTS )
 					break;
 				if( va.format == IQM_BYTE || va.format == IQM_UBYTE ) {
-					vblendindices_byte = ( qbyte * )( pbase + va.offset );
+					vblendindices_byte = ( uint8_t * )( pbase + va.offset );
 				}
 				else if( va.format == IQM_INT || va.format == IQM_UINT ) {
 					vblendindexes_int = ( int * )( pbase + va.offset );
@@ -350,7 +350,7 @@ void Mod_LoadSkeletalModel( model_t *mod, const model_t *parent, void *buffer, b
 				if( va.size != SKM_MAX_WEIGHTS )
 					break;
 				if( va.format == IQM_UBYTE ) {
-					vblendweights_byte = ( qbyte * )( pbase + va.offset );
+					vblendweights_byte = ( uint8_t * )( pbase + va.offset );
 				}
 				else if( va.format == IQM_FLOAT ) {
 					vblendweights_float = ( float * )( pbase + va.offset );
@@ -581,12 +581,12 @@ void Mod_LoadSkeletalModel( model_t *mod, const model_t *parent, void *buffer, b
 	}
 
 	// blend indices
-	poutmodel->blendIndices = ( qbyte * )pmem; pmem += sizeof( *poutmodel->blendIndices ) * header->num_vertexes * SKM_MAX_WEIGHTS;
+	poutmodel->blendIndices = ( uint8_t * )pmem; pmem += sizeof( *poutmodel->blendIndices ) * header->num_vertexes * SKM_MAX_WEIGHTS;
 	if( vblendindices_byte ) {
-		memcpy( poutmodel->blendIndices, vblendindices_byte, sizeof( qbyte ) * header->num_vertexes * SKM_MAX_WEIGHTS );
+		memcpy( poutmodel->blendIndices, vblendindices_byte, sizeof( uint8_t ) * header->num_vertexes * SKM_MAX_WEIGHTS );
 	} else if( vblendindexes_int ) {
 		int bi[SKM_MAX_WEIGHTS];
-		qbyte *pbi = poutmodel->blendIndices;
+		uint8_t *pbi = poutmodel->blendIndices;
 		for( j = 0; j < header->num_vertexes; j++ ) {
 			memcpy( bi, &vblendindexes_int[j * SKM_MAX_WEIGHTS], sizeof( int ) * SKM_MAX_WEIGHTS );
 			for( k = 0; k < SKM_MAX_WEIGHTS; k++ ) {
@@ -596,13 +596,13 @@ void Mod_LoadSkeletalModel( model_t *mod, const model_t *parent, void *buffer, b
 	}
 
 	// blend weights
-	poutmodel->blendWeights = ( qbyte * )pmem; pmem += sizeof( *poutmodel->blendWeights ) * header->num_vertexes * SKM_MAX_WEIGHTS;
+	poutmodel->blendWeights = ( uint8_t * )pmem; pmem += sizeof( *poutmodel->blendWeights ) * header->num_vertexes * SKM_MAX_WEIGHTS;
 	if( vblendweights_byte ) {
-		memcpy( poutmodel->blendWeights, vblendweights_byte, sizeof( qbyte ) * header->num_vertexes * SKM_MAX_WEIGHTS );
+		memcpy( poutmodel->blendWeights, vblendweights_byte, sizeof( uint8_t ) * header->num_vertexes * SKM_MAX_WEIGHTS );
 	}
 	else if( vblendweights_float ) {
 		float bw[SKM_MAX_WEIGHTS];
-		qbyte *pbw = poutmodel->blendWeights;
+		uint8_t *pbw = poutmodel->blendWeights;
 		for( j = 0; j < header->num_vertexes; j++ ) {
 			memcpy( bw, &vblendweights_float[j * SKM_MAX_WEIGHTS], sizeof( float ) * SKM_MAX_WEIGHTS );
 			for( k = 0; k < SKM_MAX_WEIGHTS; k++ ) {
@@ -901,7 +901,7 @@ static float R_SkeletalModelLerpBBox( const entity_t *e, const model_t *mod, vec
 typedef struct skmcacheentry_s
 {
 	size_t size;
-	qbyte *data;
+	uint8_t *data;
 	struct skmcacheentry_s *next;
 } skmcacheentry_t;
 
@@ -927,7 +927,7 @@ void R_InitSkeletalCache( void )
 /*
 * R_SkeletalModelLerpBBox
 */
-static qbyte *R_GetSketalCache( int entNum, int lodNum )
+static uint8_t *R_GetSketalCache( int entNum, int lodNum )
 {
 	skmcacheentry_t *cache;
 	
@@ -946,7 +946,7 @@ static qbyte *R_GetSketalCache( int entNum, int lodNum )
 * all of the entries in the "allocation" list are moved to the "free" list, to be reused in the 
 * later function calls.
 */
-static qbyte *R_AllocSkeletalDataCache( int entNum, int lodNum, size_t size )
+static uint8_t *R_AllocSkeletalDataCache( int entNum, int lodNum, size_t size )
 {
 	size_t best_size;
 	skmcacheentry_t *cache, *prev;
@@ -1235,7 +1235,7 @@ qboolean R_DrawSkeletalSurf( const entity_t *e, const shader_t *shader, const mf
 	// fetch bones tranforms from cache (both matrices and dual quaternions)
 	bonePoseRelativeDQ = ( dualquat_t * )R_GetSketalCache( R_ENT2NUM( e ), mod->lodnum );
 	if( bonePoseRelativeDQ ) {
-		bonePoseRelativeMat = ( mat4_t * )(( qbyte * )bonePoseRelativeDQ + bonePoseRelativeDQSize);
+		bonePoseRelativeMat = ( mat4_t * )(( uint8_t * )bonePoseRelativeDQ + bonePoseRelativeDQSize);
 	}
 	else {
 		// lerp boneposes and store results in cache
@@ -1308,7 +1308,7 @@ qboolean R_DrawSkeletalSurf( const entity_t *e, const shader_t *shader, const mf
 
 		// CPU transforms
 		if( !hardwareTransform ) {
-			bonePoseRelativeMat = ( mat4_t * )(( qbyte * )bonePoseRelativeDQ + bonePoseRelativeDQSize);
+			bonePoseRelativeMat = ( mat4_t * )(( uint8_t * )bonePoseRelativeDQ + bonePoseRelativeDQSize);
 
 			// generate matrices for all bones
 			for( i = 0; i < skmodel->numbones; i++ ) {

--- a/source/ref_gl/r_sky.c
+++ b/source/ref_gl/r_sky.c
@@ -70,7 +70,7 @@ skydome_t *R_CreateSkydome( model_t *model )
 	int i, size;
 	mesh_t *mesh;
 	skydome_t *skydome;
-	qbyte *buffer;
+	uint8_t *buffer;
 
 	size = sizeof( skydome_t ) + sizeof( mesh_t ) * 6 +
 		sizeof( elem_t ) * ELEM_LEN * 6 +

--- a/source/ref_gl/r_surf.c
+++ b/source/ref_gl/r_surf.c
@@ -659,14 +659,14 @@ void R_DrawWorld( void )
 */
 void R_MarkLeaves( void )
 {
-	qbyte *pvs;
+	uint8_t *pvs;
 	unsigned int i;
 	int rdflags;
 	mleaf_t	*leaf, **pleaf;
 	mnode_t *node;
-	qbyte *areabits;
+	uint8_t *areabits;
 	int cluster;
-	qbyte fatpvs[MAX_MAP_LEAFS/8];
+	uint8_t fatpvs[MAX_MAP_LEAFS/8];
 
 	rdflags = rn.refdef.rdflags;
 	if( rdflags & RDF_NOWORLDMODEL )

--- a/source/ref_gl/r_vbo.c
+++ b/source/ref_gl/r_vbo.c
@@ -369,7 +369,7 @@ static void R_FillVertexBuffer ## intype ## outtype( intype *in, size_t size, \
 		for( j = 0; j < size; j++ ) { \
 			out[j] = conv( *in++ ); \
 		} \
-		out = ( outtype * )(( qbyte * )out + stride); \
+		out = ( outtype * )(( uint8_t * )out + stride); \
 	} \
 }
 
@@ -404,7 +404,7 @@ vattribmask_t R_UploadVBOVertexData( mesh_vbo_t *vbo, int vertsOffset,
 	size_t vertSize;
 	vattribmask_t errMask;
 	vattribmask_t hfa;
-	qbyte *data;
+	uint8_t *data;
 
 	assert( vbo != NULL );
 	assert( mesh != NULL );

--- a/source/sdl/sdl_lib.c
+++ b/source/sdl/sdl_lib.c
@@ -23,7 +23,7 @@ const char *Sys_Library_GetFullName( const char *name )
 /*
 * Sys_Library_GetGameLibPath
 */
-const char *Sys_Library_GetGameLibPath( const char *name, qint64 time, int randomizer )
+const char *Sys_Library_GetGameLibPath( const char *name, int64_t time, int randomizer )
 {
 	static char tempname[1024 * 10];
 	Q_snprintfz( tempname, sizeof( tempname ), "%s/%s/tempmodules_%lld_%d/%s", FS_WriteDirectory(), FS_GameDirectory(), time, randomizer, name );

--- a/source/sdl/sdl_time.c
+++ b/source/sdl/sdl_time.c
@@ -16,7 +16,7 @@ unsigned int Sys_Milliseconds( void )
 	return Sys_Microseconds() / 1000;
 }
 
-quint64 Sys_Microseconds( void )
+uint64_t Sys_Microseconds( void )
 {
 	return 1000000 * SDL_GetPerformanceCounter() / freq;
 }

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -81,8 +81,8 @@ struct edict_s
 	entity_shared_t	r;
 };
 
-#define EDICT_NUM( n ) ( (edict_t *)( (qbyte *)sv.gi.edicts + sv.gi.edict_size*( n ) ) )
-#define NUM_FOR_EDICT( e ) ( ( (qbyte *)( e )-(qbyte *)sv.gi.edicts ) / sv.gi.edict_size )
+#define EDICT_NUM( n ) ( (edict_t *)( (uint8_t *)sv.gi.edicts + sv.gi.edict_size*( n ) ) )
+#define NUM_FOR_EDICT( e ) ( ( (uint8_t *)( e )-(uint8_t *)sv.gi.edicts ) / sv.gi.edict_size )
 
 typedef struct
 {
@@ -92,7 +92,7 @@ typedef struct
 	int clientarea;
 	int numareas;
 	int areabytes;
-	qbyte *areabits;					// portalarea visibility bits
+	uint8_t *areabits;					// portalarea visibility bits
 	int numplayers;
 	int ps_size;
 	player_state_t *ps;                 // [numplayers]
@@ -106,7 +106,7 @@ typedef struct
 typedef struct
 {
 	char *name;
-	qbyte *data;            // file being downloaded
+	uint8_t *data;            // file being downloaded
 	int size;               // total bytes (can't use EOF because of paks)
 	unsigned int timeout;   // so we can free the file being downloaded
 	                        // if client omits sending success or failure message
@@ -245,8 +245,8 @@ typedef struct client_entities_s
 typedef struct fatvis_s
 {
 	vec_t *skyorg;
-	qbyte pvs[MAX_MAP_LEAFS/8];
-	qbyte phs[MAX_MAP_LEAFS/8];
+	uint8_t pvs[MAX_MAP_LEAFS/8];
+	uint8_t phs[MAX_MAP_LEAFS/8];
 } fatvis_t;
 
 typedef struct
@@ -303,7 +303,7 @@ typedef struct
 
 // shared message buffer to be used for occasional messages
 extern msg_t tmpMessage;
-extern qbyte tmpMessageData[MAX_MSGLEN];
+extern uint8_t tmpMessageData[MAX_MSGLEN];
 
 extern mempool_t *sv_mempool;
 
@@ -427,7 +427,7 @@ void SV_SendServerCommand( client_t *cl, const char *format, ... );
 void SV_AddGameCommand( client_t *client, const char *cmd );
 void SV_AddReliableCommandsToMessage( client_t *client, msg_t *msg );
 qboolean SV_SendClientsFragments( void );
-void SV_InitClientMessage( client_t *client, msg_t *msg, qbyte *data, size_t size );
+void SV_InitClientMessage( client_t *client, msg_t *msg, uint8_t *data, size_t size );
 qboolean SV_SendMessageToClient( client_t *client, msg_t *msg );
 void SV_ResetClientFrameCounters( void );
 

--- a/source/server/sv_ccmds.c
+++ b/source/server/sv_ccmds.c
@@ -270,7 +270,7 @@ void SV_AutoUpdateFromWeb( qboolean checkOnly )
 	unsigned int checksum;
 	qboolean success;
 	int length, filenum;
-	qbyte *data;
+	uint8_t *data;
 	const char *token, *ptr;
 	char path[MAX_QPATH];
 	int downloadCount = 0, downloadFailed = 0;

--- a/source/server/sv_demos.c
+++ b/source/server/sv_demos.c
@@ -55,7 +55,7 @@ void SV_Demo_WriteSnap( void )
 {
 	int i;
 	msg_t msg;
-	qbyte msg_buffer[MAX_MSGLEN];
+	uint8_t msg_buffer[MAX_MSGLEN];
 
 	if( !svs.demo.file )
 		return;

--- a/source/server/sv_game.c
+++ b/source/server/sv_game.c
@@ -371,12 +371,12 @@ static void PF_PureModel( const char *name )
 *
 * Also checks portalareas so that doors block sight
 */
-static qboolean PF_inVisSet( const vec3_t p1, const vec3_t p2, qbyte *( *vis )( cmodel_state_t *, int ) )
+static qboolean PF_inVisSet( const vec3_t p1, const vec3_t p2, uint8_t *( *vis )( cmodel_state_t *, int ) )
 {
 	int leafnum;
 	int cluster;
 	int area1, area2;
-	qbyte *mask;
+	uint8_t *mask;
 
 	leafnum = CM_PointLeafnum( svs.cms, p1 );
 	cluster = CM_LeafCluster( svs.cms, leafnum );

--- a/source/server/sv_main.c
+++ b/source/server/sv_main.c
@@ -190,7 +190,7 @@ static void SV_ReadPackets( void )
 	netadr_t address;
 
 	static msg_t msg;
-	static qbyte msgData[MAX_MSGLEN];
+	static uint8_t msgData[MAX_MSGLEN];
 
 #ifdef TCP_ALLOW_CONNECT
 	socket_t* tcpsockets [] =

--- a/source/server/sv_send.c
+++ b/source/server/sv_send.c
@@ -23,7 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 // shared message buffer to be used for occasional messages
 msg_t tmpMessage;
-qbyte tmpMessageData[MAX_MSGLEN];
+uint8_t tmpMessageData[MAX_MSGLEN];
 
 
 
@@ -312,7 +312,7 @@ qboolean SV_Netchan_Transmit( netchan_t *netchan, msg_t *msg )
 /*
 * SV_InitClientMessage
 */
-void SV_InitClientMessage( client_t *client, msg_t *msg, qbyte *data, size_t size )
+void SV_InitClientMessage( client_t *client, msg_t *msg, uint8_t *data, size_t size )
 {
 	if( client->edict && ( client->edict->r.svflags & SVF_FAKECLIENT ) )
 		return;

--- a/source/snd_common/snd_cmdque.c
+++ b/source/snd_common/snd_cmdque.c
@@ -342,7 +342,7 @@ void S_IssueAviDemoCmd( sndQueue_t *queue, qboolean begin )
 */
 void S_IssueRawSamplesCmd( sndQueue_t *queue, unsigned int samples, 
 	unsigned int rate, unsigned short width, unsigned short channels, 
-	qbyte *data, qboolean music )
+	uint8_t *data, qboolean music )
 {
 	sndRawSamplesCmd_t cmd;
 	cmd.id = SND_CMD_RAW_SAMPLES;
@@ -360,7 +360,7 @@ void S_IssueRawSamplesCmd( sndQueue_t *queue, unsigned int samples,
 */
 void S_IssuePositionedRawSamplesCmd( sndQueue_t *queue, int entnum, 
 	float fvol, float attenuation, unsigned int samples, unsigned int rate, 
-	unsigned short width, unsigned short channels, qbyte *data )
+	unsigned short width, unsigned short channels, uint8_t *data )
 {
 	sndPositionedRawSamplesCmd_t cmd;
 	cmd.id = SND_CMD_POSITIONED_RAW_SAMPLES;

--- a/source/snd_common/snd_cmdque.h
+++ b/source/snd_common/snd_cmdque.h
@@ -210,7 +210,7 @@ typedef struct
 	unsigned int rate;
 	unsigned short width;
 	unsigned short channels;
-	qbyte *data;
+	uint8_t *data;
 	qboolean music;
 } sndRawSamplesCmd_t;
 
@@ -224,7 +224,7 @@ typedef struct
 	unsigned int rate; 
 	unsigned short width;
 	unsigned short channels;
-	qbyte *data;
+	uint8_t *data;
 } sndPositionedRawSamplesCmd_t;
 
 typedef struct
@@ -269,10 +269,10 @@ void S_IssueActivateCmd( sndQueue_t *queue, qboolean active );
 void S_IssueAviDemoCmd( sndQueue_t *queue, qboolean begin );
 void S_IssueRawSamplesCmd( sndQueue_t *queue, unsigned int samples, 
 	unsigned int rate, unsigned short width, unsigned short channels, 
-	qbyte *data, qboolean music );
+	uint8_t *data, qboolean music );
 void S_IssuePositionedRawSamplesCmd( sndQueue_t *queue, int entnum, 
 	float fvol, float attenuation, unsigned int samples, unsigned int rate, 
-	unsigned short width, unsigned short channels, qbyte *data );
+	unsigned short width, unsigned short channels, uint8_t *data );
 void S_IssueStuffCmd( sndQueue_t *queue, const char *text );
 
 #endif // SND_CMDQUEUE_H

--- a/source/snd_openal/snd_decoder_ogg.c
+++ b/source/snd_openal/snd_decoder_ogg.c
@@ -139,14 +139,14 @@ static void decoder_ogg_stream_shutdown( snd_stream_t *stream )
 
 static size_t ovcb_read( void *ptr, size_t size, size_t nb, void *datasource )
 {
-	qintptr filenum = (qintptr) datasource;
+	intptr_t filenum = (intptr_t) datasource;
 
 	return trap_FS_Read( ptr, size * nb, (int) filenum ) / size;
 }
 
 static int ovcb_seek( void *datasource, ogg_int64_t offset, int whence )
 {
-	qintptr filenum = (qintptr) datasource;
+	intptr_t filenum = (intptr_t) datasource;
 
 	switch( whence )
 	{
@@ -160,7 +160,7 @@ static int ovcb_seek( void *datasource, ogg_int64_t offset, int whence )
 
 static int ovcb_close( void *datasource )
 {
-	qintptr filenum = (qintptr) datasource;
+	intptr_t filenum = (intptr_t) datasource;
 
 	trap_FS_FCloseFile( (int) filenum );
 	return 0;
@@ -168,7 +168,7 @@ static int ovcb_close( void *datasource )
 
 static long ovcb_tell( void *datasource )
 {
-	qintptr filenum = (qintptr) datasource;
+	intptr_t filenum = (intptr_t) datasource;
 
 	return trap_FS_Tell( (int) filenum );
 }
@@ -223,7 +223,7 @@ void *decoder_ogg_load( const char *filename, snd_info_t *info )
 		callbacks.tell_func = NULL;
 	}
 
-	if( qov_open_callbacks( (void *) (qintptr) filenum, &vorbisfile, NULL, 0, callbacks ) < 0 )
+	if( qov_open_callbacks( (void *) (intptr_t) filenum, &vorbisfile, NULL, 0, callbacks ) < 0 )
 	{
 		Com_Printf( "Could not open %s for reading\n", filename );
 		trap_FS_FCloseFile( filenum );
@@ -337,7 +337,7 @@ qboolean decoder_ogg_cont_open( snd_stream_t *stream )
 		callbacks.tell_func = NULL;
 	}
 
-	if( qov_open_callbacks( (void *) (qintptr) ogg_stream->filenum, ogg_stream->vorbisfile, NULL, 0, callbacks ) < 0 )
+	if( qov_open_callbacks( (void *) (intptr_t) ogg_stream->filenum, ogg_stream->vorbisfile, NULL, 0, callbacks ) < 0 )
 	{
 		Com_Printf( "Couldn't open .ogg file for reading\n" );
 		trap_FS_FCloseFile( ogg_stream->filenum );

--- a/source/snd_openal/snd_decoder_wav.c
+++ b/source/snd_openal/snd_decoder_wav.c
@@ -75,7 +75,7 @@ static int readChunkInfo( int f, char *name )
 static void skipChunk( int f, int length )
 {
 	size_t toread;
-	qbyte buffer[32*1024];
+	uint8_t buffer[32*1024];
 
 	while( length > 0 )
 	{
@@ -111,7 +111,7 @@ static int findWavChunk( int filenum, const char *chunk )
 	}
 }
 
-static void byteSwapRawSamples( int samples, int width, int channels, const qbyte *data )
+static void byteSwapRawSamples( int samples, int width, int channels, const uint8_t *data )
 {
 	int i;
 
@@ -223,7 +223,7 @@ void *decoder_wav_load( const char *filename, snd_info_t *info )
 		return NULL;
 	}
 
-	byteSwapRawSamples( info->samples, info->width, info->channels, (qbyte *)buffer );
+	byteSwapRawSamples( info->samples, info->width, info->channels, (uint8_t *)buffer );
 
 	trap_FS_FCloseFile( filenum );
 

--- a/source/snd_openal/snd_local.h
+++ b/source/snd_openal/snd_local.h
@@ -116,12 +116,12 @@ void S_AddLoopSound( struct sfx_s *sfx, int entnum, float fvol, float attenuatio
 
 // cinema
 void S_RawSamples( unsigned int samples, unsigned int rate, 
-	unsigned short width, unsigned short channels, const qbyte *data, qboolean music );
+	unsigned short width, unsigned short channels, const uint8_t *data, qboolean music );
 void S_RawSamples2( unsigned int samples, unsigned int rate, 
-	unsigned short width, unsigned short channels, const qbyte *data, qboolean music, float fvol );
+	unsigned short width, unsigned short channels, const uint8_t *data, qboolean music, float fvol );
 void S_PositionedRawSamples( int entnum, float fvol, float attenuation, 
 	unsigned int samples, unsigned int rate, 
-	unsigned short width, unsigned short channels, const qbyte *data );
+	unsigned short width, unsigned short channels, const uint8_t *data );
 unsigned int S_GetRawSamplesLength( void );
 unsigned int S_GetPositionedRawSamplesLength( int entnum );
 
@@ -287,7 +287,7 @@ void SF_Clear( void );
 void SF_AddLoopSound( sfx_t *sfx, int entnum, float fvol, float attenuation );
 void SF_Update( const vec3_t origin, const vec3_t velocity, const mat3_t axis, qboolean avidump );
 void SF_RawSamples( unsigned int samples, unsigned int rate, unsigned short width, 
-	unsigned short channels, const qbyte *data, qboolean music );
+	unsigned short channels, const uint8_t *data, qboolean music );
 void SF_PositionedRawSamples( int entnum, float fvol, float attenuation, 
 	unsigned int samples, unsigned int rate, 
-	unsigned short width, unsigned short channels, const qbyte *data );
+	unsigned short width, unsigned short channels, const uint8_t *data );

--- a/source/snd_openal/snd_main.c
+++ b/source/snd_openal/snd_main.c
@@ -436,10 +436,10 @@ void SF_Update( const vec3_t origin, const vec3_t velocity, const mat3_t axis, q
 * SF_RawSamples
 */
 void SF_RawSamples( unsigned int samples, unsigned int rate, unsigned short width, 
-	unsigned short channels, const qbyte *data, qboolean music )
+	unsigned short channels, const uint8_t *data, qboolean music )
 {
 	size_t data_size = samples * width * channels;
-	qbyte *data_copy = S_Malloc( data_size );
+	uint8_t *data_copy = S_Malloc( data_size );
 
 	memcpy( data_copy, data, data_size );
 
@@ -451,10 +451,10 @@ void SF_RawSamples( unsigned int samples, unsigned int rate, unsigned short widt
 */
 void SF_PositionedRawSamples( int entnum, float fvol, float attenuation, 
 	unsigned int samples, unsigned int rate, 
-	unsigned short width, unsigned short channels, const qbyte *data )
+	unsigned short width, unsigned short channels, const uint8_t *data )
 {
 	size_t data_size = samples * width * channels;
-	qbyte *data_copy = S_Malloc( data_size );
+	uint8_t *data_copy = S_Malloc( data_size );
 
 	memcpy( data_copy, data, data_size );
 

--- a/source/snd_openal/snd_music.c
+++ b/source/snd_openal/snd_music.c
@@ -52,7 +52,7 @@ static bgTrack_t *S_AllocTrack( const char *filename )
 	track = S_Malloc( sizeof( *track ) + strlen( filename ) + 1 );
 	track->stream = NULL;
 	track->ignore = qfalse;
-	track->filename = (char *)((qbyte *)track + sizeof( *track ));
+	track->filename = (char *)((uint8_t *)track + sizeof( *track ));
 	strcpy( track->filename, filename );
 	track->isUrl = trap_FS_IsUrl( filename );
 	track->anext = s_bgTrackHead;
@@ -379,7 +379,7 @@ static qboolean music_process( void )
 {
 	int l = 0;
 	snd_stream_t *music_stream;
-	qbyte decode_buffer[MUSIC_BUFFER_SIZE];
+	uint8_t decode_buffer[MUSIC_BUFFER_SIZE];
 
 	while( S_GetRawSamplesLength() < MUSIC_PRELOAD_MSEC )
 	{

--- a/source/snd_openal/snd_stream.c
+++ b/source/snd_openal/snd_stream.c
@@ -32,7 +32,7 @@ typedef struct
 } rawsrc_t;
 
 static size_t splitmixbuf_size = 0;
-static qbyte *splitmixbuf = NULL;
+static uint8_t *splitmixbuf = NULL;
 
 #define RAW_SOUND_ENTNUM	-9999
 #define MAX_RAW_SOUNDS		16
@@ -43,7 +43,7 @@ static rawsrc_t raw_sounds[MAX_RAW_SOUNDS];
 * Local helper functions
 */
 
-static const qbyte *split_stereo( unsigned samples, int width, const qbyte *data )
+static const uint8_t *split_stereo( unsigned samples, int width, const uint8_t *data )
 {
 	unsigned i;
 	size_t buf_size;
@@ -68,8 +68,8 @@ static const qbyte *split_stereo( unsigned samples, int width, const qbyte *data
 		return splitmixbuf;
 	}
 	else if( width == 1 ) {
-		qbyte *in = ( qbyte * )data;
-		qbyte *out = ( qbyte * )splitmixbuf;
+		uint8_t *in = ( uint8_t * )data;
+		uint8_t *out = ( uint8_t * )splitmixbuf;
 		for( i = 0; i < samples; i++ ) {
 			out[0] = in[0];
 			out[samples] = in[1];
@@ -200,7 +200,7 @@ void S_StopRawSamples( void )
 
 static void S_RawSamples_( int entNum, float fvol, float attenuation, 
 	unsigned int samples, unsigned int rate, unsigned short width,
-	unsigned short channels, const qbyte *data, cvar_t *volumeVar )
+	unsigned short channels, const uint8_t *data, cvar_t *volumeVar )
 {
 	ALuint buffer;
 	ALuint format;
@@ -271,7 +271,7 @@ static void S_RawSamples_( int entNum, float fvol, float attenuation,
 * S_RawSamples2
 */
 void S_RawSamples2( unsigned int samples, unsigned int rate, unsigned short width, 
-	unsigned short channels, const qbyte *data, qboolean music, float fvol )
+	unsigned short channels, const uint8_t *data, qboolean music, float fvol )
 {
 	S_RawSamples_( RAW_SOUND_ENTNUM, fvol, ATTN_NONE, samples, rate, width, 
 		channels, data, music ? s_musicvolume : s_volume );
@@ -281,7 +281,7 @@ void S_RawSamples2( unsigned int samples, unsigned int rate, unsigned short widt
 * Global functions (sound.h)
 */
 void S_RawSamples( unsigned int samples, unsigned int rate, unsigned short width, 
-	unsigned short channels, const qbyte *data, qboolean music )
+	unsigned short channels, const uint8_t *data, qboolean music )
 {
 	S_RawSamples_( RAW_SOUND_ENTNUM, 1, ATTN_NONE, samples, rate, width, 
 		channels, data, music ? s_musicvolume : s_volume );
@@ -292,7 +292,7 @@ void S_RawSamples( unsigned int samples, unsigned int rate, unsigned short width
 */
 void S_PositionedRawSamples( int entnum, float fvol, float attenuation, 
 		unsigned int samples, unsigned int rate, 
-		unsigned short width, unsigned short channels, const qbyte *data )
+		unsigned short width, unsigned short channels, const uint8_t *data )
 {
 	if( entnum < 0 ) {
 		entnum = 0;
@@ -303,8 +303,8 @@ void S_PositionedRawSamples( int entnum, float fvol, float attenuation,
 
 	// allocate separate sources because OpenAL doesn't spatialize stereo sounds
 	if( attenuation > 0 && channels == 2 ) {
-		const qbyte *split_data = split_stereo( samples, width, data );
-		const qbyte *left = split_data, *right = split_data + samples * width;
+		const uint8_t *split_data = split_stereo( samples, width, data );
+		const uint8_t *left = split_data, *right = split_data + samples * width;
 
 		S_RawSamples_( entnum, fvol, attenuation, samples, rate, width, 1, left, s_volume );
 		S_RawSamples_( -entnum, fvol, attenuation, samples, rate, width, 1, right, s_volume );

--- a/source/snd_openal/snd_syscalls.h
+++ b/source/snd_openal/snd_syscalls.h
@@ -171,7 +171,7 @@ static inline void trap_Sleep( unsigned int milliseconds )
 	SOUND_IMPORT.Sleep( milliseconds );
 }
 
-static inline void trap_PageInMemory( qbyte *buffer, int size )
+static inline void trap_PageInMemory( uint8_t *buffer, int size )
 {
 	SOUND_IMPORT.PageInMemory( buffer, size );
 }

--- a/source/snd_qf/snd_dma.c
+++ b/source/snd_qf/snd_dma.c
@@ -868,7 +868,7 @@ static rawsound_t *S_FindRawSound( int entnum, qboolean addNew )
 */
 static unsigned int S_RawSamplesStereo( portable_samplepair_t *rawsamples, unsigned int rawend,
 	unsigned int samples, unsigned int rate, unsigned short width, 
-	unsigned short channels, const qbyte *data )
+	unsigned short channels, const uint8_t *data )
 {
 	unsigned src, dst;
 	unsigned fracstep, samplefrac;
@@ -933,7 +933,7 @@ static unsigned int S_RawSamplesStereo( portable_samplepair_t *rawsamples, unsig
 * S_RawEntSamples
 */
 static void S_RawEntSamples( int entnum, unsigned int samples, unsigned int rate, unsigned short width, 
-	unsigned short channels, const qbyte *data, int snd_vol )
+	unsigned short channels, const uint8_t *data, int snd_vol )
 {
 	rawsound_t *rawsound;
 
@@ -956,7 +956,7 @@ static void S_RawEntSamples( int entnum, unsigned int samples, unsigned int rate
 * S_RawSamples2
 */
 void S_RawSamples2( unsigned int samples, unsigned int rate, unsigned short width, 
-	unsigned short channels, const qbyte *data, int snd_vol )
+	unsigned short channels, const uint8_t *data, int snd_vol )
 {
 	S_RawEntSamples( S_RAW_SOUND_BGTRACK, samples, rate, width, channels, data, snd_vol );
 }
@@ -965,7 +965,7 @@ void S_RawSamples2( unsigned int samples, unsigned int rate, unsigned short widt
 * S_RawSamples
 */
 void S_RawSamples( unsigned int samples, unsigned int rate, unsigned short width, 
-	unsigned short channels, const qbyte *data, qboolean music )
+	unsigned short channels, const uint8_t *data, qboolean music )
 {
 	int snd_vol;
 	int entnum;
@@ -989,7 +989,7 @@ void S_RawSamples( unsigned int samples, unsigned int rate, unsigned short width
 */
 static void S_PositionedRawSamples( int entnum, float fvol, float attenuation, 
 		unsigned int samples, unsigned int rate, 
-		unsigned short width, unsigned short channels, const qbyte *data )
+		unsigned short width, unsigned short channels, const uint8_t *data )
 {
 	rawsound_t *rawsound;
 	

--- a/source/snd_qf/snd_local.h
+++ b/source/snd_qf/snd_local.h
@@ -46,7 +46,7 @@ typedef struct
 	unsigned int speed;              // not needed, because converted on load?
 	unsigned short channels;
 	unsigned short width;
-	qbyte data[1];          // variable sized
+	uint8_t data[1];          // variable sized
 } sfxcache_t;
 
 typedef struct sfx_s
@@ -100,7 +100,7 @@ typedef struct
 	unsigned int samplebits;
 	unsigned int speed;
 	float msec_per_sample;
-	qbyte *buffer;
+	uint8_t *buffer;
 } dma_t;
 
 typedef struct
@@ -180,7 +180,7 @@ void S_NextBackgroundTrack( void );
 void S_UpdateBackgroundTrack( void );
 
 void S_RawSamples2( unsigned int samples, unsigned int rate, unsigned short width, 
-	unsigned short channels, const qbyte *data, int snd_vol );
+	unsigned short channels, const uint8_t *data, int snd_vol );
 unsigned int S_GetRawSamplesLength( void );
 unsigned int S_GetPositionedRawSamplesLength( int entnum );
 
@@ -259,8 +259,8 @@ extern struct mempool_s *soundpool;
 #define S_Malloc( size ) S_MemAlloc( soundpool, size )
 #define S_Free( data ) S_MemFree( data )
 
-wavinfo_t GetWavinfo( const char *name, qbyte *wav, int wavlength );
-unsigned int ResampleSfx( unsigned int numsamples, unsigned int speed, unsigned short channels, unsigned short width, const qbyte *data, qbyte *outdata, char *name );
+wavinfo_t GetWavinfo( const char *name, uint8_t *wav, int wavlength );
+unsigned int ResampleSfx( unsigned int numsamples, unsigned int speed, unsigned short channels, unsigned short width, const uint8_t *data, uint8_t *outdata, char *name );
 
 void S_InitScaletable( void );
 
@@ -301,10 +301,10 @@ void SF_Clear( void );
 void SF_AddLoopSound( sfx_t *sfx, int entnum, float fvol, float attenuation );
 void SF_Update( const vec3_t origin, const vec3_t velocity, const mat3_t axis, qboolean avidump );
 void SF_RawSamples( unsigned int samples, unsigned int rate, unsigned short width, 
-	unsigned short channels, const qbyte *data, qboolean music );
+	unsigned short channels, const uint8_t *data, qboolean music );
 void SF_PositionedRawSamples( int entnum, float fvol, float attenuation, 
 	unsigned int samples, unsigned int rate, 
-	unsigned short width, unsigned short channels, const qbyte *data );
+	unsigned short width, unsigned short channels, const uint8_t *data );
 
 //====================================================================
 

--- a/source/snd_qf/snd_main.c
+++ b/source/snd_qf/snd_main.c
@@ -526,10 +526,10 @@ void SF_Update( const vec3_t origin, const vec3_t velocity, const mat3_t axis, q
 * SF_RawSamples
 */
 void SF_RawSamples( unsigned int samples, unsigned int rate, unsigned short width, 
-	unsigned short channels, const qbyte *data, qboolean music )
+	unsigned short channels, const uint8_t *data, qboolean music )
 {
 	size_t data_size = samples * width * channels;
-	qbyte *data_copy = S_Malloc( data_size );
+	uint8_t *data_copy = S_Malloc( data_size );
 
 	memcpy( data_copy, data, data_size );
 
@@ -541,10 +541,10 @@ void SF_RawSamples( unsigned int samples, unsigned int rate, unsigned short widt
 */
 void SF_PositionedRawSamples( int entnum, float fvol, float attenuation, 
 	unsigned int samples, unsigned int rate, 
-	unsigned short width, unsigned short channels, const qbyte *data )
+	unsigned short width, unsigned short channels, const uint8_t *data )
 {
 	size_t data_size = samples * width * channels;
-	qbyte *data_copy = S_Malloc( data_size );
+	uint8_t *data_copy = S_Malloc( data_size );
 
 	memcpy( data_copy, data, data_size );
 

--- a/source/snd_qf/snd_mem.c
+++ b/source/snd_qf/snd_mem.c
@@ -24,7 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 /*
 * ResampleSfx
 */
-unsigned int ResampleSfx( unsigned int numsamples, unsigned int speed, unsigned short channels, unsigned short width, const qbyte *data, qbyte *outdata, char *name )
+unsigned int ResampleSfx( unsigned int numsamples, unsigned int speed, unsigned short channels, unsigned short width, const uint8_t *data, uint8_t *outdata, char *name )
 {
 	size_t srclength, outcount;
 
@@ -199,7 +199,7 @@ unsigned int ResampleSfx( unsigned int numsamples, unsigned int speed, unsigned 
 sfxcache_t *S_LoadSound_Wav( sfx_t *s )
 {
 	char namebuffer[MAX_QPATH];
-	qbyte *data;
+	uint8_t *data;
 	wavinfo_t info;
 	int len, file;
 	sfxcache_t *sc;
@@ -305,10 +305,10 @@ WAV loading
 */
 
 
-qbyte *data_p;
-qbyte *iff_end;
-qbyte *last_chunk;
-qbyte *iff_data;
+uint8_t *data_p;
+uint8_t *iff_end;
+uint8_t *last_chunk;
+uint8_t *iff_data;
 int iff_chunk_len;
 
 
@@ -368,7 +368,7 @@ static void FindChunk( char *name )
 /*
 * GetWavinfo
 */
-wavinfo_t GetWavinfo( const char *name, qbyte *wav, int wavlength )
+wavinfo_t GetWavinfo( const char *name, uint8_t *wav, int wavlength )
 {
 	wavinfo_t info;
 	int i;

--- a/source/snd_qf/snd_mix.c
+++ b/source/snd_qf/snd_mix.c
@@ -374,7 +374,7 @@ static void S_DumpPaintBuffer( int endtime, int file )
 	int len, count;
 	int in_mask;
 	unsigned int *pbuf;
-	qbyte *raw;
+	uint8_t *raw;
 
 	pbuf = (unsigned int *)dma.buffer;
 	count = ( endtime - paintedtime ) * dma.channels;

--- a/source/snd_qf/snd_music.c
+++ b/source/snd_qf/snd_music.c
@@ -165,7 +165,7 @@ static bgTrack_t *S_AllocTrack( const char *filename )
 
 	track = S_Malloc( sizeof( *track ) + strlen( filename ) + 1 );
 	track->ignore = qfalse;
-	track->filename = (char *)((qbyte *)track + sizeof( *track ));
+	track->filename = (char *)((uint8_t *)track + sizeof( *track ));
 	strcpy( track->filename, filename );
 	track->isUrl = trap_FS_IsUrl( track->filename );
 	track->anext = s_bgTrackHead;
@@ -653,7 +653,7 @@ void S_LockBackgroundTrack( qboolean lock )
 * byteSwapRawSamples
 * Medar: untested
 */
-static void byteSwapRawSamples( int samples, int width, int channels, const qbyte *data )
+static void byteSwapRawSamples( int samples, int width, int channels, const uint8_t *data )
 {
 	int i;
 
@@ -678,7 +678,7 @@ void S_UpdateBackgroundTrack( void )
 	int samples, maxSamples;
 	int read, maxRead, total;
 	float scale;
-	qbyte data[MAX_RAW_SAMPLES*4];
+	uint8_t data[MAX_RAW_SAMPLES*4];
 
 	if( !s_bgTrack )
 		return;

--- a/source/snd_qf/snd_ogg.c
+++ b/source/snd_qf/snd_ogg.c
@@ -107,7 +107,7 @@ void SNDOGG_Init( qboolean verbose )
 */
 static size_t ovcb_read( void *ptr, size_t size, size_t nb, void *datasource )
 {
-	qintptr filenum = (qintptr) datasource;
+	intptr_t filenum = (intptr_t) datasource;
 
 	return trap_FS_Read( ptr, size * nb, filenum ) / size;
 }
@@ -117,7 +117,7 @@ static size_t ovcb_read( void *ptr, size_t size, size_t nb, void *datasource )
 */
 static int ovcb_seek( void *datasource, ogg_int64_t offset, int whence )
 {
-	qintptr filenum = (qintptr) datasource;
+	intptr_t filenum = (intptr_t) datasource;
 
 	switch( whence )
 	{
@@ -137,7 +137,7 @@ static int ovcb_seek( void *datasource, ogg_int64_t offset, int whence )
 */
 static int ovcb_close( void *datasource )
 {
-	qintptr filenum = (qintptr) datasource;
+	intptr_t filenum = (intptr_t) datasource;
 
 	trap_FS_FCloseFile( (int) filenum );
 	return 0;
@@ -148,7 +148,7 @@ static int ovcb_close( void *datasource )
 */
 static long ovcb_tell( void *datasource )
 {
-	qintptr filenum = (qintptr) datasource;
+	intptr_t filenum = (intptr_t) datasource;
 
 	return trap_FS_Tell( filenum );
 }
@@ -186,7 +186,7 @@ sfxcache_t *SNDOGG_Load( sfx_t *s )
 		callbacks.tell_func = NULL;
 	}
 
-	if( qov_open_callbacks( (void *)(qintptr)filenum, &vorbisfile, NULL, 0, callbacks ) < 0 )
+	if( qov_open_callbacks( (void *)(intptr_t)filenum, &vorbisfile, NULL, 0, callbacks ) < 0 )
 	{
 		Com_Printf( "Couldn't open %s for reading: %s\n", s->name );
 		trap_FS_FCloseFile( filenum );
@@ -263,7 +263,7 @@ sfxcache_t *SNDOGG_Load( sfx_t *s )
 	}
 
 	if( sc->speed != dma.speed ) {
-		sc->length = ResampleSfx( samples, sc->speed, sc->channels, 2, (qbyte *)buffer, sc->data, s->name );
+		sc->length = ResampleSfx( samples, sc->speed, sc->channels, 2, (uint8_t *)buffer, sc->data, s->name );
 		sc->loopstart = sc->length;
 		sc->speed = dma.speed;
 	}
@@ -341,7 +341,7 @@ qboolean SNDOGG_OpenTrack( bgTrack_t *track, qboolean *delay )
 
 	track->vorbisFile = vf = S_Malloc( sizeof( OggVorbis_File ) );
 
-	if( qov_open_callbacks( (void *)(qintptr)track->file, vf, NULL, 0, callbacks ) < 0 )
+	if( qov_open_callbacks( (void *)(intptr_t)track->file, vf, NULL, 0, callbacks ) < 0 )
 	{
 		Com_Printf( "SNDOGG_OpenTrack: couldn't open %s for reading\n", real_path );
 		S_Free( vf );

--- a/source/snd_qf/snd_syscalls.h
+++ b/source/snd_qf/snd_syscalls.h
@@ -166,7 +166,7 @@ static inline unsigned int trap_Milliseconds( void )
 	return SOUND_IMPORT.Milliseconds();
 }
 
-static inline void trap_PageInMemory( qbyte *buffer, int size )
+static inline void trap_PageInMemory( uint8_t *buffer, int size )
 {
 	SOUND_IMPORT.PageInMemory( buffer, size );
 }

--- a/source/tv_server/tv_downstream.c
+++ b/source/tv_server/tv_downstream.c
@@ -447,7 +447,7 @@ void TV_Downstream_AddReliableCommandsToMessage( client_t *client, msg_t *msg )
 /*
 * TV_Downstream_InitClientMessage
 */
-void TV_Downstream_InitClientMessage( client_t *client, msg_t *msg, qbyte *data, size_t size )
+void TV_Downstream_InitClientMessage( client_t *client, msg_t *msg, uint8_t *data, size_t size )
 {
 	assert( client );
 
@@ -487,7 +487,7 @@ void TV_Downstream_DropClient( client_t *drop, int type, const char *format, ...
 	va_list	argptr;
 	char string[1024];
 	msg_t Message;
-	qbyte MessageData[MAX_MSGLEN];
+	uint8_t MessageData[MAX_MSGLEN];
 
 	va_start( argptr, format );
 	Q_vsnprintfz( string, sizeof( string ), format, argptr );
@@ -631,7 +631,7 @@ void TV_Downstream_ReadPackets( void )
 	socket_t *socket;
 	netadr_t address;
 	msg_t msg;
-	qbyte msgData[MAX_MSGLEN];
+	uint8_t msgData[MAX_MSGLEN];
 
 #ifdef TCP_ALLOW_CONNECT
 	socket_t* tcpsockets [] =
@@ -918,7 +918,7 @@ void TV_Downstream_SendClientMessages( void )
 	int i;
 	client_t *client;
 	msg_t message;
-	qbyte messageData[MAX_MSGLEN];
+	uint8_t messageData[MAX_MSGLEN];
 
 	// send a message to each connected client
 	for( i = 0, client = tvs.clients; i < tv_maxclients->integer; i++, client++ )

--- a/source/tv_server/tv_downstream.h
+++ b/source/tv_server/tv_downstream.h
@@ -35,7 +35,7 @@ void TV_Downstream_UserinfoChanged( client_t *cl );
 void TV_Downstream_AddServerCommand( client_t *client, const char *cmd );
 void TV_Downstream_SendServerCommand( client_t *cl, const char *format, ... );
 void TV_Downstream_AddReliableCommandsToMessage( client_t *client, msg_t *msg );
-void TV_Downstream_InitClientMessage( client_t *client, msg_t *msg, qbyte *data, size_t size );
+void TV_Downstream_InitClientMessage( client_t *client, msg_t *msg, uint8_t *data, size_t size );
 qboolean TV_Downstream_SendMessageToClient( client_t *client, msg_t *msg );
 void TV_Downstream_DropClient( client_t *drop, int type, const char *format, ... );
 void TV_Downstream_ReadPackets( void );

--- a/source/tv_server/tv_downstream_clcmd.c
+++ b/source/tv_server/tv_downstream_clcmd.c
@@ -71,7 +71,7 @@ void TV_Downstream_New_f( client_t *client )
 	int tv_bitflags;
 	purelist_t *iter;
 	msg_t message;
-	qbyte messageData[MAX_MSGLEN];
+	uint8_t messageData[MAX_MSGLEN];
 
 	// if in CS_AWAITING we have sended the response packet the new once already,
 	// but client might have not got it so we send it again
@@ -250,7 +250,7 @@ static void TV_Downstream_Baselines_f( client_t *client )
 	int start;
 	entity_state_t nullstate;
 	msg_t message;
-	qbyte messageData[MAX_MSGLEN];
+	uint8_t messageData[MAX_MSGLEN];
 
 	if( client->state != CS_CONNECTED )
 		return;
@@ -443,7 +443,7 @@ static void TV_Downstream_Channels_f( client_t *client )
 static void TV_Downstream_DenyDownload( client_t *client, const char *reason )
 {
 	msg_t message;
-	qbyte messageData[MAX_MSGLEN];
+	uint8_t messageData[MAX_MSGLEN];
 
 	assert( client );
 	assert( reason && reason[0] );

--- a/source/tv_server/tv_lobby.c
+++ b/source/tv_server/tv_lobby.c
@@ -42,7 +42,7 @@ static void TV_Lobby_WriteFrameSnapToClient( client_t *client, msg_t *msg )
 */
 static qboolean TV_Lobby_SendClientDatagram( client_t *client )
 {
-	qbyte msg_buf[MAX_MSGLEN];
+	uint8_t msg_buf[MAX_MSGLEN];
 	msg_t msg;
 
 	assert( client );

--- a/source/tv_server/tv_local.h
+++ b/source/tv_server/tv_local.h
@@ -80,7 +80,7 @@ typedef struct
 typedef struct
 {
 	char *name;
-	qbyte *data;            // file being downloaded
+	uint8_t *data;            // file being downloaded
 	int size;               // total bytes (can't use EOF because of paks)
 	unsigned int timeout;   // so we can free the file being downloaded
 	// if client omits sending success or failure message
@@ -94,7 +94,7 @@ typedef struct
 	int clientarea;
 	int numareas;
 	size_t areabytes;
-	qbyte *areabits;                // portalarea visibility bits
+	uint8_t *areabits;                // portalarea visibility bits
 	int numplayers;
 	int ps_size;
 	player_state_t *ps;                 // [numplayers]
@@ -181,7 +181,7 @@ typedef struct client_s
 	// The sounds datagram is written to by multicasted sound commands
 	// It can be harmlessly overflowed.
 	msg_t soundsmsg;
-	qbyte soundsmsgData[MAX_MSGLEN];
+	uint8_t soundsmsgData[MAX_MSGLEN];
 
 	client_snapshot_t snapShots[UPDATE_BACKUP]; // updates can be delta'd from here
 

--- a/source/tv_server/tv_module/tvm_client.h
+++ b/source/tv_server/tv_module/tvm_client.h
@@ -67,7 +67,7 @@ struct gclient_s
 
 	pmove_state_t old_pmove;            // for detecting out-of-pmove changes
 	int buttons;
-	qbyte plrkeys;                      // used for displaying key icons
+	uint8_t plrkeys;                      // used for displaying key icons
 	int timeDelta;                      // time offset to adjust for shots collision (antilag)
 };
 

--- a/source/tv_server/tv_module/tvm_misc.c
+++ b/source/tv_server/tv_module/tvm_misc.c
@@ -45,7 +45,7 @@ edict_t *TVM_FindLocal( tvm_relay_t *relay, const edict_t *start, size_t fieldof
 	{
 		if( !from->r.inuse )
 			continue;
-		s = *(char **) ( (qbyte *)from + fieldofs );
+		s = *(char **) ( (uint8_t *)from + fieldofs );
 		if( !s )
 			continue;
 		if( !Q_stricmp( s, match ) )

--- a/source/tv_server/tv_module/tvm_public.h
+++ b/source/tv_server/tv_module/tvm_public.h
@@ -87,7 +87,7 @@ typedef struct snapshot_s
 	qboolean multipov;
 	int deltaFrameNum;
 	size_t areabytes;
-	qbyte *areabits;             // portalarea visibility bits
+	uint8_t *areabits;             // portalarea visibility bits
 	int numplayers;
 	player_state_t playerState;
 	player_state_t playerStates[MAX_CLIENTS];

--- a/source/tv_server/tv_relay.h
+++ b/source/tv_server/tv_relay.h
@@ -23,11 +23,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "tv_local.h"
 
-#define EDICT_NUM( u, n ) ( (edict_t *)( (qbyte *)u->gi.edicts + u->gi.edict_size*( n ) ) )
-#define NUM_FOR_EDICT( u, e ) ( ( (qbyte *)( e )-(qbyte *)u->gi.edicts ) / u->gi.edict_size )
+#define EDICT_NUM( u, n ) ( (edict_t *)( (uint8_t *)u->gi.edicts + u->gi.edict_size*( n ) ) )
+#define NUM_FOR_EDICT( u, e ) ( ( (uint8_t *)( e )-(uint8_t *)u->gi.edicts ) / u->gi.edict_size )
 
-#define LOCAL_EDICT_NUM( u, n ) ( (edict_t *)( (qbyte *)u->gi.local_edicts + u->gi.local_edict_size*( n ) ) )
-#define NUM_FOR_LOCAL_EDICT( u, e ) ( ( (qbyte *)( e )-(qbyte *)u->gi.local_edicts ) / u->gi.local_edict_size )
+#define LOCAL_EDICT_NUM( u, n ) ( (edict_t *)( (uint8_t *)u->gi.local_edicts + u->gi.local_edict_size*( n ) ) )
+#define NUM_FOR_LOCAL_EDICT( u, e ) ( ( (uint8_t *)( e )-(uint8_t *)u->gi.local_edicts ) / u->gi.local_edict_size )
 
 typedef struct packet_s packet_t;
 
@@ -52,8 +52,8 @@ struct packet_s
 typedef struct fatvis_s
 {
 	vec_t *skyorg;
-	qbyte pvs[MAX_MAP_LEAFS/8];
-	qbyte phs[MAX_MAP_LEAFS/8];
+	uint8_t pvs[MAX_MAP_LEAFS/8];
+	uint8_t phs[MAX_MAP_LEAFS/8];
 } fatvis_t;
 
 typedef struct client_entities_s
@@ -100,7 +100,7 @@ struct relay_s
 	snapshot_t	*lastFrame;             // latest snap received from the server
 	snapshot_t	*curFrame;              // latest snap handled
 	snapshot_t	frames[UPDATE_BACKUP];
-	qbyte *frames_areabits;
+	uint8_t *frames_areabits;
 	unsigned int framenum;
 
 	client_entities_t client_entities;

--- a/source/tv_server/tv_relay_client.c
+++ b/source/tv_server/tv_relay_client.c
@@ -95,7 +95,7 @@ void TV_Relay_BuildClientFrameSnap( relay_t *relay, client_t *client )
 */
 static qboolean TV_Relay_SendClientDatagram( relay_t *relay, client_t *client )
 {
-	qbyte msg_buf[MAX_MSGLEN];
+	uint8_t msg_buf[MAX_MSGLEN];
 	msg_t msg;
 	snapshot_t *frame;
 

--- a/source/tv_server/tv_upstream.c
+++ b/source/tv_server/tv_upstream.c
@@ -229,7 +229,7 @@ static void TV_Upstream_WriteUcmdToMessage( upstream_t *upstream, msg_t *msg )
 static void TV_Upstream_SendMessagesToServer( upstream_t *upstream, qboolean sendNow )
 {
 	msg_t message;
-	qbyte messageData[MAX_MSGLEN];
+	uint8_t messageData[MAX_MSGLEN];
 	qboolean ucmd = qfalse;
 
 	if( upstream->demo.playing )
@@ -433,7 +433,7 @@ static void TV_Upstream_FreePackets( upstream_t *upstream )
 */
 static void TV_Upstream_ReadDemoMessage( upstream_t *upstream, int timeBias )
 {
-	static qbyte msgbuf[MAX_MSGLEN];
+	static uint8_t msgbuf[MAX_MSGLEN];
 	static msg_t demomsg;
 	qboolean init = qtrue;
 	int read;
@@ -518,7 +518,7 @@ static void TV_Upstream_ReadDemoPackets( upstream_t *upstream )
 static void TV_Upstream_ReadPackets( upstream_t *upstream )
 {
 	msg_t msg;
-	qbyte msgData[MAX_MSGLEN];
+	uint8_t msgData[MAX_MSGLEN];
 	int ret;
 	netadr_t address;
 

--- a/source/tv_server/tv_upstream_svcmd.c
+++ b/source/tv_server/tv_upstream_svcmd.c
@@ -31,7 +31,7 @@ static void TV_Upstream_HandleConfigstring( upstream_t *upstream, int index, con
 {
 	char hostname[MAX_CONFIGSTRING_CHARS];
 	msg_t msg;
-	qbyte msgbuf[MAX_MSGLEN];
+	uint8_t msgbuf[MAX_MSGLEN];
 
 	if( !val || !val[0] )
 		return;

--- a/source/ui/datasources/ui_serverbrowser_datasource.cpp
+++ b/source/ui/datasources/ui_serverbrowser_datasource.cpp
@@ -552,7 +552,7 @@ void ServerBrowserDataSource::addServerToTable( ServerInfo &info, String tableNa
 
 	// Show/sort with referenceList
 	ReferenceList::iterator it = find_if( referenceList,
-							ServerInfo::EqualUnary<quint64, &ServerInfo::iaddress>( info.iaddress ) );
+							ServerInfo::EqualUnary<uint64_t, &ServerInfo::iaddress>( info.iaddress ) );
 
 	if( it == referenceList.end() ) {
 		// server isnt in the list, use insertion sort to put it in
@@ -578,7 +578,7 @@ void ServerBrowserDataSource::removeServerFromTable( ServerInfo &info, String ta
 
 	// notify rocket + remove from referenceList
 	ReferenceList::iterator it = find_if( referenceList,
-							ServerInfo::EqualUnary<quint64, &ServerInfo::iaddress>( info.iaddress ) );
+							ServerInfo::EqualUnary<uint64_t, &ServerInfo::iaddress>( info.iaddress ) );
 
 	if( it != referenceList.end() ) {
 		int index = std::distance( referenceList.begin(), it );
@@ -913,11 +913,11 @@ void ServerBrowserDataSource::filtersUpdated(void)
 
 }
 
-void ServerBrowserDataSource::notifyOfFavoriteChange( quint64 iaddr, bool add )
+void ServerBrowserDataSource::notifyOfFavoriteChange( uint64_t iaddr, bool add )
 {
 	// lets see if the server is already in our serverlist
 	ServerInfoList::iterator it_s = find_if( serverList,
-		ServerInfo::EqualUnary<quint64, &ServerInfo::iaddress>( iaddr ) );
+		ServerInfo::EqualUnary<uint64_t, &ServerInfo::iaddress>( iaddr ) );
 
 	if( it_s == serverList.end() ) {
 		return;
@@ -935,7 +935,7 @@ void ServerBrowserDataSource::notifyOfFavoriteChange( quint64 iaddr, bool add )
 	ReferenceList &referenceList = referenceListMap[tableName];
 
 	ReferenceList::iterator it = find_if( referenceList,
-							ServerInfo::EqualUnary<quint64, &ServerInfo::iaddress>( iaddr ) );
+							ServerInfo::EqualUnary<uint64_t, &ServerInfo::iaddress>( iaddr ) );
 	if( it != referenceList.end() ) {
 		NotifyRowChange( tableName, std::distance( referenceList.begin(), it ), 1 );
 	}
@@ -951,7 +951,7 @@ void ServerBrowserDataSource::notifyOfFavoriteChange( quint64 iaddr, bool add )
 
 bool ServerBrowserDataSource::addFavorite( const char *fav )
 {
-	quint64 iaddr = addr_to_int( fav );
+	uint64_t iaddr = addr_to_int( fav );
 
 	// is that address already favorited?
 	FavoritesList::const_iterator it_f = favorites.find( iaddr );
@@ -969,7 +969,7 @@ bool ServerBrowserDataSource::addFavorite( const char *fav )
 
 bool ServerBrowserDataSource::removeFavorite( const char *fav )
 {
-	quint64 iaddr = addr_to_int( fav );
+	uint64_t iaddr = addr_to_int( fav );
 
 	FavoritesList::const_iterator it_f = favorites.find( iaddr );
 	if( it_f == favorites.end() ) {

--- a/source/ui/datasources/ui_serverbrowser_datasource.h
+++ b/source/ui/datasources/ui_serverbrowser_datasource.h
@@ -40,7 +40,7 @@ namespace WSWUI {
 	public:
 		// Attributes
 		std::string		address;
-		quint64			iaddress;
+		uint64_t			iaddress;
 
 		std::string		hostname;
 		std::string		cleanname;
@@ -264,10 +264,10 @@ namespace WSWUI {
 	{
 		// typedefs
 		// use set for serverinfo list to keep unique elements
-		typedef std::set<ServerInfo, ServerInfo::_LessBinary<quint64, &ServerInfo::iaddress> > ServerInfoList;
+		typedef std::set<ServerInfo, ServerInfo::_LessBinary<uint64_t, &ServerInfo::iaddress> > ServerInfoList;
 		typedef std::list<ServerInfo*> ReferenceList;
 		typedef std::map<String, ReferenceList> ReferenceListMap;
-		typedef std::set<quint64> FavoritesList;
+		typedef std::set<uint64_t> FavoritesList;
 
 		// shortcut for the set insert
 		typedef std::pair<ServerInfoList::iterator, bool> ServerInfoListPair;
@@ -417,7 +417,7 @@ namespace WSWUI {
 		void tableNameForServerInfo( const ServerInfo &, String &table ) const;
 		void addServerToTable( ServerInfo &info, String tableName );
 		void removeServerFromTable( ServerInfo &info, String tableName );
-		void notifyOfFavoriteChange( quint64 iaddr, bool add );
+		void notifyOfFavoriteChange( uint64_t iaddr, bool add );
 	};
 
 }

--- a/source/ui/kernel/ui_boneposes.cpp
+++ b/source/ui/kernel/ui_boneposes.cpp
@@ -35,7 +35,7 @@ cgs_skeleton_t *UI_BonePoses::SkeletonForModel( struct model_s *model )
 {
 	int i, j;
 	cgs_skeleton_t *skel;
-	qbyte *buffer;
+	uint8_t *buffer;
 	cgs_bone_t *bone;
 	bonepose_t *bonePose;
 	int numBones, numFrames;
@@ -54,7 +54,7 @@ cgs_skeleton_t *UI_BonePoses::SkeletonForModel( struct model_s *model )
 	}
 
 	// allocate one huge array to hold our data
-	buffer = (qbyte *)__operator_new__( sizeof( cgs_skeleton_t ) + numBones * sizeof( cgs_bone_t ) +
+	buffer = (uint8_t *)__operator_new__( sizeof( cgs_skeleton_t ) + numBones * sizeof( cgs_bone_t ) +
 		numFrames * ( sizeof( bonepose_t * ) + numBones * sizeof( bonepose_t ) ) );
 
 	skel = ( cgs_skeleton_t * )buffer; buffer += sizeof( cgs_skeleton_t );

--- a/source/ui/kernel/ui_renderinterface.cpp
+++ b/source/ui/kernel/ui_renderinterface.cpp
@@ -116,7 +116,7 @@ bool UI_RenderInterface::GenerateTexture(Rocket::Core::TextureHandle & texture_h
 	Rocket::Core::String name( MAX_QPATH, "ui_raw_%d", texCounter++ );
 
 	// Com_Printf("RenderInterface::GenerateTexture: going to register %s %dx%d\n", name.CString(), source_dimensions.x, source_dimensions.y );
-	shader = trap::R_RegisterRawPic( name.CString(), source_dimensions.x, source_dimensions.y, (qbyte*)source );
+	shader = trap::R_RegisterRawPic( name.CString(), source_dimensions.x, source_dimensions.y, (uint8_t*)source );
 	if( !shader )
 	{
 		Com_Printf(S_COLOR_RED"Warning: RenderInterface couldnt register raw pic %s!\n", name.CString() );

--- a/source/ui/kernel/ui_streamcache.cpp
+++ b/source/ui/kernel/ui_streamcache.cpp
@@ -281,7 +281,7 @@ std::string StreamCache::CacheFileForUrl( const std::string url, bool noCache )
 	std::string fileName;
 
 	// compute hash key for the URL and convert to hex
-	hashkey = md5_digest32( ( const qbyte * )url.c_str(), url.size() );
+	hashkey = md5_digest32( ( const uint8_t * )url.c_str(), url.size() );
 	std::stringstream outstream;
 	outstream << std::hex << hashkey;	// to hex
 

--- a/source/ui/kernel/ui_syscalls.h
+++ b/source/ui/kernel/ui_syscalls.h
@@ -98,7 +98,7 @@ namespace trap
 			return UI_IMPORT.R_RegisterPic( name );
 		}
 
-		inline struct shader_s *R_RegisterRawPic( const char *name, int width, int height, qbyte *data ) {
+		inline struct shader_s *R_RegisterRawPic( const char *name, int width, int height, uint8_t *data ) {
 			return UI_IMPORT.R_RegisterRawPic( name, width, height, data );
 		}
 

--- a/source/ui/kernel/ui_utils.cpp
+++ b/source/ui/kernel/ui_utils.cpp
@@ -51,18 +51,18 @@ std::string hex2rgb( const char *hexstr )
 
 //==============================================================
 
-const char *int_to_addr( quint64 r )
+const char *int_to_addr( uint64_t r )
 {
 	return va( "%d.%d.%d.%d:%d", r&0xff, (r>>8)&0xff, (r>>16)&0xff, (r>>24)&0xff, (r>>32)&0xffff );
 }
 
-quint64 addr_to_int( const std::string &adr )
+uint64_t addr_to_int( const std::string &adr )
 {
-	quint64 r = 0, acc = 0, dots = 0;
+	uint64_t r = 0, acc = 0, dots = 0;
 
 	for( size_t i = 0; i < adr.size(); i++ )
 	{
-		quint64 c = adr[i];
+		uint64_t c = adr[i];
 		if( c == '.' || c == ':' )
 		{
 			// add to result and reset part

--- a/source/ui/kernel/ui_utils.h
+++ b/source/ui/kernel/ui_utils.h
@@ -137,7 +137,7 @@ namespace WSWUI
 	// simple benchmark timer class
 	struct BenchmarkTimer
 	{
-		quint64 start;
+		uint64_t start;
 		// constructor grabs current time automatically
 		BenchmarkTimer() : start(trap::Microseconds()) {}
 		// fetch current timedelta
@@ -206,8 +206,8 @@ namespace WSWUI
 	extern std::string rgb2hex( const char *rgbstr );
 	extern std::string hex2rgb( const char *hexstr );
 
-	extern const char *int_to_addr( quint64 r );
-	extern quint64 addr_to_int( const std::string &adr );
+	extern const char *int_to_addr( uint64_t r );
+	extern uint64_t addr_to_int( const std::string &adr );
 
 	//======================================
 

--- a/source/ui/ui_public.h
+++ b/source/ui/ui_public.h
@@ -82,7 +82,7 @@ typedef struct
 	struct model_s *( *R_RegisterModel )( const char *name );
 	struct shader_s *( *R_RegisterSkin )( const char *name );
 	struct shader_s *( *R_RegisterPic )( const char *name );
-	struct shader_s *( *R_RegisterRawPic )( const char *name, int width, int height, qbyte *data );
+	struct shader_s *( *R_RegisterRawPic )( const char *name, int width, int height, uint8_t *data );
 	struct shader_s *( *R_RegisterLevelshot )( const char *name, struct shader_s *defaultPic, qboolean *matchesDefault );
 	struct skinfile_s *( *R_RegisterSkinFile )( const char *name );
 	struct shader_s *( *R_RegisterVideo )( const char *name );
@@ -137,7 +137,7 @@ typedef struct
 
 	void ( *GetConfigString )( int i, char *str, int size );
 	unsigned int ( *Milliseconds )( void );
-	quint64 ( *Microseconds )( void );
+	uint64_t ( *Microseconds )( void );
 
 	// files will be memory mapped read only
 	// the returned buffer may be part of a larger pak file,

--- a/source/unix/unix_lib.c
+++ b/source/unix/unix_lib.c
@@ -47,7 +47,7 @@ const char *Sys_Library_GetFullName( const char *name )
 /*
 * Sys_Library_GetGameLibPath
 */
-const char *Sys_Library_GetGameLibPath( const char *name, qint64 time, int randomizer )
+const char *Sys_Library_GetGameLibPath( const char *name, int64_t time, int randomizer )
 {
 	static char tempname[PATH_MAX];
 	Q_snprintfz( tempname, sizeof(tempname), "%s/%s/tempmodules_%lld_%d/%s", FS_WriteDirectory(), FS_GameDirectory(),

--- a/source/unix/unix_time.c
+++ b/source/unix/unix_time.c
@@ -5,7 +5,7 @@
 * Sys_Microseconds
 */
 static unsigned long sys_secbase;
-quint64 Sys_Microseconds( void )
+uint64_t Sys_Microseconds( void )
 {
 	struct timeval tp;
 	struct timezone tzp;
@@ -19,7 +19,7 @@ quint64 Sys_Microseconds( void )
 	}
 
 	// TODO handle the wrap
-	return (quint64)( tp.tv_sec - sys_secbase )*1000000 + tp.tv_usec;
+	return (uint64_t)( tp.tv_sec - sys_secbase )*1000000 + tp.tv_usec;
 }
 
 /*

--- a/source/win32/conproc.c
+++ b/source/win32/conproc.c
@@ -99,19 +99,19 @@ void InitConProc( int argc, char **argv )
 	if( ( t = CCheckParm( "-HFILE" ) ) > 0 )
 	{
 		if( t < argc )
-			hFile = (HANDLE) (qintptr) atol( ccom_argv[t+1] );
+			hFile = (HANDLE) (intptr_t) atol( ccom_argv[t+1] );
 	}
 
 	if( ( t = CCheckParm( "-HPARENT" ) ) > 0 )
 	{
 		if( t < argc )
-			heventParent = (HANDLE) (qintptr) atol( ccom_argv[t+1] );
+			heventParent = (HANDLE) (intptr_t) atol( ccom_argv[t+1] );
 	}
 
 	if( ( t = CCheckParm( "-HCHILD" ) ) > 0 )
 	{
 		if( t < argc )
-			heventChild = (HANDLE) (qintptr) atol( ccom_argv[t+1] );
+			heventChild = (HANDLE) (intptr_t) atol( ccom_argv[t+1] );
 	}
 
 

--- a/source/win32/win_lib.c
+++ b/source/win32/win_lib.c
@@ -43,7 +43,7 @@ const char *Sys_Library_GetFullName( const char *name )
 /*
 * Sys_Library_GetGameLibPath
 */
-const char *Sys_Library_GetGameLibPath( const char *name, qint64 time, int randomizer )
+const char *Sys_Library_GetGameLibPath( const char *name, int64_t time, int randomizer )
 {
 	static char tempname[MAX_PATH];
 	Q_snprintfz( tempname, sizeof(tempname), "%s/%s/tempmodules_%lld_%d/%s", FS_WriteDirectory(), FS_GameDirectory(),

--- a/source/win32/win_time.c
+++ b/source/win32/win_time.c
@@ -3,12 +3,12 @@
 
 static qboolean hwtimer;
 static dynvar_t *hwtimer_var;
-static quint64 hwtimer_freq;
+static uint64_t hwtimer_freq;
 static int milli_offset = 0;
-static qint64 micro_offset = 0;
+static int64_t micro_offset = 0;
 
 static unsigned int Sys_Milliseconds_TGT( void );
-static quint64 Sys_Microseconds_QPC( void );
+static uint64_t Sys_Microseconds_QPC( void );
 
 // wsw: pb adapted High Res Performance Counter code from ezquake
 
@@ -56,8 +56,8 @@ static void Sys_SynchronizeTimers_f( void *val )
 	static int hwtimer_old = -1;
 
 	const unsigned int millis = Sys_Milliseconds_TGT();
-	const qint64 micros = Sys_Microseconds_QPC();
-	const qint64 drift = micros - millis * 1000;
+	const int64_t micros = Sys_Microseconds_QPC();
+	const int64_t drift = micros - millis * 1000;
 
 	const int hwtimer_new = ( *(char *) val ) - '0';
 
@@ -137,12 +137,12 @@ static unsigned int Sys_Milliseconds_TGT( void )
 	return now - base;
 }
 
-static quint64 Sys_Microseconds_QPC( void )
+static uint64_t Sys_Microseconds_QPC( void )
 {
 	static qboolean first = qtrue;
-	static qint64 p_start;
+	static int64_t p_start;
 
-	qint64 p_now;
+	int64_t p_now;
 	QueryPerformanceCounter( (LARGE_INTEGER *) &p_now );
 
 	if( first )
@@ -162,10 +162,10 @@ unsigned int Sys_Milliseconds( void )
 		return Sys_Milliseconds_TGT() + milli_offset;
 }
 
-quint64 Sys_Microseconds( void )
+uint64_t Sys_Microseconds( void )
 {
 	if( hwtimer )
 		return Sys_Microseconds_QPC() + micro_offset;
 	else
-		return (quint64)( Sys_Milliseconds_TGT() + milli_offset ) * 1000;
+		return (uint64_t)( Sys_Milliseconds_TGT() + milli_offset ) * 1000;
 }


### PR DESCRIPTION
Yet another controversial idea from me. Don't see much sense on keeping q-types when they are just aliases to stdint types now. Yeah, I know we needed them when there was no stdint.h on Windows. Hadn't touched qboolean for now but you see the idea. 
