### PR TITLE
Small fix for the fall damage indicator

### DIFF
--- a/source/cgame/cg_events.cpp
+++ b/source/cgame/cg_events.cpp
@@ -905,7 +905,7 @@ void CG_Event_Fall( entity_state_t *state, int parm )
 
 		CG_StartFallKickEffect( ( parm + 5 ) * 10 );
 
-		if( parm >= 5 )
+		if( parm >= 15 )
 			CG_DamageIndicatorAdd( parm, tv( 0, 0, 1 ) );
 	}
 


### PR DESCRIPTION
My mistake when testing, armor absorbed 66% of the damage so the indicator still appears on small height falls.
