### PR TITLE
Use odd size for crosshairs

### DIFF
--- a/source/cgame/cg_screen.cpp
+++ b/source/cgame/cg_screen.cpp
@@ -383,8 +383,8 @@ void CG_DrawNet( int x, int y, int w, int h, int align, vec4_t color )
 */
 static int CG_CrosshairDimensions( int x, int y, int size, int align, int *sx, int *sy )
 {
-	size = ceilf( size * (float)( cgs.vidHeight / 600.0f ) );
-	size += size & 1; // crosshairs are symmetric, so make their size even
+	// odd sizes look sharper
+	size = ( int )ceilf( size * (float)( cgs.vidHeight / 600.0f ) ) | 1;
 	*sx = CG_HorizontalAlignForWidth( x, align, size );
 	*sy = CG_VerticalAlignForHeight( y, align, size );
 	return size;


### PR DESCRIPTION
Rather than making crosshair sizes even, make them odd because crosshairs look sharper at odd sizes (especially at 800x600).

Still keeping the cvars set to 24 rather than 25 because when the size is scaled to certain resolutions (like 1280x720 and 1280x800), the default crosshair looks sharper at 24. At 1920x1080, there's no difference between 24 and 25.
