### PR TITLE
Rewrite the code for YOU FRAGGED messages

### DIFF
--- a/source/cgame/cg_hud.cpp
+++ b/source/cgame/cg_hud.cpp
@@ -854,7 +854,11 @@ void CG_SC_Obituary( void )
 
 				if( ISVIEWERENTITY( attackerNum ) && ( cg_showObituaries->integer & CG_OBITUARY_CENTER ) )
 				{
-					CG_CenterPrintToUpper( S_COLOR_RED "YOU TEAMFRAGGED %s", victim->name );
+					char name[MAX_NAME_BYTES + 2];
+					Q_strncpyz( name, victim->name, sizeof( name ) );
+					Q_strupr( name );
+					Q_strncatz( name, S_COLOR_WHITE, sizeof( name ) );
+					CG_CenterPrint( va( CG_TranslateString( "YOU TEAMFRAGGED %s" ), name ) );
 				}
 			}
 			else // good kill
@@ -866,7 +870,11 @@ void CG_SC_Obituary( void )
 
 				if( ISVIEWERENTITY( attackerNum ) && ( cg_showObituaries->integer & CG_OBITUARY_CENTER ) )
 				{
-					CG_CenterPrintToUpper( "YOU FRAGGED %s", victim->name );
+					char name[MAX_NAME_BYTES + 2];
+					Q_strncpyz( name, victim->name, sizeof( name ) );
+					Q_strupr( name );
+					Q_strncatz( name, S_COLOR_WHITE, sizeof( name ) );
+					CG_CenterPrint( va( CG_TranslateString( "YOU FRAGGED %s" ), name ) );
 				}
 			}
 		}

--- a/source/cgame/cg_local.h
+++ b/source/cgame/cg_local.h
@@ -742,7 +742,6 @@ void CG_CalcVrect( void );
 void CG_TileClear( void );
 void CG_DrawLoading( void );
 void CG_CenterPrint( const char *str );
-void CG_CenterPrintToUpper( const char *format, ... );
 
 void CG_EscapeKey( void );
 void CG_LoadStatusBar( void );

--- a/source/cgame/cg_screen.cpp
+++ b/source/cgame/cg_screen.cpp
@@ -154,60 +154,6 @@ void CG_CenterPrint( const char *str )
 			scr_center_lines++;
 }
 
-void CG_CenterPrintToUpper( const char *format, ... )
-{
-	char c, *s;
-	int colorindex = -1;
-	va_list	argptr;
-	const char *tmp;
-	const char *new_format = format;
-	char l10n_format[sizeof(scr_centerstring)];
-	const char *l10n = NULL;
-
-	tmp = format;
-	if( Q_GrabCharFromColorString( &tmp, &c, &colorindex ) == GRABCHAR_COLOR ) {
-		// attempt to translate the remaining string
-		l10n = trap_L10n_TranslateString( tmp );
-	} else {
-		l10n = trap_L10n_TranslateString( format );
-	}
-
-	if( l10n ) {
-		if( colorindex > 0 ) {
-			l10n_format[0] = '^';
-			l10n_format[1] = '0' + colorindex;
-			Q_strncpyz( &l10n_format[2], l10n, sizeof( l10n_format ) - 2 );
-		}
-		else {
-			Q_strncpyz( l10n_format, l10n, sizeof( l10n_format ) );
-		}
-		new_format = l10n_format;
-	}
-
-	va_start( argptr, format );
-	Q_vsnprintfz( scr_centerstring, sizeof( scr_centerstring ), new_format, argptr );
-	va_end( argptr );
-
-	scr_centertime_off = cg_centerTime->value;
-	scr_centertime_start = cg.time;
-
-	// count the number of lines for centering
-	scr_center_lines = 1;
-	s = scr_centerstring;
-	while( *s )
-	{
-		if( *s == '\n' )
-		{
-			scr_center_lines++;
-		}
-		else
-		{
-			*s = toupper( *s );
-		}
-		s++;
-	}
-}
-
 static void CG_DrawCenterString( void )
 {
 	int y;


### PR DESCRIPTION
- Append ^7 to the name for German and Turkish localizations.
- Don't uppercase the whole translation, it's useless because it would only work for Latin scripts, and there are already some issues with it that should encourage uppercasing directly in the location (for example, our Turkish string for this was lowercase, but it had an `i` which should be `İ`, but because it was uppercased in cgame itself it became `I`).
