### PR TITLE
Unload unused world textures before loading new ones

### DIFF
--- a/source/ref_gl/r_cin.c
+++ b/source/ref_gl/r_cin.c
@@ -98,7 +98,7 @@ static image_t *R_ResampleCinematicFrame( r_cinhandle_t *handle )
 
 			for( i = 0; i < 3; i++ ) {
 				handle->yuv_images[i] = R_LoadImage( va( "%s_%s", handle->name, letters[i] ), 
-					fake_data, 1, 1, IT_SPECIAL|IT_LUMINANCE, 1 );
+					fake_data, 1, 1, IT_SPECIAL|IT_LUMINANCE, IMAGE_TAG_GENERIC, 1 );
 			}
 			handle->new_frame = true;
 		}
@@ -118,7 +118,7 @@ static image_t *R_ResampleCinematicFrame( r_cinhandle_t *handle )
 
 			R_InitViewportTexture( &handle->image, handle->name, 0, 
 				handle->cyuv->image_width, handle->cyuv->image_height, 
-				0, IT_SPECIAL|IT_FRAMEBUFFER, samples );
+				0, IT_SPECIAL|IT_FRAMEBUFFER, IMAGE_TAG_GENERIC, samples );
 
 			R_BindFrameBufferObject( handle->image->fbo );
 
