### PR TITLE
Remove unused number above flags

### DIFF
--- a/source/cgame/cg_ents.cpp
+++ b/source/cgame/cg_ents.cpp
@@ -1119,20 +1119,6 @@ static void CG_AddFlagBaseEnt( centity_t *cent )
 
 		CG_AddFlagModelOnTag( cent, CG_TeamColorForEntity( cent->current.number, teamcolor ), "tag_flag1" );
 	}
-	// modelindex2 can add a number from 0 to 9
-	else if( cent->current.modelindex2 > 0 && cent->current.modelindex2 <= 10 )
-	{
-		static entity_t number;
-		number = cent->ent;
-		Vector4Set( number.shaderRGBA, 255, 255, 255, 255 );
-		number.rtype = RT_SPRITE;
-		number.origin[2] += 24;
-		number.origin2[2] += 24;
-		number.model = NULL;
-		number.radius = 12;
-		number.customShader = CG_MediaShader( cgs.media.shaderFlagNums[cent->current.modelindex2 - 1] );
-		CG_AddEntityToScene( &number );
-	}
 }
 
 //==========================================================================

--- a/source/cgame/cg_local.h
+++ b/source/cgame/cg_local.h
@@ -297,7 +297,6 @@ typedef struct
 	//wsw
 	cgs_media_handle_t *shaderPlayerShadow;
 	cgs_media_handle_t *shaderFlagFlare;
-	cgs_media_handle_t *shaderFlagNums[10];
 
 	// hud icons
 	cgs_media_handle_t *shaderWeaponIcon[WEAP_TOTAL];

--- a/source/cgame/cg_media.cpp
+++ b/source/cgame/cg_media.cpp
@@ -292,8 +292,6 @@ struct shader_s *CG_MediaShader( cgs_media_handle_t *mediashader )
 */
 void CG_RegisterMediaShaders( void )
 {
-	int i;
-
 	shader_headnode = NULL;
 
 	cgs.media.shaderParticle = CG_RegisterMediaShader( "particle", true );
@@ -355,8 +353,6 @@ void CG_RegisterMediaShaders( void )
 
 	// ctf
 	cgs.media.shaderFlagFlare = CG_RegisterMediaShader( PATH_FLAG_FLARE_SHADER, false );
-	for( i = 0; i < 10; i++ )
-		cgs.media.shaderFlagNums[i] = CG_RegisterMediaShader( va( "gfx/hud/%i", i ), false );
 
 	cgs.media.shaderRaceGhostEffect = CG_RegisterMediaShader( "gfx/raceghost", false );
 


### PR DESCRIPTION
Modelindex2 was set in 0.41 CTF, but AS CTF doesn't reference it anymore. Lets us remove unatlased sbnum images.
