### PR TITLE
Libraries ftlib, ref_gl, cin, snd_openal, snd_qf are linked with libm…

### DIFF
--- a/source/cin/CMakeLists.txt
+++ b/source/cin/CMakeLists.txt
@@ -12,6 +12,12 @@ file(GLOB CIN_SOURCES
     "../gameshared/q_*.c"
 )
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+        set(CLIENT_PLATFORM_LIBRARIES "m")
+else ()
+        set(CLIENT_PLATFORM_LIBRARIES "")
+endif()
+
 add_library(cin SHARED ${CIN_SOURCES} ${CIN_HEADERS})
-target_link_libraries(cin PRIVATE ${OGG_LIBRARY} ${VORBIS_LIBRARIES} ${THEORA_LIBRARY})
+target_link_libraries(cin PRIVATE ${OGG_LIBRARY} ${VORBIS_LIBRARIES} ${THEORA_LIBRARY} ${CLIENT_PLATFORM_LIBRARIES})
 qf_set_output_dir(cin libs)

--- a/source/ftlib/CMakeLists.txt
+++ b/source/ftlib/CMakeLists.txt
@@ -12,6 +12,12 @@ file(GLOB FTLIB_SOURCES
     "../gameshared/q_*.c"
 )
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+        set(CLIENT_PLATFORM_LIBRARIES "m")
+else ()
+        set(CLIENT_PLATFORM_LIBRARIES "")
+endif()
+
 add_library(ftlib SHARED ${FTLIB_SOURCES} ${FTLIB_HEADERS})
-target_link_libraries(ftlib PRIVATE ${FREETYPE_LIBRARIES})
+target_link_libraries(ftlib PRIVATE ${FREETYPE_LIBRARIES} ${CLIENT_PLATFORM_LIBRARIES})
 qf_set_output_dir(ftlib libs)

--- a/source/ref_gl/CMakeLists.txt
+++ b/source/ref_gl/CMakeLists.txt
@@ -51,7 +51,7 @@ else()
             "../unix/unix_xpm.c"
         )
 
-        set(REF_GL_PLATFORM_LIBRARIES "X11" "Xext" "Xinerama" "Xrandr" "Xxf86vm")
+        set(REF_GL_PLATFORM_LIBRARIES "X11" "Xext" "Xinerama" "Xrandr" "Xxf86vm" "m")
     endif()
 endif()
 

--- a/source/snd_openal/CMakeLists.txt
+++ b/source/snd_openal/CMakeLists.txt
@@ -18,6 +18,12 @@ file(GLOB SND_OPENAL_SOURCES
     "../gameshared/q_*.c"
 )
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+        set(CLIENT_PLATFORM_LIBRARIES "m")
+else ()
+        set(CLIENT_PLATFORM_LIBRARIES "")
+endif()
+
 add_library(snd_openal SHARED ${SND_OPENAL_HEADERS} ${SND_OPENAL_SOURCES})
-target_link_libraries(snd_openal PRIVATE ${OGG_LIBRARY} ${VORBIS_LIBRARIES})
+target_link_libraries(snd_openal PRIVATE ${OGG_LIBRARY} ${VORBIS_LIBRARIES} ${CLIENT_PLATFORM_LIBRARIES})
 qf_set_output_dir(snd_openal libs)

--- a/source/snd_qf/CMakeLists.txt
+++ b/source/snd_qf/CMakeLists.txt
@@ -32,6 +32,12 @@ else()
     set(SND_QF_PLATFORM_LIBRARIES "winmm.lib")
 endif()
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+        set(CLIENT_PLATFORM_LIBRARIES "m")
+else ()
+        set(CLIENT_PLATFORM_LIBRARIES "")
+endif()
+
 add_library(snd_qf SHARED ${SND_QF_HEADERS} ${SND_QF_SOURCES} ${SND_QF_PLATFORM_SOURCES})
-target_link_libraries(snd_qf PRIVATE ${OGG_LIBRARY} ${VORBIS_LIBRARIES} ${SND_QF_PLATFORM_LIBRARIES})
+target_link_libraries(snd_qf PRIVATE ${OGG_LIBRARY} ${VORBIS_LIBRARIES} ${SND_QF_PLATFORM_LIBRARIES} ${CLIENT_PLATFORM_LIBRARIES})
 qf_set_output_dir(snd_qf libs)


### PR DESCRIPTION
… under Linux.

Ниже повтор предыдущего текста. В этот раз я вызвал не git add, а git apply. :-) В принципе, underlinking - это просто предупреждение, не "фатальная ошибка", но, я боюсь, что сборочница ALT Linux такой пакет просто не пропустит. Поэтому под OSX можно и не линковать с этими библиотеками, а можно и слинковать - так аккуратнее.

---

Пожалуйста, рассмотрите моё вмешательство в файлы cmake (желательно stopiccot).

