### PR TITLE
Merge forwardmove/sidemove/upmove and forwardfrac/sidefrac/upfrac

### DIFF
--- a/source/cgame/cg_democams.cpp
+++ b/source/cgame/cg_democams.cpp
@@ -981,9 +981,6 @@ int CG_DemoCam_FreeFly( void )
 		// run frame
 		trap_NET_GetUserCmd( trap_NET_GetCurrentUserCmdNum() - 1, &cmd );
 		cmd.msec = cg.realFrameTime * 1000;
-		cmd.forwardfrac = ( (float)cmd.forwardmove/(float)cmd.msec );
-		cmd.sidefrac = ( (float)cmd.sidemove/(float)cmd.msec );
-		cmd.upfrac = ( (float)cmd.upmove/(float)cmd.msec );
 
 		for( i = 0; i < 3; i++ )
 			moveangles[i] = SHORT2ANGLE( cmd.angles[i] ) + SHORT2ANGLE( freecam_delta_angles[i] );
@@ -991,9 +988,9 @@ int CG_DemoCam_FreeFly( void )
 		AngleVectors( moveangles, forward, right, up );
 		VectorCopy( moveangles, cam_angles );
 
-		fmove = cmd.forwardfrac * SPEED;
-		smove = cmd.sidefrac * SPEED;
-		upmove = cmd.upfrac * SPEED;
+		fmove = cmd.forwardmove * SPEED;
+		smove = cmd.sidemove * SPEED;
+		upmove = cmd.upmove * SPEED;
 		if( cmd.buttons & BUTTON_SPECIAL )
 			maxspeed *= 2;
 

--- a/source/cgame/cg_public.h
+++ b/source/cgame/cg_public.h
@@ -43,7 +43,7 @@ typedef void ( *fdrawchar_t )( int x, int y, int w, int h, float s1, float t1, f
 
 // cg_public.h -- client game dll information visible to engine
 
-#define	CGAME_API_VERSION   93
+#define	CGAME_API_VERSION   94
 
 //
 // structs and variables shared with the main engine

--- a/source/game/ai/ai_class_dmbot.cpp
+++ b/source/game/ai/ai_class_dmbot.cpp
@@ -1699,13 +1699,6 @@ static void BOT_DMclass_RunFrame( edict_t *self )
 	ucmd.msec = game.frametime;
 	ucmd.serverTimeStamp = game.serverTime;
 
-	ucmd.forwardfrac = ucmd.forwardmove;
-	clamp( ucmd.forwardfrac, -1, 1 );
-	ucmd.sidefrac = ucmd.sidemove;
-	clamp( ucmd.sidefrac, -1, 1 );
-	ucmd.upfrac = ucmd.upmove;
-	clamp( ucmd.upfrac, -1, 1 );
-
 	ClientThink( self, &ucmd, 0 );
 	self->nextThink = level.time + 1;
 

--- a/source/game/g_public.h
+++ b/source/game/g_public.h
@@ -20,7 +20,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 // g_public.h -- game dll information visible to server
 
-#define	GAME_API_VERSION    48
+#define	GAME_API_VERSION    49
 
 //===============================================================
 

--- a/source/gameshared/gs_pmove.c
+++ b/source/gameshared/gs_pmove.c
@@ -1899,9 +1899,9 @@ void Pmove( pmove_t *pmove )
 			pm->playerState->pmove.stats[PM_STAT_FWDTIME] = 0;
 	}
 
-	pml.forwardPush = pm->cmd.forwardfrac * SPEEDKEY;
-	pml.sidePush = pm->cmd.sidefrac * SPEEDKEY;
-	pml.upPush = pm->cmd.upfrac * SPEEDKEY;
+	pml.forwardPush = pm->cmd.forwardmove * SPEEDKEY;
+	pml.sidePush = pm->cmd.sidemove * SPEEDKEY;
+	pml.upPush = pm->cmd.upmove * SPEEDKEY;
 
 	if( pm->playerState->pmove.stats[PM_STAT_NOUSERCONTROL] > 0 )
 	{

--- a/source/gameshared/q_comref.h
+++ b/source/gameshared/q_comref.h
@@ -63,8 +63,7 @@ typedef struct usercmd_s
 	uint8_t msec;
 	uint8_t buttons;
 	short angles[3];
-	float forwardfrac, sidefrac, upfrac;
-	short forwardmove, sidemove, upmove;
+	float forwardmove, sidemove, upmove;
 	unsigned int serverTimeStamp;
 } usercmd_t;
 

--- a/source/qcommon/msg.c
+++ b/source/qcommon/msg.c
@@ -775,11 +775,11 @@ void MSG_WriteDeltaUsercmd( msg_t *buf, usercmd_t *from, usercmd_t *cmd )
 	if( cmd->angles[2] != from->angles[2] )
 		bits |= CM_ANGLE3;
 
-	if( cmd->forwardfrac != from->forwardfrac )
+	if( cmd->forwardmove != from->forwardmove )
 		bits |= CM_FORWARD;
-	if( cmd->sidefrac != from->sidefrac )
+	if( cmd->sidemove != from->sidemove )
 		bits |= CM_SIDE;
-	if( cmd->upfrac != from->upfrac )
+	if( cmd->upmove != from->upmove )
 		bits |= CM_UP;
 
 	if( cmd->buttons != from->buttons )
