### PR TITLE
Update the code to match boolean Gunblade charge

### DIFF
--- a/source/cgame/cg_local.h
+++ b/source/cgame/cg_local.h
@@ -303,6 +303,7 @@ typedef struct
 	// hud icons
 	cgs_media_handle_t *shaderWeaponIcon[WEAP_TOTAL];
 	cgs_media_handle_t *shaderNoGunWeaponIcon[WEAP_TOTAL];
+	cgs_media_handle_t *shaderGunbladeBlastIcon;
 
 	cgs_media_handle_t *shaderKeyIcon[KEYICON_TOTAL];
 

--- a/source/cgame/cg_media.cpp
+++ b/source/cgame/cg_media.cpp
@@ -375,6 +375,8 @@ void CG_RegisterMediaShaders( void )
 	cgs.media.shaderNoGunWeaponIcon[WEAP_ELECTROBOLT-1] = CG_RegisterMediaShader( PATH_NG_ELECTROBOLT_ICON, true );
 	cgs.media.shaderNoGunWeaponIcon[WEAP_INSTAGUN-1] = CG_RegisterMediaShader( PATH_NG_INSTAGUN_ICON, true );
 
+	cgs.media.shaderGunbladeBlastIcon = CG_RegisterMediaShader( PATH_GUNBLADE_BLAST_ICON, true );
+
 	// Kurim : keyicons
 	cgs.media.shaderKeyIcon[KEYICON_FORWARD] = CG_RegisterMediaShader( PATH_KEYICON_FORWARD, true );
 	cgs.media.shaderKeyIcon[KEYICON_BACKWARD] = CG_RegisterMediaShader( PATH_KEYICON_BACKWARD, true );

--- a/source/game/g_ascript.cpp
+++ b/source/game/g_ascript.cpp
@@ -1981,7 +1981,6 @@ static const asProperty_t gameclient_Properties[] =
 	{ ASLIB_PROPERTY_DECL(const uint, queueTimeStamp), ASLIB_FOFFSET(gclient_t, queueTimeStamp) },
 	{ ASLIB_PROPERTY_DECL(const int, muted), ASLIB_FOFFSET(gclient_t, muted) },
 	{ ASLIB_PROPERTY_DECL(float, armor), ASLIB_FOFFSET(gclient_t, resp.armor) },
-	{ ASLIB_PROPERTY_DECL(uint, gunbladeChargeTimeStamp), ASLIB_FOFFSET(gclient_t, resp.gunbladeChargeTimeStamp) },
 	{ ASLIB_PROPERTY_DECL(const bool, chaseActive), ASLIB_FOFFSET(gclient_t, resp.chase.active) },
 	{ ASLIB_PROPERTY_DECL(int, chaseTarget), ASLIB_FOFFSET(gclient_t, resp.chase.target) },
 	{ ASLIB_PROPERTY_DECL(bool, chaseTeamonly), ASLIB_FOFFSET(gclient_t, resp.chase.teamonly) },

--- a/source/game/g_gametypes.cpp
+++ b/source/game/g_gametypes.cpp
@@ -284,7 +284,7 @@ void G_Gametype_GENERIC_ClientRespawn( edict_t *self, int old_team, int new_team
 			{
 				weapondef = GS_GetWeaponDef( WEAP_GUNBLADE );
 				client->ps.inventory[WEAP_GUNBLADE] = 1;
-				client->ps.inventory[AMMO_GUNBLADE] = weapondef->firedef.ammo_max;;
+				client->ps.inventory[AMMO_GUNBLADE] = 1;
 				client->ps.inventory[AMMO_WEAK_GUNBLADE] = 0;
 			}
 		}

--- a/source/game/g_items.cpp
+++ b/source/game/g_items.cpp
@@ -205,7 +205,7 @@ static bool Pickup_AmmoPack( edict_t *other, const int *invpack )
 	if( !invpack )
 		return false;
 
