### PR TITLE
Allow touch HUDs to open the quick menu on the left

### DIFF
--- a/source/cgame/cg_cmds.cpp
+++ b/source/cgame/cg_cmds.cpp
@@ -794,29 +794,26 @@ static void CG_SC_MenuCustom( void )
 */
 static void CG_SC_MenuQuick( void )
 {
-	char request[MAX_STRING_CHARS];
 	int i, c;
 
 	if( cgs.demoPlaying || cgs.tv )
 		return;
 
-	if( trap_Cmd_Argc() < 2 ) {
-		trap_Cmd_ExecuteText( EXEC_APPEND, "menu_quick 0\n" );
-		return;
-	}
+	cg.quickmenu[0] = '\0';
 
-	Q_strncpyz( request, "menu_quick game_quick ", sizeof( request ) );
-	
-	for( i = 1, c = 1; i < trap_Cmd_Argc() - 1; i += 2, c++ )
+	if( trap_Cmd_Argc() >= 2 )
 	{
-		const char *label = trap_Cmd_Argv( i );
-		const char *cmd = trap_Cmd_Argv( i + 1 );
+		for( i = 1, c = 1; i < trap_Cmd_Argc() - 1; i += 2, c++ )
+		{
+			const char *label = trap_Cmd_Argv( i );
+			const char *cmd = trap_Cmd_Argv( i + 1 );
 
-		Q_strncatz( request, va( "btn%i \"%s\" ", c, label ), sizeof( request ) );
-		Q_strncatz( request, va( "cmd%i \"%s%s\" ", c, *cmd ? "cmd " : "", cmd ), sizeof( request ) );
+			Q_strncatz( cg.quickmenu, va( "btn%i \"%s\" ", c, label ), sizeof( cg.quickmenu ) );
+			Q_strncatz( cg.quickmenu, va( "cmd%i \"%s%s\" ", c, *cmd ? "cmd " : "", cmd ), sizeof( cg.quickmenu ) );
+		}
 	}
 
-	trap_Cmd_ExecuteText( EXEC_APPEND, va( "%s\n", request ) );
+	CG_RefreshQuickMenu();
 }
 
 /*

--- a/source/cgame/cg_hud.cpp
+++ b/source/cgame/cg_hud.cpp
@@ -2890,17 +2890,22 @@ static bool CG_LFuncTouchScores( struct cg_layoutnode_s *commandnode, struct cg_
 static void CG_QuickMenuUpFunc( int id, unsigned int time )
 {
 	if( GS_MatchState() < MATCH_STATE_POSTMATCH )
-		trap_SCR_EnableQuickMenu( false );
+		CG_ShowQuickMenu( 0 );
 }
 
 static bool CG_LFuncTouchQuickMenu( struct cg_layoutnode_s *commandnode, struct cg_layoutnode_s *argumentnode, int numArguments )
 {
-	if( CG_TouchArea( TOUCHAREA_HUD_QUICKMENU,
-		CG_HorizontalAlignForWidth( layout_cursor_x, layout_cursor_align, layout_cursor_width ),
-		CG_VerticalAlignForHeight( layout_cursor_y, layout_cursor_align, layout_cursor_height ),
-		layout_cursor_width, layout_cursor_height, CG_QuickMenuUpFunc ) >= 0 )
+	int side = ( int )CG_GetNumericArg( &argumentnode );
+
+	if( GS_MatchState() < MATCH_STATE_POSTMATCH )
 	{
-		trap_SCR_EnableQuickMenu( true );
+		if( CG_TouchArea( TOUCHAREA_HUD_QUICKMENU,
+			CG_HorizontalAlignForWidth( layout_cursor_x, layout_cursor_align, layout_cursor_width ),
+			CG_VerticalAlignForHeight( layout_cursor_y, layout_cursor_align, layout_cursor_height ),
+			layout_cursor_width, layout_cursor_height, CG_QuickMenuUpFunc ) >= 0 )
+		{
+			CG_ShowQuickMenu( ( side < 0 ) ? -1 : 1 );
+		}
 	}
 	return true;
 }
@@ -3588,8 +3593,8 @@ static const cg_layoutcommand_t cg_LayoutCommands[] =
 		"touchQuickMenu",
 		NULL,
 		CG_LFuncTouchQuickMenu,
-		0,
-		"Places quick menu button",
+		1,
+		"Places quick menu button, 1 to show the menu on the right, -1 to show it on the left",
 		false
 	},
 

--- a/source/cgame/cg_local.h
+++ b/source/cgame/cg_local.h
@@ -615,6 +615,8 @@ typedef struct
 	size_t teaminfo_size;
 	char *motd;
 	unsigned int motd_time;
+	char quickmenu[MAX_STRING_CHARS];
+	bool quickmenu_left;
 
 	// awards
 	char award_lines[MAX_AWARD_LINES][MAX_CONFIGSTRING_CHARS];
@@ -767,6 +769,18 @@ void CG_DrawTeamInfo( int x, int y, int align, struct qfontface_s *font, vec4_t 
 void CG_DrawNet( int x, int y, int w, int h, int align, vec4_t color );
 
 void CG_GameMenu_f( void );
+
+/**
+ * Sends current quick menu string to the UI.
+ */
+void CG_RefreshQuickMenu( void );
+
+/**
+ * Toggles the visibility of the quick menu.
+ *
+ * @param state quick menu visibility (0 = hidden, 1 = on the right, -1 = on the left)
+ */
+void CG_ShowQuickMenu( int state );
 
 /**
  * Touch area ID namespaces.

--- a/source/cgame/cg_main.cpp
+++ b/source/cgame/cg_main.cpp
@@ -1147,7 +1147,7 @@ void CG_Init( const char *serverName, unsigned int playerNum,
 	cgs.hasGametypeMenu = false; // this will update as soon as we receive configstrings
 	cgs.gameMenuRequested = !gameStart;
 
-	trap_Cmd_ExecuteText( EXEC_APPEND, "menu_quick 0\n" );
+	CG_RefreshQuickMenu();
 
 	CG_RegisterVariables();
 	CG_InitTemporaryBoneposesCache();

--- a/source/cgame/cg_screen.cpp
+++ b/source/cgame/cg_screen.cpp
@@ -193,6 +193,43 @@ void CG_ScreenCrosshairDamageUpdate( void )
 //=============================================================================
 
 /*
+* CG_RefreshQuickMenu
+*/
+void CG_RefreshQuickMenu( void )
+{
+	if( !cg.quickmenu[0] )
+	{
+		trap_Cmd_ExecuteText( EXEC_APPEND, "menu_quick 0\n" );
+		return;
+	}
+
+	trap_Cmd_ExecuteText( EXEC_APPEND, va( "menu_quick game_quick left %d %s\n", cg.quickmenu_left ? 1 : 0, cg.quickmenu ) );
+}
+
+/*
+* CG_ShowQuickMenu
+*/
+void CG_ShowQuickMenu( int state )
+{
+	if( !state )
+	{
+		trap_SCR_EnableQuickMenu( false );
+		return;
+	}
+
+	bool left = ( state < 0 );
+	if( cg.quickmenu_left != left )
+	{
+		cg.quickmenu_left = left;
+		CG_RefreshQuickMenu();
+	}
+
+	trap_SCR_EnableQuickMenu( true );
+}
+
+//=============================================================================
+
+/*
 * CG_CalcVrect
 * 
 * Sets scr_vrect, the coordinates of the rendered window
@@ -251,18 +288,19 @@ static void CG_SizeDown_f( void )
 /*
 * CG_QuickMenuOn_f
 */
