### PR TITLE
GB tunings

### DIFF
--- a/source/gameshared/gs_weapondefs.c
+++ b/source/gameshared/gs_weapondefs.c
@@ -119,7 +119,7 @@ gs_weapon_definition_t gs_weaponDefs[] =
 			//timings (in msecs)
 			WEAPONUP_FRAMETIME,				// weapon up frametime
 			WEAPONDOWN_FRAMETIME,           // weapon down frametime
-			400,							// reload frametime
+			750,							// reload frametime
 			0,								// cooldown frametime
 			5000,							// projectile timeout
 			false,							// smooth refire
@@ -127,7 +127,7 @@ gs_weapon_definition_t gs_weaponDefs[] =
 			//damages
 			50,								// damage
 			0.8,							// selfdamage ratio
-			100,							// knockback
+			80,							// knockback
 			0,								// stun
 			90,								// splash radius
 			8,								// splash minimum damage
@@ -141,7 +141,7 @@ gs_weapon_definition_t gs_weaponDefs[] =
 			//ammo
 			1,                              // weapon pickup amount
 			1,								// pickup amount
-			10								// max amount
+			1								// max amount
 		},
 
 		{
@@ -153,7 +153,7 @@ gs_weapon_definition_t gs_weaponDefs[] =
 			//timings (in msecs)
 			WEAPONUP_FRAMETIME,				// weapon up frametime
 			WEAPONDOWN_FRAMETIME,			// weapon down frametime
-			800,							// reload frametime
+			750,							// reload frametime
 			0,								// cooldown frametime
 			64,								// projectile timeout  / projectile range for instant weapons
 			false,							// smooth refire


### PR DESCRIPTION
- GB modes has been unified to 50 dmg / 750 reload frame time.
- GB always shoots the same projectile.
- Knockback has been lowered from 100 to 80 to make RL knockback (90) a bit more powerful than GB one. Also lower kb is pay for the constant damage.