@@ -151,7 +151,7 @@ static image_t *R_ResampleCinematicFrame( r_cinhandle_t *handle )
 	else {
 		if( !handle->image ) {
 			handle->image = R_LoadImage( handle->name, &handle->pic, handle->width, handle->height, 
-				IT_SPECIAL, samples );
+				IT_SPECIAL, IMAGE_TAG_GENERIC, samples );
 			handle->new_frame = false;
 		} else if( handle->new_frame ) {
 			R_ReplaceImage( handle->image, &handle->pic, handle->width, handle->height, 
@@ -369,11 +369,11 @@ void R_TouchCinematic( unsigned int id )
 	handle->registrationSequence = rsh.registrationSequence;
 
 	if( handle->image ) {
-		R_TouchImage( handle->image );
+		R_TouchImage( handle->image, IMAGE_TAG_GENERIC );
 	}
 	for( i = 0; i < 3; i++ ) {
 		if( handle->yuv_images[i] ) {
-			R_TouchImage( handle->yuv_images[i] );
+			R_TouchImage( handle->yuv_images[i], IMAGE_TAG_GENERIC );
 		}
 	}
 

--- a/source/ref_gl/r_image.h
+++ b/source/ref_gl/r_image.h
@@ -60,6 +60,16 @@ enum
 #define IT_COLORCORRECTION	( ( glConfig.maxTexture3DSize >= 32 ) ? ( IT_SPECIAL|IT_COLORLUT|IT_3D ) : ( IT_SPECIAL|IT_COLORLUT ) )
 #define IT_GL_ES_NPOT		( IT_CLAMP|IT_NOMIPMAP )
 
+/**
+ * Image usage tags, to allow certain images to be freed separately.
+ */
+enum
+{
+	IMAGE_TAG_GENERIC	= 1<<0		// Images that don't fall into any other category.
+	,IMAGE_TAG_BUILTIN	= 1<<1		// Internal ref images that must not be released.
+	,IMAGE_TAG_WORLD	= 1<<2		// World textures.
+};
+
 typedef struct image_s
 {
 	char			*name;						// game path, not including extension
@@ -78,6 +88,7 @@ typedef struct image_s
 	int				samples;
 	int				fbo;						// frame buffer object texture is attached to
 	unsigned int	framenum;					// rf.frameCount texture was updated (rendered to)
+	int				tags;						// usage tags of the image
 	struct image_s	*next, *prev;
 } image_t;
 
@@ -85,11 +96,12 @@ void R_SelectTextureUnit( int tmu );
 bool R_BindTexture( int tmu, const image_t *tex );
 
 void R_InitImages( void );
-void R_TouchImage( image_t *image );
+void R_TouchImage( image_t *image, int tags );
+void R_FreeUnusedImagesByTags( int tags );
 void R_FreeUnusedImages( void );
 void R_ShutdownImages( void );
 void R_InitViewportTexture( image_t **texture, const char *name, int id, 
-	int viewportWidth, int viewportHeight, int size, int flags, int samples );
+	int viewportWidth, int viewportHeight, int size, int flags, int tags, int samples );
 image_t *R_GetPortalTexture( int viewportWidth, int viewportHeight, int flags, unsigned frameNum );
 image_t *R_GetShadowmapTexture( int id, int viewportWidth, int viewportHeight, int flags );
 void R_InitDrawFlatTexture( void );
@@ -102,9 +114,9 @@ void R_ScreenShot( const char *filename, int x, int y, int width, int height, in
 void R_TextureMode( char *string );
 void R_AnisotropicFilter( int value );
 
-image_t *R_LoadImage( const char *name, uint8_t **pic, int width, int height, int flags, int samples );
-image_t	*R_FindImage( const char *name, const char *suffix, int flags );
-image_t *R_Create3DImage( const char *name, int width, int height, int layers, int flags, int samples, bool array );
+image_t *R_LoadImage( const char *name, uint8_t **pic, int width, int height, int flags, int tags, int samples );
+image_t	*R_FindImage( const char *name, const char *suffix, int flags, int tags );
+image_t *R_Create3DImage( const char *name, int width, int height, int layers, int flags, int tags, int samples, bool array );
 void R_ReplaceImage( image_t *image, uint8_t **pic, int width, int height, int flags, int samples );
 void R_ReplaceSubImage( image_t *image, int layer, int x, int y, uint8_t **pic, int width, int height );
 void R_ReplaceImageLayer( image_t *image, int layer, uint8_t **pic );

--- a/source/ref_gl/r_light.c
+++ b/source/ref_gl/r_light.c
@@ -452,7 +452,7 @@ static int R_UploadLightmap( const char *name, uint8_t *data, int w, int h )
 
 	Q_snprintfz( uploadName, sizeof( uploadName ), "%s%i", name, r_numUploadedLightmaps );
 
-	image = R_LoadImage( uploadName, (uint8_t **)( &data ), w, h, IT_SPECIAL, LIGHTMAP_BYTES );
+	image = R_LoadImage( uploadName, (uint8_t **)( &data ), w, h, IT_SPECIAL, IMAGE_TAG_GENERIC, LIGHTMAP_BYTES );
 	r_lightmapTextures[r_numUploadedLightmaps] = image;
 
 	return r_numUploadedLightmaps++;
@@ -676,7 +676,7 @@ void R_BuildLightmaps( model_t *mod, int numLightmaps, int w, int h, const uint8
 				lightmapNum = r_numUploadedLightmaps++;
 				image = R_Create3DImage( va( "*lm%i", lightmapNum ), layerWidth, h,
 					( ( i + numLayers ) <= numLightmaps ) ? numLayers : numLightmaps % numLayers,
-					IT_SPECIAL, LIGHTMAP_BYTES, true );
+					IT_SPECIAL, IMAGE_TAG_GENERIC, LIGHTMAP_BYTES, true );
 				r_lightmapTextures[lightmapNum] = image;
 			}
 
@@ -747,7 +747,7 @@ void R_TouchLightmapImages( model_t *mod )
 	loadbmodel = (( mbrushmodel_t * )mod->extradata);
 
 	for( i = 0; i < loadbmodel->numLightmapImages; i++ ) {
-		R_TouchImage( loadbmodel->lightmapImages[i] );
+		R_TouchImage( loadbmodel->lightmapImages[i], IMAGE_TAG_GENERIC );
 	}
 }
 

--- a/source/ref_gl/r_local.h
+++ b/source/ref_gl/r_local.h
@@ -477,7 +477,7 @@ enum
 };
 
 void		RFB_Init( void );
