### PR TITLE
Fixed spelling in console messages

### DIFF
--- a/source/client/cl_serverlist.c
+++ b/source/client/cl_serverlist.c
@@ -296,7 +296,7 @@ static void CL_QueryGetInfoMessage( const char *cmdname )
 	}
 
 	// send a broadcast packet
-	Com_DPrintf( "quering %s...\n", server );
+	Com_DPrintf( "querying %s...\n", server );
 
 	if( NET_StringToAddress( server, &adr ) )
 	{

--- a/source/client/cl_sound.c
+++ b/source/client/cl_sound.c
@@ -172,7 +172,7 @@ static bool CL_SoundModule_Load( const char *name, sound_import_t *import, bool 
 	}
 
 	if( verbose )
-		Com_Printf( "Initialization of %s succesful\n", name );
+		Com_Printf( "Initialization of %s successful\n", name );
 
 	return true;
 }


### PR DESCRIPTION
via https://github.com/ckorn/PlayDeb/blob/wily/warsow/patches/typos.patch
