### PR TITLE
Move swap interval to GLimp

### DIFF
--- a/source/android/android_glw.c
+++ b/source/android/android_glw.c
@@ -388,11 +388,7 @@ bool GLimp_ScreenEnabled( void )
 */
 void GLimp_SetSwapInterval( int swapInterval )
 {
-	if( glw_state.swapInterval == swapInterval )
-		return;
-
 	glw_state.swapInterval = swapInterval;
-
 	if( glw_state.surface != EGL_NO_SURFACE )
 		qeglSwapInterval( glw_state.display, swapInterval );
 }

--- a/source/android/android_glw.c
+++ b/source/android/android_glw.c
@@ -384,6 +384,20 @@ bool GLimp_ScreenEnabled( void )
 }
 
 /*
+** GLimp_SetSwapInterval
+*/
+void GLimp_SetSwapInterval( int swapInterval )
+{
+	if( glw_state.swapInterval == swapInterval )
+		return;
+
+	glw_state.swapInterval = swapInterval;
+
+	if( glw_state.surface != EGL_NO_SURFACE )
+		qeglSwapInterval( glw_state.display, swapInterval );
+}
+
+/*
 ** GLimp_SharedContext_Create
 */
 bool GLimp_SharedContext_Create( void **context, void **surface )

--- a/source/android/android_qgl.c
+++ b/source/android/android_qgl.c
@@ -47,7 +47,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #undef QGL_FUNC
 
 static const char *_qglGetGLWExtensionsString( void );
-static void _qglSwapInterval( int interval );
 
 /*
 ** QGL_Shutdown
@@ -121,7 +120,6 @@ qgl_initerr_t QGL_Init( const char *dllname )
 #undef QGL_FUNC
 
 	qglGetGLWExtensionsString = _qglGetGLWExtensionsString;
-	qglSwapInterval = _qglSwapInterval;
 
 	return qgl_initerr_ok;
 }
@@ -159,18 +157,4 @@ static const char *_qglGetGLWExtensionsString( void )
 	if( dpy == EGL_NO_DISPLAY )
 		return NULL;
 	return qeglQueryString( dpy, EGL_EXTENSIONS );
-}
-
-/*
-** _qglSwapInterval
-*/
-static void _qglSwapInterval( int interval )
-{
-	if( glw_state.swapInterval == interval )
-		return;
-
-	glw_state.swapInterval = interval;
-
-	if( glw_state.surface != EGL_NO_SURFACE )
-		qeglSwapInterval( glw_state.display, interval );
 }

--- a/source/ref_gl/qgl.h
+++ b/source/ref_gl/qgl.h
@@ -924,8 +924,6 @@ QGL_EXT(void, glReadBufferIndexedEXT, (GLenum, GLint));
 QGL_EXT(void, glDrawBuffersIndexedEXT, (GLint, const GLenum *, const GLint *));
 #endif
 
-QGL_EXT(void, glSwapInterval, (int interval));
-
 #ifndef GL_ES_VERSION_2_0
 QGL_EXT(void, glProgramParameteri, (GLuint program, GLenum pname, GLint value));
 QGL_EXT(void, glGetProgramBinary, (GLuint program, GLsizei bufSize, GLsizei *length, GLenum *binaryFormat, GLvoid *binary));
