### PR TITLE
Don't try to copy depth when not in RF_SOFT_PARTICLES view

### DIFF
--- a/source/ref_gl/r_mesh.c
+++ b/source/ref_gl/r_mesh.c
@@ -491,12 +491,10 @@ static void _R_DrawSurfaces( drawList_t *list )
 			}
 
 			depthWrite = shader->flags & SHADER_DEPTHWRITE ? true : false;
-			if( !depthWrite && !depthCopied && Shader_ReadDepth( shader ) ) {
+			if( !depthWrite && !depthCopied && Shader_ReadDepth( shader ) &&
+				( rn.renderFlags & RF_SOFT_PARTICLES ) && rn.fbDepthAttachment && rsh.screenTextureCopy ) {
 				depthCopied = true;
-				if( rn.fbDepthAttachment && rsh.screenTextureCopy ) {
-					RB_BlitFrameBufferObject( rsh.screenTextureCopy->fbo, 
-						GL_DEPTH_BUFFER_BIT, FBO_COPY_NORMAL );
-				}
+				RB_BlitFrameBufferObject( rsh.screenTextureCopy->fbo, GL_DEPTH_BUFFER_BIT, FBO_COPY_NORMAL );
 			}
 
 			// sky and things that don't use depth test use infinite projection matrix

--- a/source/ref_gl/r_mesh.c
+++ b/source/ref_gl/r_mesh.c
@@ -491,10 +491,11 @@ static void _R_DrawSurfaces( drawList_t *list )
 			}
 
 			depthWrite = shader->flags & SHADER_DEPTHWRITE ? true : false;
-			if( !depthWrite && !depthCopied && Shader_ReadDepth( shader ) &&
-				( rn.renderFlags & RF_SOFT_PARTICLES ) && rn.fbDepthAttachment && rsh.screenTextureCopy ) {
+			if( !depthWrite && !depthCopied && Shader_ReadDepth( shader ) ) {
 				depthCopied = true;
-				RB_BlitFrameBufferObject( rsh.screenTextureCopy->fbo, GL_DEPTH_BUFFER_BIT, FBO_COPY_NORMAL );
+				if( ( rn.renderFlags & RF_SOFT_PARTICLES ) && rn.fbDepthAttachment && rsh.screenTextureCopy ) {
+					RB_BlitFrameBufferObject( rsh.screenTextureCopy->fbo, GL_DEPTH_BUFFER_BIT, FBO_COPY_NORMAL );
+				}
 			}
 
 			// sky and things that don't use depth test use infinite projection matrix


### PR DESCRIPTION
This commit seems to really fix that checkerboard bug.
