### PR TITLE
Defer consecutive userinfo changes rather than ignoring them

### DIFF
--- a/source/server/server.h
+++ b/source/server/server.h
@@ -129,8 +129,9 @@ typedef struct client_s
 {
 	sv_client_state_t state;
 
-	char userinfo[MAX_INFO_STRING];     // name, etc
-	unsigned int userinfoUpTimeout;
+	char userinfo[MAX_INFO_STRING];			// name, etc
+	char userinfoLatched[MAX_INFO_STRING];	// flood prevention - actual userinfo updates are delayed
+	unsigned int userinfoLatchTimeout;
 
 	bool reliable;                  // no need for acks, connection is reliable
 	bool mv;                        // send multiview data to the client

--- a/source/server/sv_mm.c
+++ b/source/server/sv_mm.c
@@ -204,6 +204,7 @@ static void sv_mm_clientconnect_done( stat_query_t *query, bool success, void *c
 	int session_id, isession_id;
 	client_t *cl;
 	edict_t *ent;
+	bool userinfo_changed = false;
 
 	/*
 	 * ch : JSON API
@@ -273,10 +274,7 @@ static void sv_mm_clientconnect_done( stat_query_t *query, bool success, void *c
 				ratings_section = sq_api->GetSection( root, "ratings" );
 
 				Q_strncpyz( cl->mm_login, login, sizeof( cl->mm_login ) );
-
-				if( !Info_SetValueForKey( cl->userinfo, "cl_mm_login", login ) ) {
-					Com_Printf( "Failed to set infokey cl_mm_login for player %s\n", login );
-				}
+				userinfo_changed = true;
 
 				if( ge != NULL && ratings_section != NULL )
 				{
@@ -291,7 +289,6 @@ static void sv_mm_clientconnect_done( stat_query_t *query, bool success, void *c
 						element = sq_api->GetArraySection( ratings_section, idx++ );
 					}
 				}
-				SV_UserinfoChanged( cl );
 			}
 		}
 	}
@@ -309,8 +306,7 @@ static void sv_mm_clientconnect_done( stat_query_t *query, bool success, void *c
 		isession_id = SV_MM_GenerateLocalSession();
 		Com_Printf("SV_MM_ClientConnect: Forcing local_session %d on client %s\n", isession_id, cl->name );
 		cl->mm_session = isession_id;
-		// TODO: reflect this to the userinfo
-		Info_SetValueForKey( cl->userinfo, "cl_mm_session", va("%d", isession_id ) );
+		userinfo_changed = true;
 
 		// We should also notify MM about the new local session id?
 		// Or another option would be that MM doesnt track local sessions at all,
@@ -319,6 +315,9 @@ static void sv_mm_clientconnect_done( stat_query_t *query, bool success, void *c
 		// resend scc query
 		// cl->socket->address
 	}
+
+	if( userinfo_changed )
+		SV_UserinfoChanged( cl );
 
 	Com_Printf("SV_MM_ClientConnect: %s with session id %d\n", cl->name, cl->mm_session );
 }

--- a/source/server/sv_mm.c
+++ b/source/server/sv_mm.c
@@ -274,6 +274,9 @@ static void sv_mm_clientconnect_done( stat_query_t *query, bool success, void *c
 				ratings_section = sq_api->GetSection( root, "ratings" );
 
 				Q_strncpyz( cl->mm_login, login, sizeof( cl->mm_login ) );
+				if( !Info_SetValueForKey( cl->userinfo, "cl_mm_login", login ) ) {
+					Com_Printf( "Failed to set infokey cl_mm_login for player %s\n", login );
+				}
 				userinfo_changed = true;
 
 				if( ge != NULL && ratings_section != NULL )


### PR DESCRIPTION
Simply dropping quick userinfo changes is very user-unfriendly and may lead to permanent mismatch of client settings between the server and the client.

There have been bug reports related to this issue on the forum, such as the autohop toggle doing nothing for somebody.
