### PR TITLE
Change vid_mode to vid_width/vid_height

### DIFF
--- a/source/android/android_glw.c
+++ b/source/android/android_glw.c
@@ -265,15 +265,13 @@ static bool GLimp_InitGL( void )
 /*
 ** GLimp_SetMode
 */
-rserr_t GLimp_SetMode( int x, int y, int width, int height, int displayFrequency, 
-	bool fullscreen, bool wideScreen )
+rserr_t GLimp_SetMode( int x, int y, int width, int height, int displayFrequency, bool fullscreen )
 {
 	ri.Com_Printf( "Initializing OpenGL display\n" );
 	if( glw_state.context != EGL_NO_CONTEXT )
 		GLimp_Shutdown();
 	glConfig.width = width;
 	glConfig.height = height;
-	glConfig.wideScreen = wideScreen;
 	glConfig.fullScreen = true;
 	if( !GLimp_InitGL() )
 	{

--- a/source/client/vid.h
+++ b/source/client/vid.h
@@ -29,6 +29,11 @@ typedef struct
 
 extern viddef_t	viddef;             // global video state
 
+typedef struct
+{
+	int width, height;
+} vidmode_t;
+
 // Video module initialisation etc
 void VID_Init( void );
 void VID_Shutdown( void );
@@ -37,8 +42,9 @@ void VID_Restart( bool verbose, bool soundRestart );
 // The sound module may require the handle when using directsound
 void *VID_GetWindowHandle( void );
 void VID_FlashWindow( int count );
-bool VID_GetDisplaySize( int *width, int *height );
-bool VID_GetModeInfo( int *width, int *height, bool *wideScreen, int mode );
+bool VID_GetDefaultMode( int *width, int *height );
+unsigned int VID_GetSysModes( vidmode_t *modes );
+bool VID_GetModeInfo( int *width, int *height, unsigned int mode );
 void VID_AppActivate( bool active, bool destroy );
 bool VID_RefreshIsActive( void );
 bool VID_AppIsActive( void );

--- a/source/ref_gl/r_glimp.h
+++ b/source/ref_gl/r_glimp.h
@@ -217,7 +217,6 @@ typedef struct
 
 	int				width, height;
 	bool			fullScreen;
-	bool			wideScreen;
 
 	bool			stereoEnabled;
 	int				stencilBits;
@@ -259,8 +258,7 @@ void	GLimp_BeginFrame( void );
 void	GLimp_EndFrame( void );
 int		GLimp_Init( const char *applicationName, void *hinstance, void *wndproc, void *parenthWnd );
 void	GLimp_Shutdown( void );
-rserr_t	GLimp_SetMode( int x, int y, int width, int height, int displayFrequency,
-				bool fullscreen, bool wideScreen );
+rserr_t	GLimp_SetMode( int x, int y, int width, int height, int displayFrequency, bool fullscreen );
 bool	GLimp_SetWindow( void *hinstance, void *wndproc, void *parenthWnd );
 void	GLimp_AppActivate( bool active, bool destroy );
 bool	GLimp_GetGammaRamp( size_t stride, unsigned short *psize, unsigned short *ramp );

--- a/source/ref_gl/r_local.h
+++ b/source/ref_gl/r_local.h
@@ -660,12 +660,11 @@ int			R_GetClippedFragments( const vec3_t origin, float radius, vec3_t axis[3], 
 rserr_t		R_Init( const char *applicationName, const char *screenshotPrefix, int startupColor,
 				void *hinstance, void *wndproc, void *parenthWnd, 
 				int x, int y, int width, int height, int displayFrequency,
-				bool fullscreen, bool wideScreen, bool verbose );
+				bool fullscreen, bool verbose );
 void		R_BeginRegistration( void );
 void		R_EndRegistration( void );
 void		R_Shutdown( bool verbose );
-rserr_t		R_SetMode( int x, int y, int width, int height, int displayFrequency,
-				bool fullScreen, bool wideScreen );
+rserr_t		R_SetMode( int x, int y, int width, int height, int displayFrequency, bool fullScreen );
 bool	R_SetWindow( void *hinstance, void *wndproc, void *parenthWnd );
 
 //

--- a/source/ref_gl/r_public.h
+++ b/source/ref_gl/r_public.h
@@ -22,7 +22,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "../cgame/ref.h"
 
-#define REF_API_VERSION 13
+#define REF_API_VERSION 14
 
 struct mempool_s;
 struct cinematics_s;
@@ -130,9 +130,8 @@ typedef struct
 	rserr_t		( *Init )( const char *applicationName, const char *screenshotsPrefix, int startupColor,
 					void *hinstance, void *wndproc, void *parenthWnd, 
 					int x, int y, int width, int height, int displayFrequency,
-					bool fullScreen, bool wideScreen, bool verbose );
-	rserr_t		( *SetMode )( int x, int y, int width, int height, int displayFrequency,
-					bool fullScreen, bool wideScreen );
+					bool fullScreen, bool verbose );
+	rserr_t		( *SetMode )( int x, int y, int width, int height, int displayFrequency, bool fullScreen );
 	bool	( *SetWindow )( void *hinstance, void *wndproc, void *parenthWnd );
 	void		( *Shutdown )( bool verbose );
 

--- a/source/ref_gl/r_register.c
+++ b/source/ref_gl/r_register.c
@@ -1198,8 +1198,8 @@ static void R_GfxInfo_f( void )
 	Com_Printf( "GL_MAX_FRAGMENT_UNIFORM_COMPONENTS: %i\n", glConfig.maxFragmentUniformComponents );
 	Com_Printf( "\n" );
 
-	Com_Printf( "mode: %ix%i%s%s\n", glConfig.width, glConfig.height,
-		glConfig.fullScreen ? ", fullscreen" : ", windowed", glConfig.wideScreen ? ", widescreen" : "" );
+	Com_Printf( "mode: %ix%i%s\n", glConfig.width, glConfig.height,
+		glConfig.fullScreen ? ", fullscreen" : ", windowed" );
 	Com_Printf( "picmip: %i\n", r_picmip->integer );
 	Com_Printf( "texturemode: %s\n", r_texturemode->string );
 	Com_Printf( "anisotropic filtering: %i\n", r_texturefilter->integer );
@@ -1252,7 +1252,7 @@ static unsigned R_GLVersionHash( const char *vendorString,
 rserr_t R_Init( const char *applicationName, const char *screenshotPrefix, int startupColor,
 	void *hinstance, void *wndproc, void *parenthWnd, 
 	int x, int y, int width, int height, int displayFrequency,
-	bool fullScreen, bool wideScreen, bool verbose )
+	bool fullScreen, bool verbose )
 {
 	const qgl_driverinfo_t *driver;
 	const char *dllname = NULL;
@@ -1302,7 +1302,7 @@ init_qgl:
 	}
 
 	// create the window and set up the context
-	err = GLimp_SetMode( x, y, width, height, displayFrequency, fullScreen, wideScreen );
+	err = GLimp_SetMode( x, y, width, height, displayFrequency, fullScreen );
 	if( err != rserr_ok )
 	{
 		QGL_Shutdown();
@@ -1406,10 +1406,9 @@ init_qgl:
 /*
 * R_SetMode
 */
-rserr_t R_SetMode( int x, int y, int width, int height, int displayFrequency, 
-	bool fullScreen, bool wideScreen )
+rserr_t R_SetMode( int x, int y, int width, int height, int displayFrequency, bool fullScreen )
 {
-	return GLimp_SetMode( x, y, width, height, displayFrequency, fullScreen, wideScreen );
+	return GLimp_SetMode( x, y, width, height, displayFrequency, fullScreen );
 }
 
 /*

--- a/source/sdl/sdl_vid.c
+++ b/source/sdl/sdl_vid.c
@@ -32,9 +32,9 @@ static int VID_WndProc( void *wnd, int ev, int p1, int p2 )
 /*
  * VID_Sys_Init
  */
-int VID_Sys_Init( int x, int y, int width, int height, int displayFrequency, void *parentWindow, bool fullScreen, bool wideScreen, bool verbose )
+int VID_Sys_Init( int x, int y, int width, int height, int displayFrequency, void *parentWindow, bool fullScreen, bool verbose )
 {
-	return re.Init( APPLICATION, APP_SCREENSHOTS_PREFIX, APP_STARTUP_COLOR, NULL, VID_WndProc, parentWindow, x, y, width, height, displayFrequency, fullScreen, wideScreen, verbose );
+	return re.Init( APPLICATION, APP_SCREENSHOTS_PREFIX, APP_STARTUP_COLOR, NULL, VID_WndProc, parentWindow, x, y, width, height, displayFrequency, fullScreen, verbose );
 }
 
 /*
@@ -83,9 +83,49 @@ void VID_FlashWindow( int count )
 }
 
 /*
- * VID_GetDisplaySize
+ * VID_GetSysModes
  */
-bool VID_GetDisplaySize( int *width, int *height )
+unsigned int VID_GetSysModes( vidmode_t *modes )
+{
+	int num;
+	SDL_DisplayMode mode;
+	int prevwidth = 0, prevheight = 0;
+	unsigned int ret = 0;
+
+	num = SDL_GetNumDisplayModes( 0 );
+	if( num < 1 )
+		return 0;
+
+	while( num-- ) // reverse to help the sorting a little
+	{
+		if( SDL_GetDisplayMode( 0, num, &mode ) )
+			continue;
+
+		if( SDL_BITSPERPIXEL( mode.format ) < 16 )
+			continue;
+
+		if( ( mode.w == prevwidth ) && ( mode.h == prevheight ) )
+			continue;
+
+		if( modes )
+		{
+			modes[ret].width = mode.w;
+			modes[ret].height = mode.h;
+		}
+
+		prevwidth = mode.w;
+		prevheight = mode.h;
+
+		ret++;
+	}
+
+	return ret;
+}
+
+/*
+ * VID_GetDefaultMode
+ */
+bool VID_GetDefaultMode( int *width, int *height )
 {
 	SDL_DisplayMode mode;
 	SDL_GetDesktopDisplayMode( 0, &mode );

--- a/source/ui/datasources/ui_video_datasource.cpp
+++ b/source/ui/datasources/ui_video_datasource.cpp
@@ -26,7 +26,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define VIDEO_SOURCE "video"
 #define TABLE_NAME "list"
 #define RESOLUTION "resolution"
-#define MODE "mode"
 
 namespace WSWUI
 {
@@ -43,28 +42,27 @@ VideoDataSource::~VideoDataSource( void )
 
 void VideoDataSource::updateVideoModeList( void )
 {
-	bool qwideScreen;
 	char resolution[64];
 	int i, width, height;
+	int vidWidth = trap::Cvar_Value( "vid_width" ), vidHeight = trap::Cvar_Value( "vid_height" );
+	bool custom = true;
 
 	// lists must be clear before
 	modesList.clear();
 
-	// native desktop resolution
-	modesList.push_back( Mode( toString( -2 ), "desktop" ) );
-
-    for( i = 0; trap::VID_GetModeInfo( &width, &height, &qwideScreen, i ); i++ ) ;
-	for( i = 0; trap::VID_GetModeInfo( &width, &height, &qwideScreen, i ); i++ )
+	for( i = 0; trap::VID_GetModeInfo( &width, &height, i ); i++ )
     {
-		Q_snprintfz( resolution, sizeof( resolution ), "%s%i x %i", ( qwideScreen ? "W " : "" ), width, height );
-
-		// save resolution and index
-		Mode m( toString( i ), resolution );
-		modesList.push_back( m );
+		Q_snprintfz( resolution, sizeof( resolution ), "%i x %i", width, height );
+		modesList.push_back( resolution );
+		if( width == vidWidth && height == vidHeight )
+			custom = false;
     }
 
-	// custom resolution
-	modesList.push_back( Mode( toString( -1 ), "custom" ) );
+	if( custom )
+	{
+		Q_snprintfz( resolution, sizeof( resolution ), "%i x %i", vidWidth, vidHeight );
+		modesList.push_back( resolution );
+	}
 
 	// notify updates
 	int size = modesList.size();
@@ -83,9 +81,7 @@ void VideoDataSource::GetRow( StringList &row, const String &table, int row_inde
 		for( StringList::const_iterator it = columns.begin(); it != columns.end(); ++it )
 		{
 			if( *it == RESOLUTION )
-				row.push_back( modesList[row_index].second.c_str() );
-			else if( *it == MODE )
-				row.push_back( modesList[row_index].first.c_str() );
+				row.push_back( modesList[row_index].c_str() );
 		}
 	}
 }

--- a/source/ui/datasources/ui_video_datasource.h
+++ b/source/ui/datasources/ui_video_datasource.h
@@ -15,8 +15,7 @@ public:
 	int GetNumRows( const String& table );
 private:
 
-	typedef std::pair<std::string, std::string> Mode;
-	std::vector<Mode> modesList;
+	std::vector<std::string> modesList;
 
 	// populate the table
 	void updateVideoModeList( void );

--- a/source/ui/kernel/ui_syscalls.h
+++ b/source/ui/kernel/ui_syscalls.h
@@ -298,8 +298,8 @@ namespace trap
 			return UI_IMPORT.IN_SupportedDevices();
 		}
 
-		inline bool VID_GetModeInfo( int *width, int *height, bool *wideScreen, int mode ) {
-			return UI_IMPORT.VID_GetModeInfo( width, height, wideScreen, mode );
+		inline bool VID_GetModeInfo( int *width, int *height, int mode ) {
+			return UI_IMPORT.VID_GetModeInfo( width, height, mode );
 		}
 
 		inline void VID_FlashWindow( int count ) {

--- a/source/ui/ui_public.h
+++ b/source/ui/ui_public.h
@@ -21,7 +21,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #ifndef __UI_PUBLIC_H__
 #define __UI_PUBLIC_H__
 
-#define	UI_API_VERSION	    58
+#define	UI_API_VERSION	    59
 
 typedef size_t (*ui_async_stream_read_cb_t)(const void *buf, size_t numb, float percentage, 
 	int status, const char *contentType, void *privatep);
@@ -142,7 +142,7 @@ typedef struct
 	void ( *IN_ShowSoftKeyboard )( bool show );
 	unsigned int ( *IN_SupportedDevices )( void );
 
-	bool ( *VID_GetModeInfo )( int *width, int *height, bool *wideScreen, int mode );
+	bool ( *VID_GetModeInfo )( int *width, int *height, int mode );
 	void ( *VID_FlashWindow )( int count );
 
 	void ( *GetConfigString )( int i, char *str, int size );

--- a/source/unix/unix_vid.c
+++ b/source/unix/unix_vid.c
@@ -33,14 +33,14 @@ static int VID_WndProc( x11display_t *wnd, int ev, int p1, int p2 )
 * VID_Sys_Init
 */
 int VID_Sys_Init( int x, int y, int width, int height, int displayFrequency,
-	void *parentWindow, bool fullScreen, bool wideScreen, bool verbose )
+	void *parentWindow, bool fullScreen, bool verbose )
 {
 	x11display.dpy = NULL;
 
 	return re.Init( APPLICATION, APP_SCREENSHOTS_PREFIX, APP_STARTUP_COLOR,
 		NULL, &VID_WndProc, parentWindow, 
 		x, y, width, height, displayFrequency,
-		fullScreen, wideScreen, verbose );
+		fullScreen, verbose );
 }
 
 /*
@@ -122,9 +122,42 @@ void VID_FlashWindow( int count )
 }
 
 /*
-** VID_GetDisplaySize
+** VID_GetSysModes
 */
-bool VID_GetDisplaySize( int *width, int *height )
+unsigned int VID_GetSysModes( vidmode_t *modes )
+{
+	XRRScreenConfiguration *xrrConfig;
+	XRRScreenSize *xrrSizes;
+	Display *dpy;
+	Window root;
+	int num_sizes = 0, i;
+
+	dpy = XOpenDisplay( NULL );
+	if( dpy )
+	{
+		root = DefaultRootWindow( dpy );
+		xrrConfig = XRRGetScreenInfo( dpy, root );
+		xrrSizes = XRRConfigSizes( xrrConfig, &num_sizes );
+
+		if( modes )
+		{
+			for( i = 0; i < num_sizes; i++ )
+			{
+				modes[i].width = xrrSizes[i].width;
+				modes[i].height = xrrSizes[i].height;
+			}
+		}
+
+		XCloseDisplay( dpy );
+	}
+
+	return max( num_sizes, 0 );
+}
+
+/*
+** VID_GetDefaultMode
+*/
+bool VID_GetDefaultMode( int *width, int *height )
 {
 	XRRScreenConfiguration *xrrConfig;
 	XRRScreenSize *xrrSizes;

--- a/source/win32/win_glw.c
+++ b/source/win32/win_glw.c
@@ -284,8 +284,7 @@ static bool VID_SetFullscreenMode( int displayFrequency, bool fullscreen )
 /*
 ** GLimp_SetMode
 */
-rserr_t GLimp_SetMode( int x, int y, int width, int height, int displayFrequency, 
-	bool fullscreen, bool wideScreen )
+rserr_t GLimp_SetMode( int x, int y, int width, int height, int displayFrequency, bool fullscreen )
 {
 	const char *win_fs[] = { "W", "FS" };
 
@@ -312,7 +311,6 @@ rserr_t GLimp_SetMode( int x, int y, int width, int height, int displayFrequency
 		RECT parentWindowRect;
 
 		fullscreen = false;
-		wideScreen = false;
 
 		GetWindowRect( glw_state.parenthWnd, &parentWindowRect );
 		width = parentWindowRect.right - parentWindowRect.left;
@@ -332,7 +330,6 @@ rserr_t GLimp_SetMode( int x, int y, int width, int height, int displayFrequency
 
 	glConfig.width = width;
 	glConfig.height = height;
-	glConfig.wideScreen = wideScreen;
 	glConfig.fullScreen = VID_SetFullscreenMode( displayFrequency, fullscreen );
 
 	if( !VID_CreateWindow() ) {

--- a/source/win32/win_vid.c
+++ b/source/win32/win_vid.c
@@ -541,12 +541,12 @@ void *VID_GetWindowHandle( void )
 ** VID_Sys_Init
 */
 rserr_t VID_Sys_Init( int x, int y, int width, int height, int displayFrequency,
-	void *parentWindow, bool fullScreen, bool wideScreen, bool verbose )
+	void *parentWindow, bool fullScreen, bool verbose )
 {
 	return re.Init( APPLICATION, APP_SCREENSHOTS_PREFIX, APP_STARTUP_COLOR,
 		global_hInstance, MainWndProc, parentWindow, 
 		x, y, width, height, displayFrequency,
-		fullScreen, wideScreen, verbose );
+		fullScreen, verbose );
 }
 
 /*
@@ -582,9 +582,9 @@ void VID_Front_f( void )
 }
 
 /*
-** VID_GetDisplaySize
+** VID_GetDefaultMode
 */
-bool VID_GetDisplaySize( int *width, int *height )
+bool VID_GetDefaultMode( int *width, int *height )
 {
 	DEVMODE dm;
 		
@@ -593,11 +593,49 @@ bool VID_GetDisplaySize( int *width, int *height )
 
 	EnumDisplaySettings( NULL, ENUM_CURRENT_SETTINGS, &dm );
 
+	if( !dm.dmPelsWidth || !dm.dmPelsHeight )
+		return false;
+
 	*width = dm.dmPelsWidth;
 	*height = dm.dmPelsHeight;
 
 	return true;
 }
+
+/*
+** VID_GetSysModes
+*/
+unsigned int VID_GetSysModes( vidmode_t *modes )
+{
+	DEVMODE dm;
+	unsigned int i, count = 0, prevwidth = 0, prevheight = 0;
+
+	memset( &dm, 0, sizeof( dm ) );
+	dm.dmSize = sizeof( dm );
+
+	for( i = 0; EnumDisplaySettings( NULL, i, &dm ); i++ )
+	{
+		if( dm.dmBitsPerPel < 16 )
+			continue;
+
+		if( ( dm.dmPelsWidth == prevwidth ) && ( dm.dmPelsHeight == prevheight ) )
+			continue;
+
+		if( modes )
+		{
+			modes[count].width = dm.dmPelsWidth;
+			modes[count].height = dm.dmPelsHeight;
+		}
+
+		prevwidth = dm.dmPelsWidth;
+		prevheight = dm.dmPelsHeight;
+
+		count++;
+	}
+
+	return count;
+}
+
 
 /*
 ** VID_FlashWindow


### PR DESCRIPTION
Requests the video mode list from the OS so all modes work in fullscreen and can be adjusted according to the conventions of the OS. In windowed mode, any resolution can be set as long as it's not larger than the maximum supported width and height. In fullscreen mode, the closest supported resolution is used when a non-standard one is requested.