-	for( i = AMMO_GUNBLADE; i < AMMO_TOTAL; i++ )
+	for( i = AMMO_GUNBLADE + 1; i < AMMO_TOTAL; i++ )
 	{
 		item = GS_FindItemByTag( i );
 		if( item )

--- a/source/game/g_local.h
+++ b/source/game/g_local.h
@@ -1113,7 +1113,6 @@ typedef struct
 	float armor;
 	float instashieldCharge;
 
-	unsigned int gunbladeChargeTimeStamp;
 	unsigned int next_drown_time;
 	int drowningDamage;
 	int old_waterlevel;

--- a/source/game/p_client.cpp
+++ b/source/game/p_client.cpp
@@ -523,7 +523,6 @@ void G_ClientRespawn( edict_t *self, bool ghost )
 	memset( &client->resp, 0, sizeof( client->resp ) );
 	memset( &client->ps, 0, sizeof( client->ps ) );
 	client->resp.timeStamp = level.time;
-	client->resp.gunbladeChargeTimeStamp = level.time;
 	client->ps.playerNum = PLAYERNUM( self );
 
 	// clear entity values

--- a/source/game/p_weapon.cpp
+++ b/source/game/p_weapon.cpp
@@ -352,13 +352,6 @@ static edict_t *G_Fire_Gunblade_Blast( vec3_t origin, vec3_t angles, firedef_t *
 	if( minDamage < firedef->mindamage )
 		minDamage = firedef->mindamage;
 
-	// hackish : every shot wastes all player power
-	if( owner && owner->r.client && firedef->ammo_id )
-	{
-		owner->r.client->ps.inventory[firedef->ammo_id] = firedef->ammo_pickup + firedef->usage_count;
-		owner->r.client->resp.gunbladeChargeTimeStamp = level.time;
-	}
-
 	return W_Fire_GunbladeBlast( owner, origin, angles, damage, minKnockback, knockback, stun, minDamage,
 		radius, speed, firedef->timeout, mod, timeDelta );
 }

--- a/source/gameshared/gs_items.c
+++ b/source/gameshared/gs_items.c
@@ -284,7 +284,7 @@ gsitem_t	itemdefs[] =
 	// AMMO ITEMS
 	//-----------------------------------------------------------
 
-	// AMMO_CELLS = WEAP_TOTAL
+	// AMMO_BLAST = WEAP_TOTAL
 
 	//QUAKED ammo_gunblade (.3 .3 1) (-16 -16 -16) (16 16 16)
 	{
@@ -299,7 +299,7 @@ gsitem_t	itemdefs[] =
 		S_PICKUP_AMMO,
 		EF_ROTATE_AND_BOB|EF_OUTLINE|EF_AMMOBOX,
 
-		"Cells", "cells", S_COLOR_YELLOW,
+		"Blast", "blast", S_COLOR_YELLOW,
 		0, // actual value comes from weapondefs instead
 		0, // actual value comes from weapondefs instead
 		AMMO_NONE,

--- a/source/gameshared/gs_qrespath.h
+++ b/source/gameshared/gs_qrespath.h
@@ -48,6 +48,7 @@ extern "C" {
 
 // weapon
 #define PATH_GUNBLADE_ICON	    "gfx/hud/icons/weapon/gunblade"
+#define PATH_GUNBLADE_BLAST_ICON	    "gfx/hud/icons/weapon/gunblade_blast"
 #define PATH_MACHINEGUN_ICON	"gfx/hud/icons/weapon/machinegun"
 #define PATH_RIOTGUN_ICON	    "gfx/hud/icons/weapon/riot"
 #define PATH_GRENADELAUNCHER_ICON   "gfx/hud/icons/weapon/grenade"

--- a/source/gameshared/gs_weapondefs.c
+++ b/source/gameshared/gs_weapondefs.c
@@ -108,7 +108,7 @@ gs_weapon_definition_t gs_weaponDefs[] =
 	},
 
 	{
-		"gunblade",
+		"Gunblade",
 		WEAP_GUNBLADE,
 		{
 			FIRE_MODE_STRONG,
@@ -139,8 +139,8 @@ gs_weapon_definition_t gs_weaponDefs[] =
 			0,                              // v_spread
 
 			//ammo
-			1,                              // weapon pickup amount
-			1,								// pickup amount
+			0,                              // weapon pickup amount
+			0,								// pickup amount
 			1								// max amount
 		},
 

--- a/source/gameshared/gs_weapons.c
+++ b/source/gameshared/gs_weapons.c
@@ -569,7 +569,7 @@ int GS_ThinkPlayerWeapon( player_state_t *playerState, int buttons, int msecs, i
 			module_PredictedEvent( playerState->POVnum, EV_FIREWEAPON, parm );
 
 		// waste ammo
-		if( !GS_InfiniteAmmo() )
+		if( !GS_InfiniteAmmo() && playerState->stats[STAT_WEAPON] != WEAP_GUNBLADE )
 		{
 			if( firedef->ammo_id != AMMO_NONE && firedef->usage_count )
 				playerState->inventory[firedef->ammo_id] -= firedef->usage_count;


### PR DESCRIPTION
- Strong Gunblade ammo is now boolean, sets whether the Gunblade should fire blasts or only use the blade.
- Rather than using gametype script code that is not in sync with the reloading to recharge the Gunblade, its charge is now tied to the reload time, similar to the Instagun.
- The HUD now shows a different icon when the Gunblade is charged and ready to fire instead of the boring 0 or 1 digit. Since `drawPicByItemIndex` shouldn't depend on external state, `drawWeaponIcon` is now used to draw the icon of the current weapon. It can be modified to add more various effects to weapon icons. There's no way to override both icons in the weapon list from HUD scripts though (`setCustomWeaponIcons` is not used in any stock HUDs anymore anyway).

Gametype scripts and HUDs in the game repository will be updated after the merge.
