### PR TITLE
Include space between previous origin and current origin in TouchTriggers

### DIFF
--- a/source/cgame/cg_local.h
+++ b/source/cgame/cg_local.h
@@ -706,7 +706,7 @@ void CG_CheckPredictionError( void );
 void CG_BuildSolidList( void );
 void CG_Trace( trace_t *t, vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end, int ignore, int contentmask );
 int CG_PointContents( vec3_t point );
-void CG_Predict_TouchTriggers( pmove_t *pm );
+void CG_Predict_TouchTriggers( pmove_t *pm, vec3_t previous_origin );
 
 //
 // cg_screen.c

--- a/source/cgame/cg_predict.cpp
+++ b/source/cgame/cg_predict.cpp
@@ -189,7 +189,7 @@ static bool CG_ClipEntityContact( vec3_t origin, vec3_t mins, vec3_t maxs, int e
 /*
 * CG_Predict_TouchTriggers
 */
-void CG_Predict_TouchTriggers( pmove_t *pm )
+void CG_Predict_TouchTriggers( pmove_t *pm, vec3_t previous_origin )
 {
 	int i;
 	entity_state_t *state;

--- a/source/game/g_clip.cpp
+++ b/source/game/g_clip.cpp
@@ -1087,7 +1087,7 @@ void GClip_TouchTriggers( edict_t *ent )
 	}
 }
 
-void G_PMoveTouchTriggers( pmove_t *pm )
+void G_PMoveTouchTriggers( pmove_t *pm, vec3_t previous_origin )
 {
 	int i, num;
 	edict_t	*hit;
@@ -1124,8 +1124,20 @@ void G_PMoveTouchTriggers( pmove_t *pm )
 
 	GClip_LinkEntity( ent );
 
-	VectorAdd( pm->playerState->pmove.origin, pm->mins, mins );
-	VectorAdd( pm->playerState->pmove.origin, pm->maxs, maxs );
+	// expand the search bounds to include previous and current origin
+	for( i = 0; i < 3; i++ )
+	{
+		if( previous_origin[i] < pm->playerState->pmove.origin[i] )
+		{
+			mins[i] = previous_origin[i] + pm->mins[i];
+			maxs[i] = pm->playerState->pmove.origin[i] + pm->maxs[i];
+		}
+		else
+		{
+			mins[i] = pm->playerState->pmove.origin[i] + pm->mins[i];
+			maxs[i] = previous_origin[i] + pm->maxs[i];
+		}
+	}
 
 	num = GClip_AreaEdicts( mins, maxs, touch, MAX_EDICTS, AREA_TRIGGERS, 0 );
 

--- a/source/game/g_local.h
+++ b/source/game/g_local.h
@@ -743,7 +743,7 @@ void GClip_SetAreaPortalState( edict_t *ent, bool open );
 void GClip_LinkEntity( edict_t *ent );
 void GClip_UnlinkEntity( edict_t *ent );
 void GClip_TouchTriggers( edict_t *ent );
-void G_PMoveTouchTriggers( pmove_t *pm );
+void G_PMoveTouchTriggers( pmove_t *pm, vec3_t previous_origin );
 entity_state_t *G_GetEntityStateForDeltaTime( int entNum, int deltaTime );
 int GClip_FindRadius( vec3_t org, float rad, int *list, int maxcount );
 

--- a/source/gameshared/gs_misc.c
+++ b/source/gameshared/gs_misc.c
@@ -33,7 +33,7 @@ void ( *module_Trace )( trace_t *t, vec3_t start, vec3_t mins, vec3_t maxs, vec3
 entity_state_t *( *module_GetEntityState )( int entNum, int deltaTime );
 int ( *module_PointContents )( vec3_t point, int timeDelta );
 void ( *module_PredictedEvent )( int entNum, int ev, int parm );
-void ( *module_PMoveTouchTriggers )( pmove_t *pm );
+void ( *module_PMoveTouchTriggers )( pmove_t *pm, vec3_t previous_origin );
 void ( *module_RoundUpToHullSize )( vec3_t mins, vec3_t maxs );
 const char *( *module_GetConfigString )( int index );
 

--- a/source/gameshared/gs_pmove.c
+++ b/source/gameshared/gs_pmove.c
@@ -2019,7 +2019,7 @@ void Pmove( pmove_t *pmove )
 #define FALL_DAMAGE_SCALE 1.0
 
 	// check for falling damage
-	module_PMoveTouchTriggers( pm );
+	module_PMoveTouchTriggers( pm, pml.previous_origin );
 
 	PM_UpdateDeltaAngles(); // in case some trigger action has moved the view angles (like teleported).
 

--- a/source/gameshared/gs_public.h
+++ b/source/gameshared/gs_public.h
@@ -37,7 +37,7 @@ extern void ( *module_Trace )( trace_t *t, vec3_t start, vec3_t mins, vec3_t max
 extern entity_state_t *( *module_GetEntityState )( int entNum, int deltaTime );
 extern int ( *module_PointContents )( vec3_t point, int timeDelta );
 extern void ( *module_PredictedEvent )( int entNum, int ev, int parm );
-extern void ( *module_PMoveTouchTriggers )( pmove_t *pm );
+extern void ( *module_PMoveTouchTriggers )( pmove_t *pm, vec3_t previous_origin );
 extern void ( *module_RoundUpToHullSize )( vec3_t mins, vec3_t maxs );
 extern const char *( *module_GetConfigString )( int index );
 


### PR DESCRIPTION
This fixes passing through triggers at high speeds, you only need about 4,000 ups to skip a 1 unit thick trigger. It's been thoroughly tested on the mgxrace servers, there may be a cleaner solution though.
