### PR TITLE
Change minimum dmBitsPerPel from 16 to 24

### DIFF
--- a/source/win32/win_vid.c
+++ b/source/win32/win_vid.c
@@ -614,7 +614,7 @@ unsigned int VID_GetSysModes( vidmode_t *modes )
 
 	for( i = 0; EnumDisplaySettings( NULL, i, &dm ); i++ )
 	{
-		if( dm.dmBitsPerPel < 16 )
+		if( dm.dmBitsPerPel < 24 )
 			continue;
 
 		if( ( dm.dmPelsWidth == prevwidth ) && ( dm.dmPelsHeight == prevheight ) )


### PR DESCRIPTION
Since Warsow requests a 24-bit pixel format, it likely doesn't work on 16-bit monitors. Also it was broken already, for high color Windows could return 15 bits, not 16.
