### PR TITLE
COM_FileExtension fixes

### DIFF
--- a/source/client/cl_parse.c
+++ b/source/client/cl_parse.c
@@ -126,7 +126,7 @@ bool CL_CheckOrDownloadFile( const char *filename )
 		return true;
 
 	ext = COM_FileExtension( filename );
-	if( !ext || !*ext )
+	if( !ext )
 		return true;
 
 	if( FS_CheckPakExtension( filename ) )
@@ -197,9 +197,15 @@ static void CL_DownloadComplete( void )
 	}
 
 	if( FS_CheckPakExtension( cls.download.name ) )
+	{
 		updateMapList = true;
-	else if( !Q_stricmp( COM_FileExtension( cls.download.name ), ".bsp" ) )
-		updateMapList = true;
+	}
+	else
+	{
+		const char *extension = COM_FileExtension( cls.download.name );
+		if( extension && !Q_stricmp( extension, ".bsp" ) )
+			updateMapList = true;
+	}
 
 	// Maplist hook so we also know when a new map is added
 	if( updateMapList )

--- a/source/gameshared/q_shared.c
+++ b/source/gameshared/q_shared.c
@@ -109,9 +109,6 @@ const char *COM_FileExtension( const char *filename )
 {
 	const char *src, *last;
 
-	if( !*filename )
-		return filename;
-
 	last = strrchr( filename, '/' );
 	src = strrchr( last ? last : filename, '.' );
 	if( src && *( src+1 ) )

--- a/source/qcommon/files.c
+++ b/source/qcommon/files.c
@@ -2631,14 +2631,14 @@ static pack_t *FS_LoadPackFile( const char *packfilename, bool silent )
 	Q_strncpyz( tempname, packfilename, sizeof( tempname ) );
 
 	ext = COM_FileExtension( tempname );
-	if( !ext || !*ext )
+	if( !ext )
 		return NULL;
 
 	if( !Q_stricmp( ext, ".tmp" ) )
 	{
 		COM_StripExtension( tempname );
 		ext = COM_FileExtension( tempname );
-		if( !ext || !*ext )
+		if( !ext )
 			return NULL;
 	}
 
@@ -2772,7 +2772,7 @@ bool FS_CheckPakExtension( const char *filename )
 	const char *ext;
 
 	ext = COM_FileExtension( filename );
-	if( !ext || *ext != '.' )
+	if( !ext )
 		return false;
 	ext++;
 

--- a/source/qcommon/mlist.c
+++ b/source/qcommon/mlist.c
@@ -627,17 +627,20 @@ static void ML_GetFullnameFromMap( const char *filename, char *fullname, size_t 
 */
 bool ML_ValidateFilename( const char *filename )
 {
+	const char *extension;
+
 	if( !filename || !*filename )
 		return false;
 
-	if( !COM_FileExtension( filename ) )
+	extension = COM_FileExtension( filename );
+	if( !extension )
 	{
 		if( strlen( "maps/" ) + strlen( filename ) + strlen( ".bsp" ) >= MAX_CONFIGSTRING_CHARS )
 			return false;
 	}
 	else
 	{
-		if( Q_stricmp( COM_FileExtension( filename ), ".bsp" ) )
+		if( Q_stricmp( extension, ".bsp" ) )
 			return false;
 		if( strlen( "maps/" ) + strlen( filename ) >= MAX_CONFIGSTRING_CHARS )
 			return false;

--- a/source/qcommon/sys_vfs_zip.c
+++ b/source/qcommon/sys_vfs_zip.c
@@ -332,7 +332,7 @@ char **Sys_VFS_Zip_ListFiles( const char *basepath, const char *gamedir, const c
 			if( strncmp( name, gamedir, dirlen ) || ( name[dirlen] != '/' ) )
 				continue;
 			e = COM_FileExtension( name );
-			if( !e || !e[0] ||  Q_stricmp( e + 1, extension ) )
+			if( !e || Q_stricmp( e + 1, extension ) )
 				continue;
 			list[nfiles++] = ZoneCopyString( va( "%s/%s", basepath, file->name ) );
 		}

--- a/source/server/sv_demos.c
+++ b/source/server/sv_demos.c
@@ -570,7 +570,7 @@ bool SV_IsDemoDownloadRequest( const char *request )
 	}
 
 	ext = COM_FileExtension( request );
-	if( !ext || !*ext || Q_stricmp( ext, APP_DEMO_EXTENSION_STR ) ) {
+	if( !ext || Q_stricmp( ext, APP_DEMO_EXTENSION_STR ) ) {
 		// wrong extension
 		return false;
 	}

--- a/source/server/sv_web.c
+++ b/source/server/sv_web.c
@@ -1100,7 +1100,7 @@ static void SV_Web_RouteRequest( const sv_http_request_t *request, sv_http_respo
 
 			// only serve GET requests for pack and demo files
 			extension = COM_FileExtension( filename );
-			if( !extension || !*extension || 
+			if( !extension || 
 				!(FS_CheckPakExtension( filename ) || !Q_stricmp( extension, APP_DEMO_EXTENSION_STR ) ) ) {
 				response->code = HTTP_RESP_FORBIDDEN;
 				return;


### PR DESCRIPTION
Makes COM_FileExtension return NULL, not an empty string, when an empty string is passed to it.

Also fixes a potential crash if somehow downloaded file without an extension, and overall cleanup to match the change and for consistency.
