### PR TITLE
gs_pmove.c: Addition to f5a4900, fix bouncing off stairs

### DIFF
--- a/source/gameshared/gs_pmove.c
+++ b/source/gameshared/gs_pmove.c
@@ -436,8 +436,15 @@ static void PM_StepSlideMove( void )
 	hspeed = sqrt( start_v[0]*start_v[0] + start_v[1]*start_v[1] );
 	if( hspeed && ISWALKABLEPLANE( &trace.plane ) )
 	{
-		VectorNormalize2D( pml.velocity );
-		VectorScale2D( pml.velocity, hspeed, pml.velocity );
+		if( trace.plane.normal[2] >= 1.0f - SLIDEMOVE_PLANEINTERACT_EPSILON )
+		{
+			VectorCopy( start_v, pml.velocity );
+		}
+		else
+		{
+			VectorNormalize2D( pml.velocity );
+			VectorScale2D( pml.velocity, hspeed, pml.velocity );
+		}
 	}
 
 	// wsw : jal : The following line is what produces the ramp sliding.


### PR DESCRIPTION
Do not scale from pml.velocity when stepping on stairs but restore the original velocity.
