### PR TITLE
Use real fullscreen on Linux/SDL

### DIFF
--- a/source/sdl/sdl_glw.c
+++ b/source/sdl/sdl_glw.c
@@ -53,13 +53,18 @@ void GLimp_SetWindowIcon( void )
 
 static bool GLimp_SetWindowFullscreen( bool fullscreen )
 {
+	Uint32 flags = 0;
+
 	if( fullscreen ) {
-		// we need to use SDL_WINDOW_FULLSCREEN_DESKTOP instead of SDL_WINDOW_FULLSCREEN to support Alt+Tab from fullscreen on OS X
-		return SDL_SetWindowFullscreen( glw_state.sdl_window, SDL_WINDOW_FULLSCREEN_DESKTOP ) == 0;
+#ifdef __APPLE__
+		// we need to use SDL_WINDOW_FULLSCREEN_DESKTOP to support Alt+Tab from fullscreen on OS X
+		flags = SDL_WINDOW_FULLSCREEN_DESKTOP;
+#else
+		flags = SDL_WINDOW_FULLSCREEN;
+#endif
 	}
-	else {
-		return SDL_SetWindowFullscreen( glw_state.sdl_window, 0 ) == 0;
-	}
+
+	return SDL_SetWindowFullscreen( glw_state.sdl_window, flags ) == 0;
 }
 
 static void GLimp_CreateWindow( int x, int y, int width, int height )

--- a/source/sdl/sdl_vid.c
+++ b/source/sdl/sdl_vid.c
@@ -83,6 +83,12 @@ void VID_FlashWindow( int count )
  */
 unsigned int VID_GetSysModes( vidmode_t *modes )
 {
+#ifdef __APPLE__
+	// only support borderless fullscreen because Alt+Tab doesn't work in fullscreen
+	if( modes )
+		VID_GetDefaultMode( &modes[0].width, &modes[0].height );
+	return 1;
+#else
 	int num;
 	SDL_DisplayMode mode;
 	int prevwidth = 0, prevheight = 0;
@@ -116,6 +122,7 @@ unsigned int VID_GetSysModes( vidmode_t *modes )
 	}
 
 	return ret;
+#endif
 }
 
 /*


### PR DESCRIPTION
Only allow borderless fullscreen with native resolution on Mac, but use real fullscreen on Linux.