Я попытался обновить пакет warsow в дистрибутиве ALT Linux до текущей беты 1.6. В качестве engine я взял текущий QFusion (после релиза возьму релизный SDK). Всё отлично скомпилировалось (правда с предупреждениями), но после этого внутренние тесты дистрибутива обнаружили вот что:

lib.req: WARNING: /home/vkni/tmp/warsow-buildroot/usr/lib64/warsow/libs/libcin_x86_64.so: underlinked libraries: /lib64/libm.so.6
lib.req: WARNING: /home/vkni/tmp/warsow-buildroot/usr/lib64/warsow/libs/libftlib_x86_64.so: underlinked libraries: /lib64/libm.so.6
lib.req: WARNING: /home/vkni/tmp/warsow-buildroot/usr/lib64/warsow/libs/libref_gl_x86_64.so: underlinked libraries: /lib64/libm.so.6
lib.req: WARNING: /home/vkni/tmp/warsow-buildroot/usr/lib64/warsow/libs/libsnd_openal_x86_64.so: underlinked libraries: /lib64/libm.so.6
lib.req: WARNING: /home/vkni/tmp/warsow-buildroot/usr/lib64/warsow/libs/libsnd_qf_x86_64.so: underlinked libraries: /lib64/libm.so.6

verify-elf: WARNING: ./usr/lib64/warsow/libs/libangelwrap_x86_64.so: undefined symbol: pthread_rwlock_unlock
verify-elf: WARNING: ./usr/lib64/warsow/libs/libangelwrap_x86_64.so: undefined symbol: pthread_key_create
verify-elf: WARNING: ./usr/lib64/warsow/libs/libangelwrap_x86_64.so: undefined symbol: pthread_rwlock_init
verify-elf: WARNING: ./usr/lib64/warsow/libs/libangelwrap_x86_64.so: undefined symbol: pthread_getspecific
verify-elf: WARNING: ./usr/lib64/warsow/libs/libangelwrap_x86_64.so: undefined symbol: pthread_mutex_trylock
verify-elf: WARNING: ./usr/lib64/warsow/libs/libangelwrap_x86_64.so: undefined symbol: pthread_key_delete
verify-elf: WARNING: ./usr/lib64/warsow/libs/libangelwrap_x86_64.so: undefined symbol: pthread_rwlock_rdlock
verify-elf: WARNING: ./usr/lib64/warsow/libs/libangelwrap_x86_64.so: undefined symbol: pthread_rwlock_destroy
verify-elf: WARNING: ./usr/lib64/warsow/libs/libangelwrap_x86_64.so: undefined symbol: pthread_rwlock_wrlock
verify-elf: WARNING: ./usr/lib64/warsow/libs/libangelwrap_x86_64.so: undefined symbol: pthread_setspecific
verify-elf: WARNING: ./usr/lib64/warsow/libs/libsnd_openal_x86_64.so: undefined symbol: dlopen
verify-elf: WARNING: ./usr/lib64/warsow/libs/libsnd_openal_x86_64.so: undefined symbol: dlclose
verify-elf: WARNING: ./usr/lib64/warsow/libs/libsnd_openal_x86_64.so: undefined symbol: dlsym
verify-elf: WARNING: ./usr/lib64/warsow/libs/libirc_x86_64.so: undefined symbol: __pow_finite
verify-elf: WARNING: ./usr/lib64/warsow/libs/libirc_x86_64.so: undefined symbol: sincos
verify-elf: WARNING: ./usr/lib64/warsow/libs/libirc_x86_64.so: undefined symbol: __expf_finite
verify-elf: WARNING: ./usr/lib64/warsow/libs/libirc_x86_64.so: undefined symbol: cosf
verify-elf: WARNING: ./usr/lib64/warsow/libs/libirc_x86_64.so: undefined symbol: __exp_finite
verify-elf: WARNING: ./usr/lib64/warsow/libs/libirc_x86_64.so: undefined symbol: __acosf_finite
verify-elf: WARNING: ./usr/lib64/warsow/libs/libirc_x86_64.so: undefined symbol: sin
verify-elf: WARNING: ./usr/lib64/warsow/libs/libirc_x86_64.so: undefined symbol: atan
verify-elf: WARNING: ./usr/lib64/warsow/libs/libirc_x86_64.so: undefined symbol: __atan2_finite
verify-elf: WARNING: ./usr/lib64/warsow/libs/libirc_x86_64.so: undefined symbol: tan
verify-elf: WARNING: ./usr/lib64/warsow/libs/libirc_x86_64.so: undefined symbol: sincosf
verify-elf: WARNING: ./usr/lib64/warsow/libs/libirc_x86_64.so: undefined symbol: __asinf_finite

Pull request корректирует только часть предупреждений - те, что об underlinked libraries. С остальными предупреждениями я разберусь позже.

Кроме того, в libRocket были предупреждения об неинициализированных переменных (это лучше отловить PVS-кой). Компилятор - x86_64-alt-linux-gcc (GCC) 5.1.1 20150618 (ALT Linux 5.1.1-alt2)
