### PR TITLE
Add CPU architecture to GL version hash

### DIFF
--- a/source/ref_gl/r_register.c
+++ b/source/ref_gl/r_register.c
@@ -1229,7 +1229,7 @@ static unsigned R_GLVersionHash( const char *vendorString,
 	unsigned hash;
 
 	tmp_size = strlen( vendorString ) + strlen( rendererString ) +
-		strlen( versionString ) + 1;
+		strlen( versionString ) + strlen( ARCH ) + 1;
 
 	pos = 0;
 	tmp = R_Malloc( tmp_size );
@@ -1244,6 +1244,11 @@ static unsigned R_GLVersionHash( const char *vendorString,
 
 	csize = strlen( versionString );
 	memcpy( tmp + pos, versionString, csize );
+	pos += csize;
+
+	// shaders are not compatible between 32-bit and 64-bit at least on Nvidia
+	csize = strlen( ARCH );
+	memcpy( tmp + pos, ARCH, csize );
 	pos += csize;
 
 	hash = COM_SuperFastHash( tmp, tmp_size, tmp_size );


### PR DESCRIPTION
Shaders are not compatible between 32-bit and 64-bit on Nvidia cards.