-int			RFB_RegisterObject( int width, int height, bool depthRB, bool stencilRB );
+int			RFB_RegisterObject( int width, int height, bool builtin, bool depthRB, bool stencilRB );
 void		RFB_UnregisterObject( int object );
 void		RFB_TouchObject( int object );
 void		RFB_BindObject( int object );

--- a/source/ref_gl/r_model.c
+++ b/source/ref_gl/r_model.c
@@ -41,7 +41,7 @@ static int mod_numknown;
 static int modfilelen;
 static bool mod_isworldmodel;
 static const dvis_t *mod_worldvis;
-static model_t *r_prevworldmodel;
+model_t *r_prevworldmodel;
 static mapconfig_t *mod_mapConfigs;
 
 static mempool_t *mod_mempool;
@@ -845,7 +845,7 @@ static void Mod_TouchBrushModel( model_t *model )
 	R_TouchLightmapImages( model );
 
 	if( loadbmodel->colorCorrectionLUT ) {
-		R_TouchImage( loadbmodel->colorCorrectionLUT );
+		R_TouchImage( loadbmodel->colorCorrectionLUT, IMAGE_TAG_GENERIC );
 	}
 }
 
@@ -1260,7 +1260,7 @@ static void R_FinishMapConfig( const model_t *mod )
 	if( mapConfig.colorCorrection[0] )
 	{
 		( ( mbrushmodel_t * )( mod->extradata ) )->colorCorrectionLUT =
-			R_FindImage( mapConfig.colorCorrection, NULL, IT_COLORCORRECTION );
+			R_FindImage( mapConfig.colorCorrection, NULL, IT_COLORCORRECTION, IMAGE_TAG_GENERIC );
 	}
 
 	mod_mapConfigs[mod - mod_known] = mapConfig;

--- a/source/ref_gl/r_model.h
+++ b/source/ref_gl/r_model.h
@@ -407,6 +407,8 @@ typedef struct model_s
 
 //============================================================================
 
+extern model_t *r_prevworldmodel;
+
 void		R_InitModels( void );
 void		R_ShutdownModels( void );
 void		R_FreeUnusedModels( void );

--- a/source/ref_gl/r_q3bsp.c
+++ b/source/ref_gl/r_q3bsp.c
@@ -412,14 +412,13 @@ static void Mod_LoadShaderrefs( const lump_t *l )
 	// free world textures from the previous map that are not used on the new map
 	if( r_prevworldmodel && ( r_prevworldmodel->registrationSequence != rsh.registrationSequence ) )
 	{
-		const shaderType_e types[] = { SHADER_TYPE_VERTEX, SHADER_TYPE_DELUXEMAP };
-		unsigned int numTypes = ( r_lighting_vertexlight->integer ? 1 : 2 );
+		const shaderType_e shaderTypes[] = { SHADER_TYPE_DELUXEMAP, SHADER_TYPE_VERTEX };
 
 		shaderref = loadmodel_shaderrefs;
 		for( i = 0; i < count; i++, shaderref++ )
-			R_TouchShadersByName( shaderref->name, types, numTypes );
+			R_TouchShadersByName( shaderref->name );
 
-		R_FreeUnusedShaders( types, numTypes );
+		R_FreeUnusedShadersByType( shaderTypes, sizeof( shaderTypes ) / sizeof( shaderTypes[0] ) );
 		R_FreeUnusedImagesByTags( IMAGE_TAG_WORLD );
 	}
 }

