### PR TITLE
Weapondefs' adjustments on EB and RG

### DIFF
--- a/source/gameshared/gs_weapondefs.c
+++ b/source/gameshared/gs_weapondefs.c
@@ -258,7 +258,7 @@ gs_weapon_definition_t gs_weaponDefs[] =
 			FIRE_MODE_STRONG,
 			AMMO_SHELLS,
 			1,								// ammo usage per shot
-			25,								// projectiles fired each shot
+			20,								// projectiles fired each shot
 
 			//timings (in msecs)
 			WEAPONUP_FRAMETIME,				// weapon up frametime
@@ -269,9 +269,9 @@ gs_weapon_definition_t gs_weaponDefs[] =
 			false,							// smooth refire
 
 			//damages
-			4,								// damage
+			5,								// damage
 			0,								// selfdamage ratio (rg cant selfdamage)
-			5,								// knockback
+			7,								// knockback
 			85,								// stun
 			0,								// splash radius
 			0,								// splash minimum damage

--- a/source/gameshared/gs_weapondefs.c
+++ b/source/gameshared/gs_weapondefs.c
@@ -631,7 +631,7 @@ gs_weapon_definition_t gs_weaponDefs[] =
 			//damages
 			75,								// damage
 			0,  							// selfdamage ratio
-			40,								// knockback
+			80,								// knockback
 			1000,							// stun
 			0,								// splash radius
 			75,								// minimum damage


### PR DESCRIPTION
EB:
- 40 knockback is not even noticeable, it can be compared only with 2xPG or 3xLG. You can't really drop enemy from the ledges or insist him to make a movement mistake by such EB hit.
- You can't stop enemy RL rush initiation with the 40 knockback.
- 80 number follows the logic of dmg/knockback ratio on other weapons, where knockback is at least a bit  higher than dmg number.

RG:
- changing from 25bullets x 4dmg to 20bullets x 5dmg makes the patter a bit smaller for something like 5%.
- any hit (apart from full hit) would be a bit more harmful up to 5%.
- knockback is changed from 125 (25x5) to 140 (20x7).
