### PR TITLE
Cleanup lighting cvars

### DIFF
--- a/source/ref_gl/r_local.h
+++ b/source/ref_gl/r_local.h
@@ -339,7 +339,6 @@ extern cvar_t *r_portalonly;
 extern cvar_t *r_portalmaps;
 extern cvar_t *r_portalmaps_maxtexsize;
 
-extern cvar_t *r_lighting_bumpscale;
 extern cvar_t *r_lighting_deluxemapping;
 extern cvar_t *r_lighting_specular;
 extern cvar_t *r_lighting_glossintensity;

--- a/source/ref_gl/r_register.c
+++ b/source/ref_gl/r_register.c
@@ -55,7 +55,6 @@ cvar_t *r_portalonly;
 cvar_t *r_portalmaps;
 cvar_t *r_portalmaps_maxtexsize;
 
-cvar_t *r_lighting_bumpscale;
 cvar_t *r_lighting_deluxemapping;
 cvar_t *r_lighting_specular;
 cvar_t *r_lighting_glossintensity;
@@ -1078,7 +1077,6 @@ static void R_Register( const char *screenshotsPrefix )
 	r_portalmaps = ri.Cvar_Get( "r_portalmaps", "1", CVAR_ARCHIVE|CVAR_LATCH_VIDEO );
 	r_portalmaps_maxtexsize = ri.Cvar_Get( "r_portalmaps_maxtexsize", "1024", CVAR_ARCHIVE );
 
-	r_lighting_bumpscale = ri.Cvar_Get( "r_lighting_bumpscale", "8", CVAR_ARCHIVE|CVAR_LATCH_VIDEO );
 	r_lighting_deluxemapping = ri.Cvar_Get( "r_lighting_deluxemapping", "1", CVAR_ARCHIVE|CVAR_LATCH_VIDEO );
 	r_lighting_specular = ri.Cvar_Get( "r_lighting_specular", "1", CVAR_ARCHIVE|CVAR_LATCH_VIDEO );
 	r_lighting_glossintensity = ri.Cvar_Get( "r_lighting_glossintensity", "1.5", CVAR_ARCHIVE );
@@ -1089,7 +1087,7 @@ static void R_Register( const char *screenshotsPrefix )
 	r_lighting_packlightmaps = ri.Cvar_Get( "r_lighting_packlightmaps", "1", CVAR_ARCHIVE|CVAR_LATCH_VIDEO );
 	r_lighting_maxlmblocksize = ri.Cvar_Get( "r_lighting_maxlmblocksize", "2048", CVAR_ARCHIVE|CVAR_LATCH_VIDEO );
 	r_lighting_vertexlight = ri.Cvar_Get( "r_lighting_vertexlight", "0", CVAR_ARCHIVE|CVAR_LATCH_VIDEO );
-	r_lighting_maxglsldlights = ri.Cvar_Get( "r_lighting_maxglsldlights", "16", CVAR_ARCHIVE|CVAR_LATCH_VIDEO );
+	r_lighting_maxglsldlights = ri.Cvar_Get( "r_lighting_maxglsldlights", "16", CVAR_ARCHIVE );
 	r_lighting_grayscale = ri.Cvar_Get( "r_lighting_grayscale", "0", CVAR_ARCHIVE|CVAR_LATCH_VIDEO );
 
 	r_offsetmapping = ri.Cvar_Get( "r_offsetmapping", "2", CVAR_ARCHIVE );


### PR DESCRIPTION
Remove unused r_lighting_bumpscale, make r_lighting_maxglsldlights non-latched.