-static void SCR_QuickMenuOn_f( void )
+static void CG_QuickMenuOn_f( void )
 {
-	trap_SCR_EnableQuickMenu( true );
+	if( GS_MatchState() < MATCH_STATE_POSTMATCH )
+		CG_ShowQuickMenu( 1 );
 }
 
 /*
 * CG_QuickMenuOff_f
 */
-static void SCR_QuickMenuOff_f( void )
+static void CG_QuickMenuOff_f( void )
 {
 	if( GS_MatchState() < MATCH_STATE_POSTMATCH )
-		trap_SCR_EnableQuickMenu( false );
+		CG_ShowQuickMenu( 0 );
 }
 
 //============================================================================
@@ -339,8 +377,8 @@ void CG_ScreenInit( void )
 	trap_Cmd_AddCommand( "help_hud", Cmd_CG_PrintHudHelp_f );
 	trap_Cmd_AddCommand( "gamemenu", CG_GameMenu_f );
 
-	trap_Cmd_AddCommand( "+quickmenu", &SCR_QuickMenuOn_f );
-	trap_Cmd_AddCommand( "-quickmenu", &SCR_QuickMenuOff_f );
+	trap_Cmd_AddCommand( "+quickmenu", &CG_QuickMenuOn_f );
+	trap_Cmd_AddCommand( "-quickmenu", &CG_QuickMenuOff_f );
 
 	int i;
 	for( i = 0; i < TOUCHPAD_COUNT; ++i )

--- a/source/cgame/cg_view.cpp
+++ b/source/cgame/cg_view.cpp
@@ -132,7 +132,7 @@ static void CG_AddLocalSounds( void )
 	{
 		if( !postmatchsound_set && !demostream )
 		{
-			trap_SCR_EnableQuickMenu( true );
+			CG_ShowQuickMenu( 1 );
 
 			trap_S_StartBackgroundTrack( S_PLAYLIST_POSTMATCH, NULL, 3 ); // loop random track from the playlist
 			postmatchsound_set = true;
@@ -149,7 +149,7 @@ static void CG_AddLocalSounds( void )
 
 		if( postmatchsound_set )
 		{
-			trap_SCR_EnableQuickMenu( false );
+			CG_ShowQuickMenu( 0 );
 
 			trap_S_StopBackgroundTrack();
 			postmatchsound_set = false;


### PR DESCRIPTION
A touch HUD may want to place the quick menu on the left of the screen rather than the right side (for instance, if the button is on the right). The default HUD does that in the flipped mode.
