### PR TITLE
GB tunings: disable charging for damage, unify damages and reload times across melee and projectile

### DIFF
--- a/source/game/p_weapon.cpp
+++ b/source/game/p_weapon.cpp
@@ -335,7 +335,6 @@ static edict_t *G_Fire_Gunblade_Blast( vec3_t origin, vec3_t angles, firedef_t *
 	if( owner && owner->r.client )
 	{
 		power = (float)owner->r.client->ps.inventory[firedef->ammo_id] / (float)firedef->ammo_max;
-		damage *= power;
 		knockback *= power;
 		radius *= power;
 	}

--- a/source/gameshared/gs_weapondefs.c
+++ b/source/gameshared/gs_weapondefs.c
@@ -119,7 +119,7 @@ gs_weapon_definition_t gs_weaponDefs[] =
 			//timings (in msecs)
 			WEAPONUP_FRAMETIME,				// weapon up frametime
 			WEAPONDOWN_FRAMETIME,           // weapon down frametime
-			400,							// reload frametime
+			500,							// reload frametime
 			0,								// cooldown frametime
 			5000,							// projectile timeout
 			false,							// smooth refire
@@ -153,7 +153,7 @@ gs_weapon_definition_t gs_weaponDefs[] =
 			//timings (in msecs)
 			WEAPONUP_FRAMETIME,				// weapon up frametime
 			WEAPONDOWN_FRAMETIME,			// weapon down frametime
-			400,							// reload frametime
+			500,							// reload frametime
 			0,								// cooldown frametime
 			64,								// projectile timeout  / projectile range for instant weapons
 			false,							// smooth refire

--- a/source/gameshared/gs_weapondefs.c
+++ b/source/gameshared/gs_weapondefs.c
@@ -125,7 +125,7 @@ gs_weapon_definition_t gs_weaponDefs[] =
 			false,							// smooth refire
 
 			//damages
-			50,								// damage
+			40,								// damage
 			0.8,							// selfdamage ratio
 			100,							// knockback
 			0,								// stun
@@ -153,13 +153,13 @@ gs_weapon_definition_t gs_weaponDefs[] =
 			//timings (in msecs)
 			WEAPONUP_FRAMETIME,				// weapon up frametime
 			WEAPONDOWN_FRAMETIME,			// weapon down frametime
-			800,							// reload frametime
+			400,							// reload frametime
 			0,								// cooldown frametime
 			64,								// projectile timeout  / projectile range for instant weapons
 			false,							// smooth refire
 
 			//damages
-			50,								// damage
+			40,								// damage
 			0,								// selfdamage ratio
 			50,								// knockback
 			0,								// stun


### PR DESCRIPTION
Projectile:
- gun becomes more useful on dealing damage, especially right after the spawn
- it still needs some time between highest possible gb jumps

Melee:
- higher dps for the most risky gun - risk should be paid.
- powerful melee gives more variety of weapon choice in close combats

Both modes now have same DPS = 80. Previously it was 65 for projectile and 62,5 for melee.