--- a/source/ref_gl/r_q3bsp.c
+++ b/source/ref_gl/r_q3bsp.c
@@ -392,21 +392,35 @@ static void Mod_LoadShaderrefs( const lump_t *l )
 {
 	int i, count;
 	dshaderref_t *in;
-	dshaderref_t *out;
+	dshaderref_t *shaderref;
 
 	in = ( void * )( mod_base + l->fileofs );
 	if( l->filelen % sizeof( *in ) )
 		ri.Com_Error( ERR_DROP, "Mod_LoadShaderrefs: funny lump size in %s", loadmodel->name );
 	count = l->filelen / sizeof( *in );
-	out = Mod_Malloc( loadmodel, count*sizeof( *out ) );
+	shaderref = Mod_Malloc( loadmodel, count*sizeof( *shaderref ) );
 
-	loadmodel_shaderrefs = out;
+	loadmodel_shaderrefs = shaderref;
 	loadmodel_numshaderrefs = count;
 
-	for( i = 0; i < count; i++, in++, out++ )
+	for( i = 0; i < count; i++, in++, shaderref++ )
 	{
-		Q_strncpyz( out->name, in->name, sizeof( out->name ) );
-		out->flags = LittleLong( in->flags );
+		Q_strncpyz( shaderref->name, in->name, sizeof( shaderref->name ) );
+		shaderref->flags = LittleLong( in->flags );
+	}
+
+	// free world textures from the previous map that are not used on the new map
+	if( r_prevworldmodel && ( r_prevworldmodel->registrationSequence != rsh.registrationSequence ) )
+	{
+		const shaderType_e types[] = { SHADER_TYPE_VERTEX, SHADER_TYPE_DELUXEMAP };
+		unsigned int numTypes = ( r_lighting_vertexlight->integer ? 1 : 2 );
+
+		shaderref = loadmodel_shaderrefs;
+		for( i = 0; i < count; i++, shaderref++ )
+			R_TouchShadersByName( shaderref->name, types, numTypes );
+
+		R_FreeUnusedShaders( types, numTypes );
+		R_FreeUnusedImagesByTags( IMAGE_TAG_WORLD );
 	}
 }
 

--- a/source/ref_gl/r_register.c
+++ b/source/ref_gl/r_register.c
@@ -1521,7 +1521,7 @@ void R_EndRegistration( void )
 	R_FreeUnusedModels();
 	R_FreeUnusedVBOs();
 	R_FreeUnusedSkinFiles();
-	R_FreeUnusedShaders();
+	R_FreeUnusedShaders( NULL, 0 );
 	R_FreeUnusedCinematics();
 	R_FreeUnusedImages();
 	RFB_FreeUnusedObjects();

--- a/source/ref_gl/r_register.c
+++ b/source/ref_gl/r_register.c
@@ -1521,7 +1521,7 @@ void R_EndRegistration( void )
 	R_FreeUnusedModels();
 	R_FreeUnusedVBOs();
 	R_FreeUnusedSkinFiles();
-	R_FreeUnusedShaders( NULL, 0 );
+	R_FreeUnusedShaders();
 	R_FreeUnusedCinematics();
 	R_FreeUnusedImages();
 	RFB_FreeUnusedObjects();

--- a/source/ref_gl/r_scene.c
+++ b/source/ref_gl/r_scene.c
@@ -359,8 +359,9 @@ void R_RenderScene( const refdef_t *fd )
 				if( r_colorcorrection_override->string[0] ) {
 					if( r_colorcorrection_override->modified ) {
 						r_colorcorrection_override->modified = false;
-						rsh.colorCorrectionOverrideLUT =
-							R_FindImage( r_colorcorrection_override->string, NULL, IT_COLORCORRECTION );
+						rsh.colorCorrectionOverrideLUT = R_FindImage(
+							r_colorcorrection_override->string,
+							NULL, IT_COLORCORRECTION, IMAGE_TAG_BUILTIN );
 					}
 					colorCorrectionLUT = rsh.colorCorrectionOverrideLUT;
 				}

--- a/source/ref_gl/r_shader.c
+++ b/source/ref_gl/r_shader.c
@@ -1987,9 +1987,9 @@ void R_TouchShader( shader_t *s )
 }
 
 /*
-* R_FreeUnusedShaders
+* R_FreeUnusedShadersByType
 */
-void R_FreeUnusedShaders( const shaderType_e *types, unsigned int numTypes )
+void R_FreeUnusedShadersByType( const shaderType_e *types, unsigned int numTypes )
 {
 	int i;
 	unsigned int type;
@@ -2021,6 +2021,14 @@ void R_FreeUnusedShaders( const shaderType_e *types, unsigned int numTypes )
 
 		R_UnlinkShader( s );
 	}
