### PR TITLE
Hack PowerVR RGB FB blending using clear, not shader combo

### DIFF
--- a/glsl/defaultCelshade.frag.glsl
+++ b/glsl/defaultCelshade.frag.glsl
@@ -94,9 +94,5 @@ void main(void)
 	outColor.rgb = mix(outColor.rgb, u_FogColor, fogDensity);
 #endif
 
-#ifdef APPLY_BLEND
 	qf_FragColor = vec4(outColor);
-#else
-	qf_FragColor = vec4(vec3(outColor), 1.0);
-#endif
 }

--- a/glsl/defaultMaterial.frag.glsl
+++ b/glsl/defaultMaterial.frag.glsl
@@ -144,9 +144,5 @@ void main()
 	color.rgb = mix(color.rgb, u_FogColor, fogDensity);
 #endif
 
-#ifdef APPLY_BLEND
 	qf_FragColor = vec4(color);
-#else
-	qf_FragColor = vec4(vec3(color), 1.0);
-#endif
 }

--- a/glsl/defaultQ3AShader.frag.glsl
+++ b/glsl/defaultQ3AShader.frag.glsl
@@ -107,9 +107,5 @@ void main(void)
 	QF_ALPHATEST(color.a);
 #endif
 
-#ifdef APPLY_BLEND
 	qf_FragColor = vec4(color);
-#else
-	qf_FragColor = vec4(vec3(color), 1.0);
-#endif
 }

--- a/source/ref_gl/r_backend.c
+++ b/source/ref_gl/r_backend.c
@@ -557,7 +557,13 @@ void RB_Clear( int bits, float r, float g, float b, float a )
 
 	if( bits & GL_COLOR_BUFFER_BIT )
 	{
-		state = ( state & ~GLSTATE_NO_COLORWRITE ) | GLSTATE_ALPHAWRITE;
+		int fboID = RB_BoundFrameBufferObject();
+		image_t *fboTex = RFB_GetObjectTextureAttachment( fboID, false );
+
+		state &= ~GLSTATE_NO_COLORWRITE;
+		if( ( !fboID && glConfig.forceRGBAFramebuffers ) || ( fboTex && ( fboTex->samples == 4 ) ) )
+			state |= GLSTATE_ALPHAWRITE;
+
 		qglClearColor( r, g, b, a );
 	}
 

--- a/source/ref_gl/r_backend.c
+++ b/source/ref_gl/r_backend.c
@@ -357,12 +357,12 @@ void RB_SetState( int state )
 		}
 	}
 
-	if( diff & GLSTATE_NO_COLORWRITE )
+	if( diff & (GLSTATE_NO_COLORWRITE|GLSTATE_ALPHAWRITE) )
 	{
 		if( state & GLSTATE_NO_COLORWRITE )
 			qglColorMask( GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE );
 		else
-			qglColorMask( GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE );
+			qglColorMask( GL_TRUE, GL_TRUE, GL_TRUE, ( state & GLSTATE_ALPHAWRITE ) ? GL_TRUE : GL_FALSE );
 	}
 
 	if( diff & (GLSTATE_DEPTHFUNC_EQ|GLSTATE_DEPTHFUNC_GT) )
@@ -557,7 +557,7 @@ void RB_Clear( int bits, float r, float g, float b, float a )
 
 	if( bits & GL_COLOR_BUFFER_BIT )
 	{
-		state &= ~GLSTATE_NO_COLORWRITE;
+		state = ( state & ~GLSTATE_NO_COLORWRITE ) | GLSTATE_ALPHAWRITE;
 		qglClearColor( r, g, b, a );
 	}
 

--- a/source/ref_gl/r_backend.c
+++ b/source/ref_gl/r_backend.c
@@ -557,13 +557,7 @@ void RB_Clear( int bits, float r, float g, float b, float a )
 
 	if( bits & GL_COLOR_BUFFER_BIT )
 	{
-		int fboID = RB_BoundFrameBufferObject();
-		image_t *fboTex = RFB_GetObjectTextureAttachment( fboID, false );
-
-		state &= ~GLSTATE_NO_COLORWRITE;
-		if( ( !fboID && glConfig.forceRGBAFramebuffers ) || ( fboTex && ( fboTex->samples == 4 ) ) )
-			state |= GLSTATE_ALPHAWRITE;
-
+		state = ( state & ~GLSTATE_NO_COLORWRITE ) | GLSTATE_ALPHAWRITE;
 		qglClearColor( r, g, b, a );
 	}
 

