### PR TITLE
Use events instead of condition variables on Windows

### DIFF
--- a/source/win32/win_sys.c
+++ b/source/win32/win_sys.c
@@ -58,6 +58,8 @@ static dynvar_set_status_t Sys_SetAffinity_f( void *affinity );
 void Sys_InitTimeDynvar( void );
 void Sys_InitTime( void );
 
+void Sys_InitThreads( void );
+
 /*
 ===============================================================================
 
@@ -142,6 +144,8 @@ void Sys_Init( void )
 	timeBeginPeriod( 1 );
 
 	Sys_InitTime();
+
+	Sys_InitThreads();
 
 	if( dedicated->integer )
 	{


### PR DESCRIPTION
Removes the minimum requirement for Windows Vista.
