### PR TITLE
Scale offset depending on aspect ratio

### DIFF
--- a/source/cgame/cg_vweap.cpp
+++ b/source/cgame/cg_vweap.cpp
@@ -299,8 +299,8 @@ void CG_CalcViewWeapon( cg_viewweapon_t *viewweapon )
 	gunOffset[RIGHT] = cg_gunx->value + weaponInfo->handpositionOrigin[RIGHT];
 	gunOffset[UP] = cg_guny->value + weaponInfo->handpositionOrigin[UP];
 	
-	// scale forward gun offset depending on fov
-	gunOffset[FORWARD] /= cg.view.fracDistFOV;
+	// scale forward gun offset depending on fov and aspect ratio
+	gunOffset[FORWARD] = gunOffset[FORWARD] * cgs.vidWidth / ( cgs.vidHeight * cg.view.fracDistFOV ) ;
 
 	// hand cvar offset
 	handOffset = 0.0f;


### PR DESCRIPTION
Fixes its inconsistency on different resolutions
before
![wsw_150816_211439](https://cloud.githubusercontent.com/assets/4707112/9294629/e2b0dbe6-445b-11e5-8226-c6d600fcec17.jpg)
![wsw_150816_211448](https://cloud.githubusercontent.com/assets/4707112/9294633/ee63dad8-445b-11e5-8a54-a16e97a897d1.jpg)
after
![wsw_150816_210705](https://cloud.githubusercontent.com/assets/4707112/9294637/009d394c-445c-11e5-9ee9-088b38c1c210.jpg)
![wsw_150816_210719](https://cloud.githubusercontent.com/assets/4707112/9294638/056c66d2-445c-11e5-8ef1-6b9a84bc6edb.jpg)

p.s. if that request would be merged, it will need tuning of offsets in weapon model configs.
