### PR TITLE
Increase GB splash radius and knockback

### DIFF
--- a/source/gameshared/gs_weapondefs.c
+++ b/source/gameshared/gs_weapondefs.c
@@ -129,9 +129,9 @@ gs_weapon_definition_t gs_weaponDefs[] =
 			//damages
 			40,								// damage
 			1.0,							// selfdamage ratio
-			80,								// knockback
+			85,								// knockback
 			0,								// stun
-			40,								// splash radius
+			60,								// splash radius
 			8,								// splash minimum damage
 			10,                             // splash minimum knockback
 


### PR DESCRIPTION
Current GB jump is just a joke that needs uber defrag skills to be done properly. Following changes make that state less dramatical.
