### PR TITLE
Fix spaces in two system chat messages

### DIFF
--- a/source/game/g_gametypes.cpp
+++ b/source/game/g_gametypes.cpp
@@ -1267,7 +1267,7 @@ void G_Match_CheckReadys( void )
 
 	if( allready == true && GS_MatchState() != MATCH_STATE_COUNTDOWN )
 	{
-		G_PrintMsg( NULL, "All players are ready.  Match starting!\n" );
+		G_PrintMsg( NULL, "All players are ready. Match starting!\n" );
 		G_Match_LaunchState( MATCH_STATE_COUNTDOWN );
 	}
 	else if( allready == false && GS_MatchState() == MATCH_STATE_COUNTDOWN )

--- a/source/game/p_client.cpp
+++ b/source/game/p_client.cpp
@@ -771,7 +771,7 @@ void ClientBegin( edict_t *ent )
 
 	mm_login = Info_ValueForKey( client->userinfo, "cl_mm_login" );
 	if( mm_login && *mm_login && client->mm_session > 0 ) {
-		G_PrintMsg( NULL, "%s" S_COLOR_WHITE "(" S_COLOR_YELLOW "%s" S_COLOR_WHITE ") entered the game\n", client->netname, mm_login );
+		G_PrintMsg( NULL, "%s" S_COLOR_WHITE " (" S_COLOR_YELLOW "%s" S_COLOR_WHITE ") entered the game\n", client->netname, mm_login );
 	}
 	else {
 		G_PrintMsg( NULL, "%s" S_COLOR_WHITE " entered the game\n", client->netname );


### PR DESCRIPTION
Removes pretty obvious double space from one string, and adds a missing space to another to separate the client name and the MM user name.
