### PR TITLE
Add touch weapon dropping

### DIFF
--- a/source/game/g_frame.cpp
+++ b/source/game/g_frame.cpp
@@ -340,6 +340,7 @@ void G_CheckCvars( void )
 	GS_GamestatSetFlag( GAMESTAT_FLAG_MMCOMPATIBLE, level.gametype.mmCompatible );
 
 	GS_GamestatSetLongFlag( GAMELONG_FLAG_ISTUTORIAL, ( level.gametype.isTutorial != 0 ) );
+	GS_GamestatSetLongFlag( GAMELONG_FLAG_CANDROPWEAPON, ( level.gametype.dropableItemsMask & IT_WEAPON ) != 0 );
 
 	gs.gameState.stats[GAMESTAT_MAXPLAYERSINTEAM] = level.gametype.maxPlayersPerTeam;
 	clamp( gs.gameState.stats[GAMESTAT_MAXPLAYERSINTEAM], 0, 255 );

--- a/source/gameshared/gs_public.h
+++ b/source/gameshared/gs_public.h
@@ -132,6 +132,7 @@ enum
 #define GAMESTAT_FLAG_MMCOMPATIBLE ( 1<<15 )
 
 #define GAMELONG_FLAG_ISTUTORIAL (1<<0)
+#define GAMELONG_FLAG_CANDROPWEAPON (1<<1)
 
 typedef struct
 {
@@ -163,6 +164,7 @@ extern gs_state_t gs;
 #define GS_TeamOnlyMinimap() ( ( gs.gameState.stats[GAMESTAT_FLAGS] & GAMESTAT_FLAG_TEAMONLYMINIMAP ) ? true : false )
 #define GS_MMCompatible() ( (gs.gameState.stats[GAMESTAT_FLAGS] & GAMESTAT_FLAG_MMCOMPATIBLE ) ? true : false )
 #define GS_TutorialGametype() ( gs.gameState.longstats[GAMELONG_FLAGS] & GAMELONG_FLAG_ISTUTORIAL ? true : false )
+#define GS_CanDropWeapon() ( gs.gameState.longstats[GAMELONG_FLAGS] & GAMELONG_FLAG_CANDROPWEAPON ? true : false )
 
 #define GS_MatchState() ( gs.gameState.stats[GAMESTAT_MATCHSTATE] )
 #define GS_MaxPlayersInTeam() ( gs.gameState.stats[GAMESTAT_MAXPLAYERSINTEAM] )


### PR DESCRIPTION
Dropping weapons may be useful for teamplay.

This pull request lets touchscreen players drop weapons by holding their icons for 1 second, with a sliding animation for the icon.