+}
+
+/*
+* R_FreeUnusedShaders
+*/
+void R_FreeUnusedShaders( void )
+{
+	R_FreeUnusedShadersByType( NULL, 0 );
 }
 
 /*
@@ -2744,14 +2752,13 @@ shader_t *R_ShaderById( unsigned int id )
 /*
 * R_TouchShadersByName
 */
-void R_TouchShadersByName( const char *name, const shaderType_e *types, unsigned int numTypes )
+void R_TouchShadersByName( const char *name )
 {
 	unsigned int shortNameSize;
 	char *shortName;
 	unsigned int nameLength;
 	unsigned int key;
 	shader_t *hnode, *s;
-	unsigned int i, typesTouched = 0;
 
 	if( !name || !name[0] )
 		return;
@@ -2765,24 +2772,8 @@ void R_TouchShadersByName( const char *name, const shaderType_e *types, unsigned
 	key = COM_SuperFastHash( ( const uint8_t * )shortName, nameLength, nameLength ) % SHADERS_HASH_SIZE;
 	hnode = &r_shaders_hash_headnode[key];
 	for( s = hnode->next; s != hnode; s = s->next ) {
-		if( strcmp( s->name, shortName ) ) {
-			continue;
-		}
-
-		if( !numTypes ) {
-			// touch all shaders with the requested name, no matter what their type is
+		if( !strcmp( s->name, shortName ) ) {
 			R_TouchShader( s );
-			continue;
-		}
-
-		for( i = 0; i < numTypes; i++ ) {
-			if( s->type == types[i] ) {
-				R_TouchShader( s );
-				typesTouched++;
-			}
-		}
-		if( typesTouched == numTypes ) {
-			return;
 		}
 	}
 }

--- a/source/ref_gl/r_shader.c
+++ b/source/ref_gl/r_shader.c
@@ -405,7 +405,7 @@ static bool Shader_SkipConditionBlock( const char **ptr )
 
 //===========================================================================
 
-static void Shader_ParseSkySides( const char **ptr, image_t **images, bool underscore )
+static void Shader_ParseSkySides( const char **ptr, image_t **images, bool underscore, int imagetags )
 {
 	int i, j;
 	char *token;
@@ -455,7 +455,7 @@ static void Shader_ParseSkySides( const char **ptr, image_t **images, bool under
 				Q_strncatz( suffix, cubemapSides[i][j].suf, sizeof( suffix ) );
 
 				images[j] = R_FindImage( token, suffix, 
-					IT_SKY|IT_NOMIPMAP|IT_CLAMP|IT_SYNC|cubemapSides[i][j].flags );
+					IT_SKY|IT_NOMIPMAP|IT_CLAMP|IT_SYNC|cubemapSides[i][j].flags, imagetags );
 				if( !images[j] )
 					break;
 			}
@@ -544,7 +544,7 @@ static image_t *Shader_FindImage( shader_t *shader, const char *name, int flags 
 		return rsh.whiteTexture;
 	}
 
-	image = R_FindImage( name, NULL, flags );
+	image = R_FindImage( name, NULL, flags, shader->imagetags );
 	if( !image )
 	{
 		ri.Com_DPrintf( S_COLOR_YELLOW "WARNING: shader %s has a stage with no image: %s\n", shader->name, name );
@@ -670,7 +670,7 @@ static void Shader_SkyParmsExt( shader_t *shader, shaderpass_t *pass, const char
 {
 	float skyheight;
 
-	Shader_ParseSkySides( ptr, shader->skyboxImages, underscore );
+	Shader_ParseSkySides( ptr, shader->skyboxImages, underscore, shader->imagetags );
 
 	skyheight = Shader_ParseFloat( ptr );
 	if( !skyheight )
@@ -966,7 +966,7 @@ static const shaderkey_t shaderkeys[] =
 
 // ===============================================================
 
-static void Shaderpass_LoadMaterial( image_t **normalmap, image_t **glossmap, image_t **decalmap, const char *name, int addFlags )
+static void Shaderpass_LoadMaterial( image_t **normalmap, image_t **glossmap, image_t **decalmap, const char *name, int addFlags, int imagetags )
 {
 	image_t *images[3];
 
@@ -974,16 +974,16 @@ static void Shaderpass_LoadMaterial( image_t **normalmap, image_t **glossmap, im
 	images[0] = images[1] = images[2] = NULL;
 
 	// load normalmap image
-	images[0] = R_FindImage( name, "_norm", (addFlags|IT_NORMALMAP) );
+	images[0] = R_FindImage( name, "_norm", (addFlags|IT_NORMALMAP), imagetags );
 
 	// load glossmap image
 	if( r_lighting_specular->integer ) {
-		images[1] = R_FindImage( name, "_gloss", addFlags );
+		images[1] = R_FindImage( name, "_gloss", addFlags, imagetags );
 	}
 
-	images[2] = R_FindImage( name, "_decal", addFlags );
+	images[2] = R_FindImage( name, "_decal", addFlags, imagetags );
 	if( !images[2] ) {
-		images[2] = R_FindImage( name, "_add", addFlags );
+		images[2] = R_FindImage( name, "_add", addFlags, imagetags );
 	}
 
 	*normalmap = images[0];
@@ -1083,7 +1083,7 @@ static void Shaderpass_CubeMapExt( shader_t *shader, shaderpass_t *pass, int add
 		return;
 	}
 
-	pass->images[0] = R_FindImage( token, NULL, flags|IT_CUBEMAP );
+	pass->images[0] = R_FindImage( token, NULL, flags|IT_CUBEMAP, shader->imagetags );
 	if( pass->images[0] )
 	{
 		pass->tcgen = tcgen;
@@ -1233,7 +1233,8 @@ static void Shaderpass_Material( shader_t *shader, shaderpass_t *pass, const cha
 
 	// load default images
 	pass->program_type = GLSL_PROGRAM_TYPE_MATERIAL;
-	Shaderpass_LoadMaterial( &pass->images[1], &pass->images[2], &pass->images[3], pass->images[0]->name, flags );
+	Shaderpass_LoadMaterial( &pass->images[1], &pass->images[2], &pass->images[3],
+		pass->images[0]->name, flags, shader->imagetags );
 }
 
 static void Shaderpass_Distortion( shader_t *shader, shaderpass_t *pass, const char **ptr )
@@ -1945,12 +1946,15 @@ static void R_UnlinkShader( shader_t *shader )
 void R_TouchShader( shader_t *s )
 {
 	unsigned i, j;
+	unsigned imagetags;
 
 	if( s->registrationSequence == rsh.registrationSequence ) {
 		return;
 	}
 
 	s->registrationSequence = rsh.registrationSequence;
+
+	imagetags = s->imagetags;
 
 	// touch all images this shader references
 	for( i = 0; i < s->numpasses; i++ ) {
@@ -1959,7 +1963,7 @@ void R_TouchShader( shader_t *s )
 		for( j = 0; j < MAX_SHADER_IMAGES; j++ ) {
 			image_t *image = pass->images[j];
 			if( image ) {
-				R_TouchImage( image );
+				R_TouchImage( image, imagetags );
 			} else if( !pass->program_type ) {
 				// only programs can have gaps in images
 				break;
@@ -1976,7 +1980,7 @@ void R_TouchShader( shader_t *s )
 		for( i = 0; i < 6; i++ ) {
 			image_t *image = s->skyboxImages[i];
 			if( image ) {
-				R_TouchImage( image );
+				R_TouchImage( image, imagetags );
 			}
 		}
 	}
@@ -1985,9 +1989,10 @@ void R_TouchShader( shader_t *s )
 /*
 * R_FreeUnusedShaders
 */
-void R_FreeUnusedShaders( void )
+void R_FreeUnusedShaders( const shaderType_e *types, unsigned int numTypes )
 {
 	int i;
+	unsigned int type;
 	shader_t *s;
 
 	for( i = 0, s = r_shaders; i < MAX_SHADERS; i++, s++ ) {
@@ -1998,6 +2003,18 @@ void R_FreeUnusedShaders( void )
 		if( s->registrationSequence == rsh.registrationSequence ) {
 			// we need this shader
 			continue;
+		}
+
+		if( numTypes ) {
+			for( type = 0; type < numTypes; type++ ) {
+				if( s->type == types[type] ) {
+					break;
+				}
+			}
+			if( type >= numTypes ) {
+				// not in the type filter
+				continue;
+			}
 		}
 
 		R_FreeShader( s );
@@ -2487,6 +2504,11 @@ static void R_LoadShaderReal( shader_t *s, const char *shortname,
 	s->name = ( char * )shortname; // HACK, will be copied over in Shader_Finish
 	s->type = type;
 
+	if( ( type == SHADER_TYPE_DELUXEMAP ) || ( type == SHADER_TYPE_VERTEX ) )
+		s->imagetags = IMAGE_TAG_WORLD;
+	else
+		s->imagetags = IMAGE_TAG_GENERIC;
+
 	// set defaults
 	s->flags = SHADER_CULL_FRONT;
 	s->vattribs = 0;
@@ -2565,7 +2587,7 @@ create_default:
 			break;
 		case SHADER_TYPE_DELUXEMAP:
 			// deluxemapping
-			Shaderpass_LoadMaterial( &materialImages[0], &materialImages[1], &materialImages[2], shortname, 0 );
+			Shaderpass_LoadMaterial( &materialImages[0], &materialImages[1], &materialImages[2], shortname, 0, s->imagetags );
 
 			data = R_Malloc( shortname_length + 1 + sizeof( shaderpass_t ) );
 			s->flags = SHADER_DEPTHWRITE|SHADER_CULL_FRONT|SHADER_LIGHTMAP;
@@ -2605,7 +2627,7 @@ create_default:
 			break;
 		case SHADER_TYPE_DIFFUSE:
 			// load material images
-			Shaderpass_LoadMaterial( &materialImages[0], &materialImages[1], &materialImages[2], shortname, 0 );
+			Shaderpass_LoadMaterial( &materialImages[0], &materialImages[1], &materialImages[2], shortname, 0, s->imagetags );
 
 			data = R_Malloc( shortname_length + 1 + sizeof( shaderpass_t ) );
 			s->flags = SHADER_DEPTHWRITE|SHADER_CULL_FRONT;
@@ -2720,6 +2742,52 @@ shader_t *R_ShaderById( unsigned int id )
 }
 
 /*
+* R_TouchShadersByName
+*/
+void R_TouchShadersByName( const char *name, const shaderType_e *types, unsigned int numTypes )
+{
+	unsigned int shortNameSize;
+	char *shortName;
+	unsigned int nameLength;
+	unsigned int key;
+	shader_t *hnode, *s;
+	unsigned int i, typesTouched = 0;
+
+	if( !name || !name[0] )
+		return;
+
+	shortNameSize = strlen( name ) + 1;
+	shortName = alloca( shortNameSize );
+	nameLength = R_ShaderCleanName( name, shortName, shortNameSize );
+	if( !nameLength )
+		return;
+
+	key = COM_SuperFastHash( ( const uint8_t * )shortName, nameLength, nameLength ) % SHADERS_HASH_SIZE;
+	hnode = &r_shaders_hash_headnode[key];
+	for( s = hnode->next; s != hnode; s = s->next ) {
+		if( strcmp( s->name, shortName ) ) {
+			continue;
+		}
+
+		if( !numTypes ) {
+			// touch all shaders with the requested name, no matter what their type is
+			R_TouchShader( s );
+			continue;
+		}
+
+		for( i = 0; i < numTypes; i++ ) {
+			if( s->type == types[i] ) {
+				R_TouchShader( s );
+				typesTouched++;
+			}
+		}
+		if( typesTouched == numTypes ) {
+			return;
+		}
+	}
+}
+
+/*
 * R_LoadShader
 */
 shader_t *R_LoadShader( const char *name, shaderType_e type, bool forceDefault )
@@ -2754,12 +2822,15 @@ shader_t *R_LoadShader( const char *name, shaderType_e type, bool forceDefault )
 
 	// scan all instances of the same shader for exact match of the type
 	for( s = hnode->next; s != hnode; s = s->next ) {
-		if( ( s->type == type ) && !strcmp( s->name, shortname ) ) {
+		if( strcmp( s->name, shortname ) ) {
+			continue;
+		}
+		if( s->type == type ) {
 			// exact match found
 			R_TouchShader( s );
 			return s;
 		}
-		if( ( type == SHADER_TYPE_2D ) && ( s->type == SHADER_TYPE_2D_RAW ) && !strcmp( s->name, shortname ) ) {
+		if( ( type == SHADER_TYPE_2D ) && ( s->type == SHADER_TYPE_2D_RAW ) ) {
 			// almost exact match:
 			// alias SHADER_TYPE_2D_RAW to SHADER_TYPE_2D so the shader can be "touched" by name
 			R_TouchShader( s );
@@ -2821,7 +2892,7 @@ shader_t *R_RegisterRawPic( const char *name, int width, int height, uint8_t *da
 		image = s->passes[0].images[0];
 		if( !image || image == rsh.noTexture ) {
 			// try to load new image
-			image = R_LoadImage( name, &data, width, height, flags, samples );
+			image = R_LoadImage( name, &data, width, height, flags, IMAGE_TAG_GENERIC, samples );
 			s->passes[0].images[0] = image;
 		}
 		else {

--- a/source/ref_gl/r_shader.h
+++ b/source/ref_gl/r_shader.h
@@ -297,9 +297,9 @@ shader_t	*R_RegisterSkin( const char *name );
 shader_t	*R_RegisterVideo( const char *name );
 
 void		R_TouchShader( shader_t *s );
-// if types contains SHADER_TYPE_2D, it likely should contain SHADER_TYPE_2D_RAW too
-void		R_TouchShadersByName( const char *name, const shaderType_e *types, unsigned int numTypes );
-void		R_FreeUnusedShaders( const shaderType_e *types, unsigned int numTypes );
+void		R_TouchShadersByName( const char *name );
+void		R_FreeUnusedShadersByType( const shaderType_e *types, unsigned int numTypes );
+void		R_FreeUnusedShaders( void );
 
 void		R_RemapShader( const char *from, const char *to, int timeOffset );
 

--- a/source/ref_gl/r_shader.h
+++ b/source/ref_gl/r_shader.h
@@ -243,6 +243,10 @@ typedef struct shader_s
 	unsigned int		flags;
 	vattribmask_t		vattribs;
 	unsigned int		sort;
+	int					imagetags;					// usage tags of the images - currently only depend
+													// on type, but if one shader can be requesed with
+													// different tags, functions like R_TouchShader
+													// should merge the existing and the requested tags
 
 	unsigned int		numpasses;
 	shaderpass_t		*passes;
@@ -293,7 +297,9 @@ shader_t	*R_RegisterSkin( const char *name );
 shader_t	*R_RegisterVideo( const char *name );
 
 void		R_TouchShader( shader_t *s );
-void		R_FreeUnusedShaders( void );
+// if types contains SHADER_TYPE_2D, it likely should contain SHADER_TYPE_2D_RAW too
+void		R_TouchShadersByName( const char *name, const shaderType_e *types, unsigned int numTypes );
+void		R_FreeUnusedShaders( const shaderType_e *types, unsigned int numTypes );
 
 void		R_RemapShader( const char *from, const char *to, int timeOffset );
 


### PR DESCRIPTION
This commit releases world textures from the previous map that are not used on the new map before the new textures are loaded, eliminating the video memory usage spike during map loading that may lead to crashes when two maps have very different texture sets.

Since shaders are hashed/keyed (and things like HUD already do lots of shader lookups every frame), loading times will not be increased.
