### PR TITLE
Set qglDrawBuffer and qglReadBuffer correctly

### DIFF
--- a/source/ref_gl/r_local.h
+++ b/source/ref_gl/r_local.h
@@ -481,7 +481,6 @@ void		RFB_BindObject( int object );
 int			RFB_BoundObject( void );
 void		RFB_AttachTextureToObject( int object, image_t *texture );
 image_t		*RFB_GetObjectTextureAttachment( int object, bool depth );
-void		RFB_DisableObjectDrawBuffer( void );
 void		RFB_BlitObject( int dest, int bitMask, int mode );
 bool	RFB_CheckObjectStatus( void );
 void		RFB_GetObjectSize( int object, int *width, int *height );

--- a/source/ref_gl/r_main.c
+++ b/source/ref_gl/r_main.c
@@ -1300,11 +1300,6 @@ static void R_BindRefInstFBO( void )
 	}
 
 	R_BindFrameBufferObject( fbo );
-
-	if( fbo && !rn.fbColorAttachment ) {
-		// inform the driver we do not wish to render to the color buffer
-		RFB_DisableObjectDrawBuffer();
-	}
 }
 
 /*


### PR DESCRIPTION
Sets glDrawBuffer and glReadBuffer when a framebuffer is created rather than when a ref inst is bound without a color attachment.
