### PR TITLE
Don't draw RG/MG flesh hit

### DIFF
--- a/source/cgame/cg_lents.cpp
+++ b/source/cgame/cg_lents.cpp
@@ -429,11 +429,22 @@ void CG_BulletExplosion( const vec3_t pos, const vec_t *dir, const trace_t *trac
 	VecToAngles( local_dir, angles );
 
 	if( tr->surfFlags & SURF_FLESH ||
-		( tr->ent > 0 && cg_entities[tr->ent].current.type == ET_PLAYER ) ||
-		( tr->ent > 0 && cg_entities[tr->ent].current.type == ET_CORPSE ) )
+		( tr->ent > 0 && cg_entities[tr->ent].current.type == ET_PLAYER ) )
 	{
 		return;
 	}
+	else if ( tr->ent > 0 && cg_entities[tr->ent].current.type == ET_CORPSE )
+        {
+		le = CG_AllocModel( LE_ALPHA_FADE, pos, angles, 3, //3 frames for weak 
+                        1, 0, 0, 1, //full white no inducted alpha
+                        0, 0, 0, 0, //dlight
+                        CG_MediaModel( cgs.media.modBulletExplode ),
+                        NULL );
+		le->ent.rotation = rand() % 360;
+		le->ent.scale = 1.0f;
+		if( ISVIEWERENTITY( tr->ent ) )
+			le->ent.renderfx |= RF_VIEWERMODEL;
+        }
 	else if( cg_particles->integer && (tr->surfFlags & SURF_DUST) )
 	{
 		// throw particles on dust

--- a/source/cgame/cg_lents.cpp
+++ b/source/cgame/cg_lents.cpp
@@ -428,13 +428,12 @@ void CG_BulletExplosion( const vec3_t pos, const vec_t *dir, const trace_t *trac
 
 	VecToAngles( local_dir, angles );
 
-	if( tr->surfFlags & SURF_FLESH ||
-		( tr->ent > 0 && cg_entities[tr->ent].current.type == ET_PLAYER ) )
+	if( tr->ent > 0 && cg_entities[tr->ent].current.type == ET_PLAYER )
 	{
 		return;
 	}
-	else if ( tr->ent > 0 && cg_entities[tr->ent].current.type == ET_CORPSE )
-        {
+	else if ( tr->surfFlags & SURF_FLESH || ( tr->ent > 0 && cg_entities[tr->ent].current.type == ET_CORPSE ) )
+	{
 		le = CG_AllocModel( LE_ALPHA_FADE, pos, angles, 3, //3 frames for weak 
                         1, 0, 0, 1, //full white no inducted alpha
                         0, 0, 0, 0, //dlight
@@ -444,7 +443,7 @@ void CG_BulletExplosion( const vec3_t pos, const vec_t *dir, const trace_t *trac
 		le->ent.scale = 1.0f;
 		if( ISVIEWERENTITY( tr->ent ) )
 			le->ent.renderfx |= RF_VIEWERMODEL;
-        }
+	}
 	else if( cg_particles->integer && (tr->surfFlags & SURF_DUST) )
 	{
 		// throw particles on dust

--- a/source/cgame/cg_lents.cpp
+++ b/source/cgame/cg_lents.cpp
@@ -432,15 +432,7 @@ void CG_BulletExplosion( const vec3_t pos, const vec_t *dir, const trace_t *trac
 		( tr->ent > 0 && cg_entities[tr->ent].current.type == ET_PLAYER ) ||
 		( tr->ent > 0 && cg_entities[tr->ent].current.type == ET_CORPSE ) )
 	{
-		le = CG_AllocModel( LE_ALPHA_FADE, pos, angles, 3, //3 frames for weak
-			1, 0, 0, 1, //full white no inducted alpha
-			0, 0, 0, 0, //dlight
-			CG_MediaModel( cgs.media.modBulletExplode ),
-			NULL );
-		le->ent.rotation = rand() % 360;
-		le->ent.scale = 1.0f;
-		if( ISVIEWERENTITY( tr->ent ) )
-			le->ent.renderfx |= RF_VIEWERMODEL;
+		return;
 	}
 	else if( cg_particles->integer && (tr->surfFlags & SURF_DUST) )
 	{


### PR DESCRIPTION
RG/MG flesh hit is a client side effect which tends to be incorrect even on low ping - http://screenshotcomparison.com/comparison.php?id=137247

And since it is drawn in red it may look like a bloody hit while there was no hit at all. So the best option is not to draw it at all, especially when there is another hit effect called BloodTrail.

Btw the same solution is used in q3 engine:
![shot0005](https://cloud.githubusercontent.com/assets/4707112/12090731/8da225d6-b302-11e5-9c19-9eab6261c0af.jpg)
