### PR TITLE
Limit FPS of the loading screen to 15

### DIFF
--- a/source/cgame/cg_screen.cpp
+++ b/source/cgame/cg_screen.cpp
@@ -1294,8 +1294,16 @@ void CG_LoadingString( const char *str )
 */
 void CG_LoadingItemName( const char *str )
 {
+	static unsigned int lastUpdateTime;
+
 	cg.precacheCount++;
-	trap_R_UpdateScreen();
+
+	unsigned int updateTime = trap_Milliseconds();
+	if( ( updateTime - lastUpdateTime ) > 66 )
+	{
+		trap_R_UpdateScreen();
+		lastUpdateTime = updateTime;
+	}
 }
 
 /*

--- a/source/cgame/cg_screen.cpp
+++ b/source/cgame/cg_screen.cpp
@@ -1299,7 +1299,7 @@ void CG_LoadingItemName( const char *str )
 	cg.precacheCount++;
 
 	unsigned int updateTime = trap_Milliseconds();
-	if( ( updateTime - lastUpdateTime ) > 66 )
+	if( ( updateTime - lastUpdateTime ) > 33 )
 	{
 		trap_R_UpdateScreen();
 		lastUpdateTime = updateTime;


### PR DESCRIPTION
When vsync is on (and it cannot be disabled on some systems), there is a delay of up to 16ms between every file loaded. This commit limits the FPS of the loading screen to 15 to allow more files to be loaded between screen updates.
