### PR TITLE
Some Steam presence improvements

### DIFF
--- a/source/client/cl_parse.c
+++ b/source/client/cl_parse.c
@@ -951,7 +951,7 @@ static void CL_ParseServerData( msg_t *msg )
 
 	cls.wakelock = Sys_AcquireWakeLock();
 
-	if( !cls.demo.playing && !cls.sv_tv && cls.serveraddress.type == NA_IP )
+	if( !cls.demo.playing && ( cls.serveraddress.type == NA_IP ) )
 		Steam_AdvertiseGame( cls.serveraddress.address.ipv4.ip, NET_GetAddressPort( &cls.serveraddress ) );
 
 	// separate the printfs so the server message can have a color

--- a/source/server/sv_oob.c
+++ b/source/server/sv_oob.c
@@ -1070,10 +1070,11 @@ bool SV_SteamServerQuery( const char *s, const socket_t *socket, const netadr_t 
 		MSG_WriteString( &msg, hostname );
 		MSG_WriteString( &msg, sv.mapname );
 		MSG_WriteString( &msg, gamedir );
-		if( sv.configstrings[CS_GAMETYPETITLE][0] )
+		if( sv.configstrings[CS_GAMETYPETITLE][0] || sv.configstrings[CS_GAMETYPENAME][0] )
 		{
 			char gamename[MAX_INFO_VALUE * 2];
-			Q_snprintfz( gamename, sizeof( gamename ), APPLICATION " %s", sv.configstrings[CS_GAMETYPETITLE] );
+			Q_snprintfz( gamename, sizeof( gamename ), APPLICATION " %s",
+				sv.configstrings[sv.configstrings[CS_GAMETYPETITLE][0] ? CS_GAMETYPETITLE : CS_GAMETYPENAME] );
 			MSG_WriteString( &msg, gamename );
 		}
 		else

--- a/source/tv_server/tv_downstream_oob.c
+++ b/source/tv_server/tv_downstream_oob.c
@@ -684,7 +684,7 @@ bool TV_Downstream_SteamServerQuery( const char *s, const socket_t *socket, cons
 		MSG_WriteString( &msg, hostname );
 		MSG_WriteString( &msg, "" ); // no map
 		MSG_WriteString( &msg, gamedir );
-		MSG_WriteString( &msg, APPLICATION );
+		MSG_WriteString( &msg, APPLICATION " TV" );
 		MSG_WriteShort( &msg, ( APP_STEAMID <= USHRT_MAX ) ? APP_STEAMID : 0 );
 		MSG_WriteByte( &msg, count );
 		MSG_WriteByte( &msg, min( tv_maxclients->integer, 99 ) );


### PR DESCRIPTION
Call AdvertiseGame for TV servers because they respond to Source queries now.

Also put game type script name in the game name in the server browser when the title is not available, and show TV servers as "Warsow TV" to distinguish from normal servers in favorites/history/friends tabs.