@@ -795,11 +795,11 @@ void MSG_WriteDeltaUsercmd( msg_t *buf, usercmd_t *from, usercmd_t *cmd )
 		MSG_WriteShort( buf, cmd->angles[2] );
 
 	if( bits & CM_FORWARD )
-		MSG_WriteChar( buf, (int)( cmd->forwardfrac * UCMD_PUSHFRAC_SNAPSIZE ) );
+		MSG_WriteChar( buf, (int)( cmd->forwardmove * UCMD_PUSHFRAC_SNAPSIZE ) );
 	if( bits & CM_SIDE )
-		MSG_WriteChar( buf, (int)( cmd->sidefrac * UCMD_PUSHFRAC_SNAPSIZE ) );
+		MSG_WriteChar( buf, (int)( cmd->sidemove * UCMD_PUSHFRAC_SNAPSIZE ) );
 	if( bits & CM_UP )
-		MSG_WriteChar( buf, (int)( cmd->upfrac * UCMD_PUSHFRAC_SNAPSIZE ) );
+		MSG_WriteChar( buf, (int)( cmd->upmove * UCMD_PUSHFRAC_SNAPSIZE ) );
 
 	if( bits & CM_BUTTONS )
 		MSG_WriteByte( buf, cmd->buttons );
@@ -826,11 +826,11 @@ void MSG_ReadDeltaUsercmd( msg_t *msg_read, usercmd_t *from, usercmd_t *move )
 
 	// read movement
 	if( bits & CM_FORWARD )
-		move->forwardfrac = (float)MSG_ReadChar( msg_read )/UCMD_PUSHFRAC_SNAPSIZE;
+		move->forwardmove = (float)MSG_ReadChar( msg_read )/UCMD_PUSHFRAC_SNAPSIZE;
 	if( bits & CM_SIDE )
-		move->sidefrac = (float)MSG_ReadChar( msg_read )/UCMD_PUSHFRAC_SNAPSIZE;
+		move->sidemove = (float)MSG_ReadChar( msg_read )/UCMD_PUSHFRAC_SNAPSIZE;
 	if( bits & CM_UP )
-		move->upfrac = (float)MSG_ReadChar( msg_read )/UCMD_PUSHFRAC_SNAPSIZE;
+		move->upmove = (float)MSG_ReadChar( msg_read )/UCMD_PUSHFRAC_SNAPSIZE;
 
 	// read buttons
 	if( bits & CM_BUTTONS )

--- a/source/server/sv_client.c
+++ b/source/server/sv_client.c
@@ -1065,10 +1065,6 @@ void SV_ExecuteClientThinks( int clientNum )
 		msec = ucmd->serverTimeStamp - client->UcmdTime;
 		clamp( msec, 1, 200 );
 		ucmd->msec = msec;
-		// convert push fractions to push times
-		ucmd->forwardmove = ucmd->forwardfrac * msec;
-		ucmd->sidemove = ucmd->sidefrac * msec;
-		ucmd->upmove = ucmd->upfrac * msec;
 		timeDelta = 0;
 		if( client->lastframe > 0 )
 			timeDelta = -(int)( svs.gametime - ucmd->serverTimeStamp );

--- a/source/tv_server/tv_downstream.c
+++ b/source/tv_server/tv_downstream.c
@@ -1005,10 +1005,6 @@ void TV_Downstream_ExecuteClientThinks( relay_t *relay, client_t *client )
 		msec = ucmd->serverTimeStamp - client->UcmdTime;
 		clamp( msec, 1, 200 );
 		ucmd->msec = msec;
-		// convert push fractions to push times
-		ucmd->forwardmove = ucmd->forwardfrac * msec;
-		ucmd->sidemove = ucmd->sidefrac * msec;
-		ucmd->upmove = ucmd->upfrac * msec;
 		timeDelta = 0;
 		if( client->lastframe > 0 )
 			timeDelta = -(int)( higherTime - ucmd->serverTimeStamp );

--- a/source/tv_server/tv_module/tvm_pmove.c
+++ b/source/tv_server/tv_module/tvm_pmove.c
@@ -301,9 +301,9 @@ void TVM_Pmove( pmove_t *pmove )
 
 	pm->playerState->viewheight = playerbox_stand_viewheight;
 
-	pml.forwardPush = pm->cmd.forwardfrac * SPEEDKEY;
-	pml.sidePush = pm->cmd.sidefrac * SPEEDKEY;
-	pml.upPush = pm->cmd.upfrac * SPEEDKEY;
+	pml.forwardPush = pm->cmd.forwardmove * SPEEDKEY;
+	pml.sidePush = pm->cmd.sidemove * SPEEDKEY;
+	pml.upPush = pm->cmd.upmove * SPEEDKEY;
 
 	if( pm->playerState->pmove.stats[PM_STAT_NOUSERCONTROL] > 0 )
 	{


### PR DESCRIPTION
Removes `forwardmove`, `sidemove` and `upmove` that are only used to recreate `forwardfrac`, `sidefrac` and `upfrac` with significant precision loss.

Renames `frac` `float` variables to `move` for readability and because the bot code uses `move` (but only within -1...1 range that is `frac` is directly assigned to later).

Should fix the frame time dependence bug of gamepad analog stick movement (it could be only -1/0/1 at 1000 FPS, 4 steps in each direction at 250 FPS, etc, now there are 255 possible values at any framerate) reported on the forum.