@@ -977,5 +975,7 @@ QGL_FUNC_OPT(void, glTexSubImage3D, (GLenum target, GLint level, GLint xoffset, 
 QGL_WGL_EXT(const char *, wglGetExtensionsStringEXT, (void));
 QGL_WGL_EXT(BOOL, wglGetDeviceGammaRamp3DFX, (HDC, WORD *));
 QGL_WGL_EXT(BOOL, wglSetDeviceGammaRamp3DFX, (HDC, WORD *));
+QGL_WGL_EXT(BOOL, wglSwapIntervalEXT, (int interval));
 
 // GLX_EXT Functions
+QGL_GLX_EXT(int, glXSwapIntervalSGI, (int interval));

--- a/source/ref_gl/r_glimp.h
+++ b/source/ref_gl/r_glimp.h
@@ -267,6 +267,7 @@ rserr_t	GLimp_SetWindow( void *hinstance, void *wndproc, void *parenthWnd );
 void	GLimp_AppActivate( bool active, bool destroy );
 bool	GLimp_GetGammaRamp( size_t stride, unsigned short *psize, unsigned short *ramp );
 void	GLimp_SetGammaRamp( size_t stride, unsigned short   size, unsigned short *ramp );
+void	GLimp_SetSwapInterval( int swapInterval );
 
 bool	GLimp_SharedContext_Create( void **context, void **surface );
 bool	GLimp_SharedContext_MakeCurrent( void *context, void *surface );

--- a/source/ref_gl/r_main.c
+++ b/source/ref_gl/r_main.c
@@ -1478,19 +1478,12 @@ void R_PopRefInst( void )
 */
 static void R_SwapInterval( int swapInterval )
 {
-	if( !glConfig.stereoEnabled && !r_swapinterval_min->integer )
-		GLimp_SetSwapInterval( swapInterval );
-}
+	static int currentSwapInterval = 0;
 
-/*
-* R_UpdateSwapInterval
-*/
-static void R_UpdateSwapInterval( void )
-{
-	if( r_swapinterval->modified )
+	if( ( swapInterval != currentSwapInterval ) && !r_swapinterval_min->integer && !glConfig.stereoEnabled )
 	{
-		r_swapinterval->modified = false;
-		R_SwapInterval( r_swapinterval->integer ? 1 : 0 );
+		GLimp_SetSwapInterval( swapInterval );
+		currentSwapInterval = swapInterval;
 	}
 }
 
@@ -1627,14 +1620,8 @@ void R_BeginFrame( float cameraSeparation, bool forceClear, bool forceVsync )
 		r_outlines_scale->modified = false;
 	}
 
-	// swapinterval stuff (vertical synchronization)
-	if( forceVsync ) {
-		R_SwapInterval( 1 );
-	}
-	else {
-		r_swapinterval->modified = true;
-		R_UpdateSwapInterval();
-	}
+	// set swap interval (vertical synchronization)
+	R_SwapInterval( ( r_swapinterval->integer || forceVsync ) ? 1 : 0 );
 
 	memset( &rf.stats, 0, sizeof( rf.stats ) );
 

--- a/source/ref_gl/r_main.c
+++ b/source/ref_gl/r_main.c
@@ -1476,10 +1476,10 @@ void R_PopRefInst( void )
 /*
 * R_SwapInterval
 */
-static void R_SwapInterval( bool swapInterval )
+static void R_SwapInterval( int swapInterval )
 {
-	if( qglSwapInterval && !glConfig.stereoEnabled && !r_swapinterval_min->integer )
-		qglSwapInterval( swapInterval );
+	if( !glConfig.stereoEnabled && !r_swapinterval_min->integer )
+		GLimp_SetSwapInterval( swapInterval );
 }
 
 /*
@@ -1490,7 +1490,7 @@ static void R_UpdateSwapInterval( void )
 	if( r_swapinterval->modified )
 	{
 		r_swapinterval->modified = false;
-		R_SwapInterval( r_swapinterval->integer ? true : false );
+		R_SwapInterval( r_swapinterval->integer ? 1 : 0 );
 	}
 }
 
@@ -1629,7 +1629,7 @@ void R_BeginFrame( float cameraSeparation, bool forceClear, bool forceVsync )
 
 	// swapinterval stuff (vertical synchronization)
 	if( forceVsync ) {
-		R_SwapInterval( true );
+		R_SwapInterval( 1 );
 	}
 	else {
 		r_swapinterval->modified = true;

--- a/source/ref_gl/r_register.c
+++ b/source/ref_gl/r_register.c
@@ -1145,8 +1145,6 @@ static void R_Register( const char *screenshotsPrefix )
 #else
 	r_swapinterval = ri.Cvar_Get( "r_swapinterval", "0", CVAR_ARCHIVE );
 #endif
-	// make sure r_swapinterval is checked after vid_restart
-	r_swapinterval->modified = true;
 	r_swapinterval_min = ri.Cvar_Get( "r_swapinterval_min", "0", CVAR_READONLY ); // exposes vsync support to UI
 
 	r_temp1 = ri.Cvar_Get( "r_temp1", "0", 0 );
@@ -1372,6 +1370,9 @@ static rserr_t R_PostInit( void )
 		QGL_Shutdown();
 		return rserr_unknown;
 	}
+
+	// make sure vsync is disabled by default if possible - it is assumed by R_SwapInterval
+	GLimp_SetSwapInterval( r_swapinterval_min->integer );
 
 	R_FillStartupBackgroundColor( COLOR_R( glConfig.startupColor ) / 255.0f,
 		COLOR_G( glConfig.startupColor ) / 255.0f, COLOR_B( glConfig.startupColor ) / 255.0f );

--- a/source/ref_gl/r_register.c
+++ b/source/ref_gl/r_register.c
@@ -416,7 +416,7 @@ static const gl_extension_func_t gl_ext_texture_3D_OES_funcs[] =
 /* WGL_EXT_swap_interval */
 static const gl_extension_func_t wgl_ext_swap_interval_EXT_funcs[] =
 {
-	 GL_EXTENSION_FUNC_EXT("wglSwapIntervalEXT",&qglSwapInterval)
+	 GL_EXTENSION_FUNC_EXT("wglSwapIntervalEXT",&qwglSwapIntervalEXT)
 
 	,GL_EXTENSION_FUNC_EXT(NULL,NULL)
 };
@@ -428,7 +428,7 @@ static const gl_extension_func_t wgl_ext_swap_interval_EXT_funcs[] =
 /* GLX_SGI_swap_control */
 static const gl_extension_func_t glx_ext_swap_control_SGI_funcs[] =
 {
-	 GL_EXTENSION_FUNC_EXT("glXSwapIntervalSGI",&qglSwapInterval)
+	 GL_EXTENSION_FUNC_EXT("glXSwapIntervalSGI",&qglXSwapIntervalSGI)
 
 	,GL_EXTENSION_FUNC_EXT(NULL,NULL)
 };

--- a/source/sdl/sdl_glw.c
+++ b/source/sdl/sdl_glw.c
@@ -289,6 +289,14 @@ bool GLimp_ScreenEnabled( void )
 }
 
 /*
+** GLimp_SetSwapInterval
+*/
+void GLimp_SetSwapInterval( int swapInterval )
+{
+	SDL_GL_SetSwapInterval( swapInterval );
+}
+
+/*
 ** GLimp_SharedContext_Create
 */
 bool GLimp_SharedContext_Create( void **context, void **surface )

