### PR TITLE
Follow up commits for GB tunings

### DIFF
--- a/source/gameshared/gs_weapondefs.c
+++ b/source/gameshared/gs_weapondefs.c
@@ -125,11 +125,11 @@ gs_weapon_definition_t gs_weaponDefs[] =
 			false,							// smooth refire
 
 			//damages
-			50,								// damage
-			0.8,							// selfdamage ratio
+			40,								// damage
+			1.0,							// selfdamage ratio
 			80,							// knockback
 			0,								// stun
-			90,								// splash radius
+			80,								// splash radius
 			8,								// splash minimum damage
 			10,                             // splash minimum knockback
 

--- a/source/gameshared/gs_weapondefs.c
+++ b/source/gameshared/gs_weapondefs.c
@@ -119,7 +119,7 @@ gs_weapon_definition_t gs_weaponDefs[] =
 			//timings (in msecs)
 			WEAPONUP_FRAMETIME,				// weapon up frametime
 			WEAPONDOWN_FRAMETIME,           // weapon down frametime
-			750,							// reload frametime
+			800,							// reload frametime
 			0,								// cooldown frametime
 			5000,							// projectile timeout
 			false,							// smooth refire
@@ -153,7 +153,7 @@ gs_weapon_definition_t gs_weaponDefs[] =
 			//timings (in msecs)
 			WEAPONUP_FRAMETIME,				// weapon up frametime
 			WEAPONDOWN_FRAMETIME,			// weapon down frametime
-			750,							// reload frametime
+			600,							// reload frametime
 			0,								// cooldown frametime
 			64,								// projectile timeout  / projectile range for instant weapons
 			false,							// smooth refire


### PR DESCRIPTION
GB projectile:
- dmg 50->40
- reload time 750 -> 800
- smaller splash radius 90->80
- selfdamage 0.8->1.0 to keep the same selfdamage value and to prevent GB jump abusing

GB melee:
- reload time 750 -> 600
