### PR TITLE
Rewrite damage indicators

### DIFF
--- a/source/cgame/cg_damage_indicator.cpp
+++ b/source/cgame/cg_damage_indicator.cpp
@@ -29,13 +29,15 @@ void CG_DamageIndicatorAdd( int damage, const vec3_t dir )
 	unsigned int damageTime;
 	vec3_t playerAngles;
 	mat3_t playerAxis;
-#define INDICATOR_EPSILON 0.25f
+// epsilons are 30 degrees
+#define INDICATOR_EPSILON 0.5f
+#define INDICATOR_EPSILON_UP 0.85f
 #define TOP_BLEND 0
 #define RIGHT_BLEND 1
 #define BOTTOM_BLEND 2
 #define LEFT_BLEND 3
 	float blends[4];
-	float forward, side, up;
+	float forward, side;
 
 	if( !cg_damage_indicator->integer )
 		return;
@@ -52,8 +54,9 @@ void CG_DamageIndicatorAdd( int damage, const vec3_t dir )
 	Vector4Set( blends, 0, 0, 0, 0 );
 	damageTime = damage * cg_damage_indicator_time->value;
 
-	// asume frontal when no dir was given
-	if( !dir || VectorCompare( dir, vec3_origin ) || cg_damage_indicator->integer == 2 )
+	// up and down go distributed equally to all blends and assumed when no dir is given
+	if( !dir || VectorCompare( dir, vec3_origin ) || cg_damage_indicator->integer == 2 ||
+		( fabs( DotProduct( dir, &playerAxis[AXIS_UP] ) ) > INDICATOR_EPSILON_UP ) )
 	{
 		blends[RIGHT_BLEND] += damageTime;
 		blends[LEFT_BLEND] += damageTime;
@@ -64,40 +67,15 @@ void CG_DamageIndicatorAdd( int damage, const vec3_t dir )
 	{
 		side = DotProduct( dir, &playerAxis[AXIS_RIGHT] );
 		if( side > INDICATOR_EPSILON )
-		{
-			blends[LEFT_BLEND] += side * damageTime;
-		}
+			blends[LEFT_BLEND] += damageTime;
 		else if( side < -INDICATOR_EPSILON )
-		{
-			blends[RIGHT_BLEND] += -side * damageTime;
-		}
+			blends[RIGHT_BLEND] += damageTime;
 
-		up = DotProduct( dir, &playerAxis[AXIS_UP] );
-		if( up > INDICATOR_EPSILON )
-		{
-			blends[BOTTOM_BLEND] += up * damageTime;
-		}
-		else if( up < -INDICATOR_EPSILON )
-		{
-			blends[TOP_BLEND] += -up * damageTime;
-		}
-
-		// forward goes distributed equally to all blends
 		forward = DotProduct( dir, &playerAxis[AXIS_FORWARD] );
 		if( forward > INDICATOR_EPSILON )
-		{
-			blends[RIGHT_BLEND] += forward * damageTime;
-			blends[LEFT_BLEND] += forward * damageTime;
-			blends[TOP_BLEND] += forward * damageTime;
-			blends[BOTTOM_BLEND] += forward * damageTime;
-		}
+			blends[BOTTOM_BLEND] += damageTime;
 		else if( forward < -INDICATOR_EPSILON )
-		{
-			blends[RIGHT_BLEND] += -forward * damageTime;
-			blends[LEFT_BLEND] += -forward * damageTime;
-			blends[TOP_BLEND] += -forward * damageTime;
-			blends[BOTTOM_BLEND] += -forward * damageTime;
-		}
+			blends[TOP_BLEND] += damageTime;
 	}
 
 	for( i = 0; i < 4; i++ )
@@ -110,6 +88,7 @@ void CG_DamageIndicatorAdd( int damage, const vec3_t dir )
 #undef BOTTOM_BLEND
 #undef LEFT_BLEND
 #undef INDICATOR_EPSILON
+#undef INDICATOR_EPSILON_UP
 }
 
 /*

--- a/source/cgame/cg_events.cpp
+++ b/source/cgame/cg_events.cpp
@@ -905,7 +905,7 @@ void CG_Event_Fall( entity_state_t *state, int parm )
 
 		CG_StartFallKickEffect( ( parm + 5 ) * 10 );
 
-		if( parm > 0 )
+		if( parm >= 5 )
 			CG_DamageIndicatorAdd( parm, tv( 0, 0, 1 ) );
 	}
 

--- a/source/cgame/cg_main.cpp
+++ b/source/cgame/cg_main.cpp
@@ -768,7 +768,7 @@ static void CG_RegisterVariables( void )
 	cg_cartoonHitEffect =	trap_Cvar_Get( "cg_cartoonHitEffect", "0", CVAR_ARCHIVE );
 
 	cg_damage_indicator =	trap_Cvar_Get( "cg_damage_indicator", "1", CVAR_ARCHIVE );
-	cg_damage_indicator_time =	trap_Cvar_Get( "cg_damage_indicator_time", "50", CVAR_ARCHIVE );
+	cg_damage_indicator_time =	trap_Cvar_Get( "cg_damage_indicator_time", "25", CVAR_ARCHIVE );
 	cg_pickup_flash =	trap_Cvar_Get( "cg_pickup_flash", "0", CVAR_ARCHIVE );
 
 	cg_weaponAutoSwitch =	trap_Cvar_Get( "cg_weaponAutoSwitch", "2", CVAR_ARCHIVE );


### PR DESCRIPTION
- Change the meaning of the top and bottom indicators from useless up/down to front/back (up/down is now applied to all 4 indicators for cases such as rocket jumps).
- Change the epsilon to 30 degrees, so forward/backward and top/left indicators are only mixed when the damage is actually done from a corner.
- Since times are added, not alphas, don't multiply the times by dot products, so the indicators don't disappear too quickly.
