### PR TITLE
Map sets gravity cvar

### DIFF
--- a/source/game/g_func.cpp
+++ b/source/game/g_func.cpp
@@ -2166,7 +2166,7 @@ void SP_func_pendulum( edict_t *ent )
 		length = 8;
 	}
 
-	freq = 1 / ( M_PI * 2 ) *sqrt( g_gravity->value / ( 3 *length ) );
+	freq = 1 / ( M_PI * 2 ) *sqrt( level.gravity / ( 3 *length ) );
 
 	VectorCopy( ent->s.angles, ent->moveinfo.start_angles );
 	VectorClear( ent->moveinfo.dir );

--- a/source/game/g_local.h
+++ b/source/game/g_local.h
@@ -237,6 +237,7 @@ typedef struct
 	int numLocations;
 
 	timeout_t timeout;
+	float gravity;
 } level_locals_t;
 
 

--- a/source/game/g_phys.cpp
+++ b/source/game/g_phys.cpp
@@ -29,7 +29,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 static void SV_AddGravity( edict_t *ent )
 {
-	ent->velocity[2] -= ent->gravity * g_gravity->value * FRAMETIME;
+	ent->velocity[2] -= ent->gravity * level.gravity * FRAMETIME;
 }
 /*
 typedef struct

--- a/source/game/g_spawn.cpp
+++ b/source/game/g_spawn.cpp
@@ -747,6 +747,7 @@ void G_InitLevel( char *mapname, char *entities, int entstrlen, unsigned int lev
 
 	level.spawnedTimeStamp = game.realtime;
 	level.time = levelTime;
+	level.gravity = g_gravity->value;
 
 	// get the strings back
 	Q_strncpyz( level.mapname, name, sizeof( level.mapname ) );
@@ -976,5 +977,5 @@ static void SP_worldspawn( edict_t *ent )
 	}
 
 	if( st.gravity )
-		trap_Cvar_Set( "g_gravity", st.gravity );
+		level.gravity = atof( st.gravity );
 }

--- a/source/game/g_trigger.cpp
+++ b/source/game/g_trigger.cpp
@@ -410,7 +410,7 @@ static void trigger_push_setup( edict_t *self )
 	VectorScale( origin, 0.5, origin );
 
 	height = target->s.origin[2] - origin[2];
-	time = sqrt( height / ( 0.5 * g_gravity->value ) );
+	time = sqrt( height / ( 0.5 * level.gravity ) );
 	if( !time )
 	{
 		G_FreeEdict( self );
@@ -421,7 +421,7 @@ static void trigger_push_setup( edict_t *self )
 	velocity[2] = 0;
 	dist = VectorNormalize( velocity );
 	VectorScale( velocity, dist / time, velocity );
-	velocity[2] = time * g_gravity->value;
+	velocity[2] = time * level.gravity;
 	VectorCopy( velocity, self->s.origin2 );
 }
 

--- a/source/game/p_client.cpp
+++ b/source/game/p_client.cpp
@@ -1637,7 +1637,7 @@ void ClientThink( edict_t *ent, usercmd_t *ucmd, int timeDelta )
 	VectorCopy( ent->velocity, client->ps.pmove.velocity );
 	VectorCopy( ent->s.angles, client->ps.viewangles );
 
-	client->ps.pmove.gravity = g_gravity->value;
+	client->ps.pmove.gravity = level.gravity;
 
 	if( GS_MatchState() >= MATCH_STATE_POSTMATCH || GS_MatchPaused() 
 		|| ( ent->movetype != MOVETYPE_PLAYER && ent->movetype != MOVETYPE_NOCLIP ) )


### PR DESCRIPTION
Racesow was just bit by [this line](https://github.com/Warsow/qfusion/blob/master/source/game/g_spawn.cpp#L979), which lets a worldspawn set the servers `g_gravity` cvar, so the gravity changes persist across games/maps/levels.
