### PR TITLE
Fix crosshair color cvar

### DIFF
--- a/source/cgame/cg_screen.cpp
+++ b/source/cgame/cg_screen.cpp
@@ -423,8 +423,8 @@ static void CG_DrawCrosshairChar( int x, int y, int size, int num, vec_t *color 
 */
 void CG_DrawCrosshair( int x, int y, int align )
 {
-	static vec4_t chColor = { 255, 255, 255, 255 };
-	static vec4_t chColorStrong = { 255, 255, 255, 255 };
+	static vec4_t chColor = { 1.0f, 1.0f, 1.0f, 1.0f };
+	static vec4_t chColorStrong = { 1.0f, 1.0f, 1.0f, 1.0f };
 	int rgbcolor;
 	int sx, sy, size;
 
@@ -456,11 +456,14 @@ void CG_DrawCrosshair( int x, int y, int align )
 		}
 		if( rgbcolor != -1 )
 		{
-			Vector4Set( chColor, COLOR_R( rgbcolor ), COLOR_G( rgbcolor ), COLOR_B( rgbcolor ), 255 );
+			Vector4Set( chColor,
+				COLOR_R( rgbcolor ) * ( 1.0f / 255.0f ),
+				COLOR_G( rgbcolor ) * ( 1.0f / 255.0f ),
+				COLOR_B( rgbcolor ) * ( 1.0f / 255.0f ), 1.0f );
 		}
 		else
 		{
-			Vector4Set( chColor, 255, 255, 255, 255 );
+			Vector4Set( chColor, 1.0f, 1.0f, 1.0f, 1.0f );
 		}
 		cg_crosshair_color->modified = false;
 	}
@@ -491,11 +494,14 @@ void CG_DrawCrosshair( int x, int y, int align )
 		}
 		if( rgbcolor != -1 )
 		{
-			Vector4Set( chColorStrong, COLOR_R( rgbcolor ), COLOR_G( rgbcolor ), COLOR_B( rgbcolor ), 255 );
+			Vector4Set( chColorStrong,
+				COLOR_R( rgbcolor ) * ( 1.0f / 255.0f ),
+				COLOR_G( rgbcolor ) * ( 1.0f / 255.0f ),
+				COLOR_B( rgbcolor ) * ( 1.0f / 255.0f ), 1.0f );
 		}
 		else
 		{
-			Vector4Set( chColorStrong, 255, 255, 255, 255 );
+			Vector4Set( chColorStrong, 1.0f, 1.0f, 1.0f, 1.0f );
 		}
 		cg_crosshair_strong_color->modified = false;
 	}

--- a/source/gameshared/q_shared.c
+++ b/source/gameshared/q_shared.c
@@ -960,7 +960,7 @@ const char *COM_RemoveJunkChars( const char *in )
 */
 int COM_ReadColorRGBString( const char *in )
 {
-	static int playerColor[3];
+	int playerColor[3];
 	if( in && in[0] )
 	{
 		if( sscanf( in, "%3i %3i %3i", &playerColor[0], &playerColor[1], &playerColor[2] ) == 3 )


### PR DESCRIPTION
Fixes 1-254 values not working when setting the crosshair color. Also makes a local variable in COM_ReadColorRGBString non-static for thread safety.
