### PR TITLE
Only print server out of date message once

### DIFF
--- a/source/server/sv_oob.c
+++ b/source/server/sv_oob.c
@@ -1219,13 +1219,18 @@ bool SV_SteamServerQuery( const char *s, const socket_t *socket, const netadr_t 
 	if( s[0] == 'O' )
 	{
 		// out of date message
-		int i;
-		for( i = 0; i < MAX_MASTERS; i++ )
+		static bool printed = false;
+		if( !printed )
 		{
-			if( sv_masters[i].steam && NET_CompareAddress( address, &sv_masters[i].address ) )
+			int i;
+			for( i = 0; i < MAX_MASTERS; i++ )
 			{
-				Com_Printf( "Server is out of date and cannot be added to the Steam master servers.\n" );
-				return true;
+				if( sv_masters[i].steam && NET_CompareAddress( address, &sv_masters[i].address ) )
+				{
+					Com_Printf( "Server is out of date and cannot be added to the Steam master servers.\n" );
+					printed = true;
+					return true;
+				}
 			}
 		}
 		return true;

--- a/source/tv_server/tv_downstream_oob.c
+++ b/source/tv_server/tv_downstream_oob.c
@@ -759,9 +759,16 @@ bool TV_Downstream_SteamServerQuery( const char *s, const socket_t *socket, cons
 	if( s[0] == 'O' )
 	{
 		// out of date message
-		bool isSteamMaster = false;
-		if( TV_Downstream_IsMaster( address, &isSteamMaster ) && isSteamMaster )
-			Com_Printf( "Server is out of date and cannot be added to the Steam master servers.\n" );
+		static bool printed = false;
+		if( !printed )
+		{
+			bool isSteamMaster = false;
+			if( TV_Downstream_IsMaster( address, &isSteamMaster ) && isSteamMaster )
+			{
+				Com_Printf( "Server is out of date and cannot be added to the Steam master servers.\n" );
+				printed = true;
+			}
+		}
 		return true;
 	}
 #endif


### PR DESCRIPTION
Prints the server out of date message coming from Steam master servers only once rather than 3 times every 5 minutes.
