### PR TITLE
Fix setting of RF_PORTALVIEW

### DIFF
--- a/source/ref_gl/r_portals.c
+++ b/source/ref_gl/r_portals.c
@@ -281,7 +281,7 @@ setup_and_render:
 		Matrix3_Copy( rn.refdef.viewaxis, axis );
 		VectorCopy( viewerOrigin, rn.pvsOrigin );
 
-		rn.renderFlags = RF_PORTALVIEW;
+		rn.renderFlags |= RF_PORTALVIEW;
 		if( prevFlipped )
 			rn.renderFlags |= RF_FLIPFRONTFACE;
 	}
@@ -337,6 +337,8 @@ setup_and_render:
 		// might fly into (or behind) a wall
 		VectorCopy( best->origin2, rn.pvsOrigin );
 		VectorCopy( best->origin2, rn.lodOrigin );
+
+		rn.renderFlags |= RF_PORTALVIEW;
 
 		// ignore entities, if asked politely
 		if( best->renderfx & RF_NOPORTALENTS )


### PR DESCRIPTION
In the `else` case of portal `rn` configuration, set RF_PORTALVIEW flag (like it was set in 1.5), otherwise there may be things like nested portals and weapon view model visible through the portals.

Also use `|=` instead of `=` for the refraction case, since it appears to be 1.5 legacy (the mirror case uses `|=` now while it used `=` in 1.5).
