### PR TITLE
Added libraries, missing under Linux, to irc, snd_openal, and angelwrap.

### DIFF
--- a/source/angelwrap/CMakeLists.txt
+++ b/source/angelwrap/CMakeLists.txt
@@ -15,8 +15,14 @@ file(GLOB angelwrap_SOURCES
     "../gameshared/q_*.c"
 )
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+	set(ANGELWRAP_PLATFORM_LIBRARIES "pthread")
+else ()
+        set(ANGELWRAP_PLATFORM_LIBRARIES "")
+endif()
+
 add_library(angelwrap SHARED ${angelwrap_SOURCES} ${angelwrap_HEADERS})
-target_link_libraries(angelwrap PRIVATE ${ANGELSCRIPT_LIBRARY})
+target_link_libraries(angelwrap PRIVATE ${ANGELSCRIPT_LIBRARY} ${ANGELWRAP_PLATFORM_LIBRARIES})
 qf_set_output_dir(angelwrap libs)
 
 # TODO: Remove this hack from here

--- a/source/irc/CMakeLists.txt
+++ b/source/irc/CMakeLists.txt
@@ -17,3 +17,7 @@ qf_set_output_dir(irc libs)
 if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     target_link_libraries(irc PRIVATE "ws2_32.lib")
 endif()
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    target_link_libraries(irc PRIVATE "m")
+endif()

--- a/source/snd_openal/CMakeLists.txt
+++ b/source/snd_openal/CMakeLists.txt
@@ -19,7 +19,7 @@ file(GLOB SND_OPENAL_SOURCES
 )
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-        set(SND_OPENAL_PLATFORM_LIBRARIES "m")
+        set(SND_OPENAL_PLATFORM_LIBRARIES "m" "dl")
 else ()
         set(SND_OPENAL_PLATFORM_LIBRARIES "")
 endif()


### PR DESCRIPTION
Добавлены библиотеки под Linux'ом:
1. pthread - в angelwrap
2. m (синусы-косинусы и прочие неприличные слова) - в irc
3. dl (dlopen и т.д.) - в snd_openal
