### PR TITLE
Use bilinear filtering for RGB shadows

### DIFF
--- a/glsl/include/rgbdepth.glsl
+++ b/glsl/include/rgbdepth.glsl
@@ -1,7 +1,7 @@
 #ifndef decodedepthmacro24
-// Lifted from Darkplaces shader program
-#define decodedepthmacro24(d) dot((d).rgb, vec3(1.0, 255.0 / 65536.0, 255.0 / 16777215.0))
-#define encodedepthmacro24(d) fract(d * vec4(1.0, 256.0, 65536.0, 0.0))
-#define decodedepthmacro16(d) dot((d).rgb, vec3(1.0, 63.0 / 65535.0, 31.0 / 1024.0))
-#define encodedepthmacro16(d) fract(d * vec4(1.0, 1024.0, 32.0, 0.0))
+#define decodedepthmacro24(d) dot((d).rgb, vec3(1.0, 1.0 / 255.0, 1.0 / 65025.0))
+#define encodedepthmacro24(d) fract(d * vec4(1.0, 255.0, 65025.0, 0.0))
+// Use green for near because it has one more bit of precision
+#define decodedepthmacro16(d) dot((d).rgb, vec3(1.0, 1.0 / 961.0, 1.0 / 31.0))
+#define encodedepthmacro16(d) fract(d * vec4(1.0, 961.0, 31.0, 0.0))
 #endif


### PR DESCRIPTION
Makes edges of shadows rounded and less blocky.
May be 1 texel off, but we have a border in shadowmaps anyway.
Also more accurate depth encoding (roughly 3e-8 inaccuracy when tested with doubles).