--- a/source/ref_gl/r_backend_program.c
+++ b/source/ref_gl/r_backend_program.c
@@ -920,10 +920,6 @@ static void RB_RenderMeshGLSL_Material( const shaderpass_t *pass, r_glslfeat_t p
 	// set shaderpass state (blending, depthwrite, etc)
 	RB_SetShaderpassState( pass->flags );
 
-	if( rb.gl.state & GLSTATE_BLEND_MASK ) {
-		programFeatures |= GLSL_SHADER_COMMON_BLEND;
-	}
-
 	// we only send S-vectors to GPU and recalc T-vectors as cross product
 	// in vertex shader
 	RB_BindTexture( 1, normalmap );         // normalmap
@@ -1571,10 +1567,6 @@ static void RB_RenderMeshGLSL_Q3AShader( const shaderpass_t *pass, r_glslfeat_t 
 
 	RB_SetShaderpassState( state );
 
-	if( rb.gl.state & GLSTATE_BLEND_MASK ) {
-		programFeatures |= GLSL_SHADER_COMMON_BLEND;
-	}
-
 	if( programFeatures & GLSL_SHADER_COMMON_SOFT_PARTICLE ) {
 		RB_BindTexture( 3, rsh.screenDepthTextureCopy );
 	}
@@ -1670,10 +1662,6 @@ static void RB_RenderMeshGLSL_Celshade( const shaderpass_t *pass, r_glslfeat_t p
 
 	// set shaderpass state (blending, depthwrite, etc)
 	RB_SetShaderpassState( pass->flags );
-
-	if( rb.gl.state & GLSTATE_BLEND_MASK ) {
-		programFeatures |= GLSL_SHADER_COMMON_BLEND;
-	}
 
 	// replacement images are there to ensure that the entity is still
 	// properly colored despite real images still being loaded in a separate thread
@@ -2241,6 +2229,8 @@ static void RB_SetShaderState( void )
 */
 static void RB_SetShaderpassState( int state )
 {
+	image_t *fboTex = RFB_GetObjectTextureAttachment( RB_BoundFrameBufferObject(), false );
+
 	state |= rb.currentShaderState;
 	if( rb.alphaHack ) {
 		if( !( state & GLSTATE_BLEND_MASK ) ) {
@@ -2250,6 +2240,9 @@ static void RB_SetShaderpassState( int state )
 	}
 	if( rb.noColorWrite ) {
 		state |= GLSTATE_NO_COLORWRITE;
+	}
+	if( fboTex && ( fboTex->samples == 4 ) ) {
+		state |= GLSTATE_ALPHAWRITE;
 	}
 	if( rb.depthEqual && (state & GLSTATE_DEPTHWRITE) ) {
 		state |= GLSTATE_DEPTHFUNC_EQ;

--- a/source/ref_gl/r_backend_program.c
+++ b/source/ref_gl/r_backend_program.c
@@ -2229,8 +2229,6 @@ static void RB_SetShaderState( void )
 */
 static void RB_SetShaderpassState( int state )
 {
-	image_t *fboTex = RFB_GetObjectTextureAttachment( RB_BoundFrameBufferObject(), false );
-
 	state |= rb.currentShaderState;
 	if( rb.alphaHack ) {
 		if( !( state & GLSTATE_BLEND_MASK ) ) {
@@ -2240,9 +2238,6 @@ static void RB_SetShaderpassState( int state )
 	}
 	if( rb.noColorWrite ) {
 		state |= GLSTATE_NO_COLORWRITE;
-	}
-	if( fboTex && ( fboTex->samples == 4 ) ) {
-		state |= GLSTATE_ALPHAWRITE;
 	}
 	if( rb.depthEqual && (state & GLSTATE_DEPTHWRITE) ) {
 		state |= GLSTATE_DEPTHFUNC_EQ;

--- a/source/ref_gl/r_glimp.h
+++ b/source/ref_gl/r_glimp.h
@@ -120,17 +120,18 @@ enum
 	GLSTATE_DSTBLEND_ONE_MINUS_DST_ALPHA	= 128,
 
 	GLSTATE_NO_COLORWRITE					= 0x100,
+	GLSTATE_ALPHAWRITE						= 0x200,
 
-	GLSTATE_DEPTHWRITE						= 0x200,
-	GLSTATE_DEPTHFUNC_EQ					= 0x400,
-	GLSTATE_DEPTHFUNC_GT					= 0x800,
+	GLSTATE_DEPTHWRITE						= 0x400,
+	GLSTATE_DEPTHFUNC_EQ					= 0x800,
+	GLSTATE_DEPTHFUNC_GT					= 0x1000,
 
-	GLSTATE_OFFSET_FILL						= 0x1000,
-	GLSTATE_NO_DEPTH_TEST					= 0x2000,
+	GLSTATE_OFFSET_FILL						= 0x2000,
+	GLSTATE_NO_DEPTH_TEST					= 0x4000,
 
-	GLSTATE_STENCIL_TEST					= 0x4000,
+	GLSTATE_STENCIL_TEST					= 0x8000,
 
-	GLSTATE_MARK_END						= 0x8000 // SHADERPASS_MARK_BEGIN
+	GLSTATE_MARK_END						= 0x10000 // SHADERPASS_MARK_BEGIN
 };
 
 #define GLSTATE_MASK		( GLSTATE_MARK_END-1 )
@@ -239,6 +240,9 @@ typedef struct
 					,maxFragmentUniformComponents
 					;
 	unsigned int	maxGLSLBones;	// the maximum amount of bones we can handle in a vertex shader
+
+	bool			forceRGBAFramebuffers;	// PowerVR hack - its blending interprets alpha in RGB FBs as 0, not 1
+
 	glextinfo_t		ext;
 } glconfig_t;
 

--- a/source/ref_gl/r_image.c
+++ b/source/ref_gl/r_image.c
@@ -2630,8 +2630,8 @@ static void R_InitScreenTexturesPair( const char *name, image_t **color,
 	}
 
 	if( color ) {
-		// samples is 4 no matter whether alpha blending is used because RGB FBs are broken on some PowerVRs
-		R_InitViewportTexture( color, name, 0, glConfig.width, glConfig.height, 0, colorFlags, IMAGE_TAG_BUILTIN, 4 );
+		R_InitViewportTexture( color, name, 0, glConfig.width, glConfig.height, 0, colorFlags, IMAGE_TAG_BUILTIN,
+			glConfig.forceRGBAFramebuffers ? 4 : 3 );
 	}
 	if( depth && *color ) {
 		R_InitViewportTexture( depth, va( "%s_depth", name ), 0, glConfig.width, glConfig.height, 0, depthFlags, IMAGE_TAG_BUILTIN, 1 );

--- a/source/ref_gl/r_program.c
+++ b/source/ref_gl/r_program.c
@@ -632,8 +632,6 @@ static const glsl_feature_t glsl_features_material[] =
 	{ GLSL_SHADER_COMMON_AFUNC_LT128, "#define QF_ALPHATEST(a) { if ((a) >= 0.5) discard; }\n", "_afunc_lt128" },
 	{ GLSL_SHADER_COMMON_AFUNC_GT0, "#define QF_ALPHATEST(a) { if ((a) <= 0.0) discard; }\n", "_afunc_gt0" },
 
-	{ GLSL_SHADER_COMMON_BLEND, "#define APPLY_BLEND\n", "_blend" },
-
 	{ GLSL_SHADER_COMMON_TC_MOD, "#define APPLY_TC_MOD\n", "_tc_mod" },
 
 	{ GLSL_SHADER_MATERIAL_LIGHTSTYLE3, "#define NUM_LIGHTMAPS 4\n#define qf_lmvec01 vec4\n#define qf_lmvec23 vec4\n", "_ls3" },
@@ -798,7 +796,6 @@ static const glsl_feature_t glsl_features_q3a[] =
 	{ GLSL_SHADER_COMMON_AFUNC_LT128, "#define QF_ALPHATEST(a) { if ((a) >= 0.5) discard; }\n", "_afunc_lt128" },
 	{ GLSL_SHADER_COMMON_AFUNC_GT0, "#define QF_ALPHATEST(a) { if ((a) <= 0.0) discard; }\n", "_afunc_gt0" },
 
-	{ GLSL_SHADER_COMMON_BLEND, "#define APPLY_BLEND\n", "_blend" },
 
 	{ GLSL_SHADER_COMMON_TC_MOD, "#define APPLY_TC_MOD\n", "_tc_mod" },
 
@@ -851,8 +848,6 @@ static const glsl_feature_t glsl_features_celshade[] =
 	{ GLSL_SHADER_COMMON_AFUNC_GE128, "#define QF_ALPHATEST(a) { if ((a) < 0.5) discard; }\n", "_afunc_ge128" },
 	{ GLSL_SHADER_COMMON_AFUNC_LT128, "#define QF_ALPHATEST(a) { if ((a) >= 0.5) discard; }\n", "_afunc_lt128" },
 	{ GLSL_SHADER_COMMON_AFUNC_GT0, "#define QF_ALPHATEST(a) { if ((a) <= 0.0) discard; }\n", "_afunc_gt0" },
-
-	{ GLSL_SHADER_COMMON_BLEND, "#define APPLY_BLEND\n", "_blend" },
 
 	{ GLSL_SHADER_COMMON_TC_MOD, "#define APPLY_TC_MOD\n", "_tc_mod" },
 

--- a/source/ref_gl/r_program.h
+++ b/source/ref_gl/r_program.h
@@ -23,7 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 typedef uint64_t r_glslfeat_t;
 
 #define GLSL_BIT(x)							(1ULL << (x))
-#define GLSL_BITS_VERSION					13
+#define GLSL_BITS_VERSION					14
 
 #define DEFAULT_GLSL_MATERIAL_PROGRAM			"defaultMaterial"
 #define DEFAULT_GLSL_DISTORTION_PROGRAM			"defaultDistortion"
@@ -106,9 +106,7 @@ enum
 
 #define GLSL_SHADER_COMMON_FRAGMENT_HIGHP		GLSL_BIT(26)
 
-#define GLSL_SHADER_COMMON_BLEND				GLSL_BIT(27)
-
-#define GLSL_SHADER_COMMON_TC_MOD				GLSL_BIT(28)
+#define GLSL_SHADER_COMMON_TC_MOD				GLSL_BIT(27)
 
 // material prgoram type features
 #define GLSL_SHADER_MATERIAL_LIGHTSTYLE0		GLSL_BIT(32)

--- a/source/ref_gl/r_register.c
+++ b/source/ref_gl/r_register.c
@@ -993,6 +993,13 @@ static void R_FinalizeGLExtensions( void )
 		ri.Cvar_ForceSet( "gl_ext_vertex_buffer_object", "1" );
 	}
 
+#ifdef GL_ES_VERSION_2_0
+	// Use 32-bit framebuffers on PowerVR instead of 24-bit with the alpha cleared to 1
+	// because blending incorrectly assumes alpha 0 when an RGB FB is used there, not 1.
+	if( !strcmp( glConfig.vendorString, "Imagination Technologies" ) )
+		glConfig.forceRGBAFramebuffers = true;
+#endif
+
 	ri.Cvar_Get( "r_texturefilter_max", "0", CVAR_READONLY );
 	ri.Cvar_ForceSet( "r_texturefilter_max", va( "%i", glConfig.maxTextureFilterAnisotropic ) );
 

--- a/source/ref_gl/r_shader.h
+++ b/source/ref_gl/r_shader.h
@@ -86,7 +86,7 @@ enum
 };
 
 // shaderpass flags
-#define SHADERPASS_MARK_BEGIN		0x8000 // same as GLSTATE_MARK_END
+#define SHADERPASS_MARK_BEGIN		0x10000 // same as GLSTATE_MARK_END
 enum
 {
 	SHADERPASS_LIGHTMAP				= SHADERPASS_MARK_BEGIN,


### PR DESCRIPTION
PowerVR blending assumes alpha to be 0 in RGB framebuffers instead of 1 like other GPUs leading to translucent polygons creating black backgrounds.

This pull request frees one shader bit and disables the hack on non-PowerVR GPU for smaller FB texture size and bigger tiles on Adreno.

Will update SDL and Unix code to use 24 bits instead of 32 later if needed.
