### PR TITLE
Micro-optimization: Don't interpolate lightmap layers

### DIFF
--- a/glsl/include/varying_material.glsl
+++ b/glsl/include/varying_material.glsl
@@ -5,7 +5,7 @@ qf_varying qf_lmvec01 v_LightmapTexCoord01;
 qf_varying qf_lmvec23 v_LightmapTexCoord23;
 #endif
 #ifdef LIGHTMAP_ARRAYS
-qf_varying vec4 v_LightmapLayer0123;
+qf_flat_varying vec4 v_LightmapLayer0123;
 #endif
 #endif
 

--- a/glsl/include/varying_q3a.glsl
+++ b/glsl/include/varying_q3a.glsl
@@ -24,7 +24,7 @@ qf_varying qf_lmvec01 v_LightmapTexCoord01;
 qf_varying qf_lmvec23 v_LightmapTexCoord23;
 #endif
 #ifdef LIGHTMAP_ARRAYS
-qf_varying vec4 v_LightmapLayer0123;
+qf_flat_varying vec4 v_LightmapLayer0123;
 #endif
 #endif
 

--- a/source/ref_gl/r_program.c
+++ b/source/ref_gl/r_program.c
@@ -947,15 +947,15 @@ static const glsl_feature_t * const glsl_programtypes_features[] =
 "#endif\n" \
 
 #define QF_BUILTIN_GLSL_MACROS_GLSL120 "" \
+"#define qf_varying varying\n" \
+"#define qf_flat_varying varying\n" \
 "#ifdef VERTEX_SHADER\n" \
 "# define qf_FrontColor gl_FrontColor\n" \
-"# define qf_varying varying\n" \
 "# define qf_attribute attribute\n" \
 "#endif\n" \
 "#ifdef FRAGMENT_SHADER\n" \
 "# define qf_FrontColor gl_Color\n" \
 "# define qf_FragColor gl_FragColor\n" \
-"# define qf_varying varying\n" \
 "#endif\n" \
 "#define qf_texture texture2D\n" \
 "#define qf_textureLod texture2DLod\n" \
@@ -971,12 +971,14 @@ static const glsl_feature_t * const glsl_programtypes_features[] =
 "#ifdef VERTEX_SHADER\n" \
 "  out myhalf4 qf_FrontColor;\n" \
 "# define qf_varying out\n" \
+"# define qf_flat_varying flat out\n" \
 "# define qf_attribute in\n" \
 "#endif\n" \
 "#ifdef FRAGMENT_SHADER\n" \
 "  in myhalf4 qf_FrontColor;\n" \
 "  out myhalf4 qf_FragColor;\n" \
 "# define qf_varying in\n" \
+"# define qf_flat_varying flat in\n" \
 "#endif\n" \
 "#define qf_texture texture\n" \
 "#define qf_textureCube texture\n" \
@@ -989,6 +991,7 @@ static const glsl_feature_t * const glsl_programtypes_features[] =
 
 #define QF_BUILTIN_GLSL_MACROS_GLSL100ES "" \
 "#define qf_varying varying\n" \
+"#define qf_flat_varying varying\n" \
 "#ifdef VERTEX_SHADER\n" \
 "# define qf_attribute attribute\n" \
 "#endif\n" \
@@ -1021,6 +1024,7 @@ static const glsl_feature_t * const glsl_programtypes_features[] =
 #define QF_BUILTIN_GLSL_MACROS_GLSL300ES "" \
 "#ifdef VERTEX_SHADER\n" \
 "# define qf_varying out\n" \
+"# define qf_flat_varying flat out\n" \
 "# define qf_attribute in\n" \
 "#endif\n" \
 "#ifdef FRAGMENT_SHADER\n" \
@@ -1034,6 +1038,7 @@ static const glsl_feature_t * const glsl_programtypes_features[] =
 "  precision lowp sampler2DShadow;\n" \
 "  layout(location = 0) out vec4 qf_FragColor;\n" \
 "# define qf_varying in\n" \
+"# define qf_flat_varying flat in\n" \
 "#endif\n" \
 " qf_varying myhalf4 qf_FrontColor;\n" \
 "#define qf_texture texture\n" \


### PR DESCRIPTION
Specify lightmap layers as `flat` to prevent interpolation of them on GLSL130+/GLESSL300+ because it's done using the ALU on modern GPUs, not by dedicated hardware: http://www.slideshare.net/DevCentralAMD/lowlevel-shader-optimization-for-nextgen-and-dx11-by-emil-persson slide 18

Using `qf_flat_varying` instead of `qf_flat qf_varying` because empty defines are known to crash shader compilation on Intel.