--- a/source/sdl/sdl_qgl.c
+++ b/source/sdl/sdl_qgl.c
@@ -76,7 +76,6 @@ and Zephaniah E. Hull. Adapted by Victor Luchits for qfusion project.
 
 static const char *_qglGetGLWExtensionsString( void );
 static const char *_qglGetGLWExtensionsStringInit( void );
-static void _qglSwapInterval( int interval );
 
 /*
 ** QGL_Shutdown
@@ -174,7 +173,6 @@ qgl_initerr_t QGL_Init( const char *dllname )
 #undef QGL_FUNC
 
 	qglGetGLWExtensionsString = _qglGetGLWExtensionsString;
-	qglSwapInterval = _qglSwapInterval;
 
 	return qgl_initerr_ok;
 }
@@ -205,12 +203,4 @@ void *qglGetProcAddress( const GLubyte *procName )
 static const char *_qglGetGLWExtensionsString( void )
 {
 	return NULL;
-}
-
-/*
-** qglSwapInterval
-*/
-static void _qglSwapInterval( int interval )
-{
-	SDL_GL_SetSwapInterval( interval );
 }

--- a/source/unix/unix_glw.c
+++ b/source/unix/unix_glw.c
@@ -1100,6 +1100,15 @@ bool GLimp_ScreenEnabled( void )
 }
 
 /*
+** GLimp_SetSwapInterval
+*/
+void GLimp_SetSwapInterval( int swapInterval )
+{
+	if( qglXSwapIntervalSGI )
+		qglXSwapIntervalSGI( swapInterval );
+}
+
+/*
 ** GLimp_SharedContext_Create
 */
 bool GLimp_SharedContext_Create( void **context, void **surface )

--- a/source/win32/win_glw.c
+++ b/source/win32/win_glw.c
@@ -615,6 +615,15 @@ bool GLimp_ScreenEnabled( void )
 }
 
 /*
+** GLimp_SetSwapInterval
+*/
+void GLimp_SetSwapInterval( int swapInterval )
+{
+	if( qwglSwapIntervalEXT )
+		qwglSwapIntervalEXT( swapInterval );
+}
+
+/*
 ** GLimp_SharedContext_Create
 */
 bool GLimp_SharedContext_Create( void **context, void **surface )


### PR DESCRIPTION
Rather than falsely assuming that all windowing systems have the same prototype for swap interval setting (our prototype is wrong anyway - it has `void` return value while it should be `BOOL` on WGL and `int` on GLX), let GLimp actually call the appropriate SwapInterval function.

This should fix the SDL2 build error on Windows.
