### PR TITLE
Use static mesh for all post-processing layers

### DIFF
--- a/glsl/include/postprocessing.vert.glsl
+++ b/glsl/include/postprocessing.vert.glsl
@@ -7,6 +7,5 @@ qf_varying vec2 v_TexCoord;
 void main(void)
 {
     gl_Position = u_ModelViewProjectionMatrix * a_Position;
-	v_TexCoord = TextureMatrix2x3Mul(u_TextureMatrix, a_Position.xy);
-	v_TexCoord.y = 1.0 - v_TexCoord.y;
+	v_TexCoord = TextureMatrix2x3Mul(u_TextureMatrix, a_TexCoord);
 }

--- a/source/ref_gl/r_main.c
+++ b/source/ref_gl/r_main.c
@@ -947,9 +947,10 @@ static void R_ApplyBrightness( void )
 mesh_vbo_t *R_InitPostProcessingVBO( void )
 {
 	vec4_t xyz[4] = { {0,0,0,1}, {1,0,0,1}, {1,1,0,1}, {0,1,0,1} };
+	vec2_t texcoords[4] = { {0,1}, {1,1}, {1,0}, {0,0} };
 	elem_t elems[6] = { 0, 1, 2, 0, 2, 3 };
 	mesh_t mesh;
-	vattribmask_t vattribs = VATTRIB_POSITION_BIT;
+	vattribmask_t vattribs = VATTRIB_POSITION_BIT|VATTRIB_TEXCOORDS_BIT;
 	mesh_vbo_t *vbo;
 	
 	vbo = R_CreateMeshVBO( &rf, 4, 6, 0, vattribs, VBO_TAG_NONE, vattribs );
@@ -960,6 +961,7 @@ mesh_vbo_t *R_InitPostProcessingVBO( void )
 	memset( &mesh, 0, sizeof( mesh ) );
 	mesh.numVerts = 4;
 	mesh.xyzArray = xyz;
+	mesh.stArray = texcoords;
 	mesh.numElems = 6;
 	mesh.elems = elems;
 


### PR DESCRIPTION
Since post-processing effects can't be batched anyway because they always use different textures and shaders (and R_DrawStretchQuick ends batches), use the static mesh (which was originally introduced to work around the weird Adreno bug that caused dynamic VBOs to randomly become "slow" to use under strange conditions) for Q3A shader effects as well as FXAA and CC.

This pull request is required to approach 2-6 BufferSubData calls per frame in the future.

Also post processing effects are now flipped correctly when the refdef is not vertically centered on the screen, and EndStretchBatch is now called when the correct frame buffer is bound.
