### PR TITLE
Surface changing in the threaded renderer, some context management cleanup and frame cmd alignment

### DIFF
--- a/source/android/android_glw.c
+++ b/source/android/android_glw.c
@@ -246,26 +246,7 @@ static void GLimp_Android_UpdateWindowSurface( void )
 
 	ANativeWindow_setBuffersGeometry( window, glConfig.width, glConfig.height, glw_state.format );
 
-#if 0
-	if( glConfig.stereoEnabled )
-	{
-		const char *extensions = qglGetGLWExtensionsString();
-		if( extensions && strstr( extensions, "EGL_EXT_multiview_window" ) )
-		{
-			int attribs[] = { EGL_MULTIVIEW_VIEW_COUNT_EXT, 2, EGL_NONE };
-			glw_state.surface = qeglCreateWindowSurface( glw_state.display, glw_state.config, window, attribs );
-		}
-	}
-#endif
-
-	if( glw_state.surface == EGL_NO_SURFACE ) // Try to create a non-stereo surface.
-	{
-#if 0
-		glConfig.stereoEnabled = false;
-#endif
-		glw_state.surface = qeglCreateWindowSurface( glw_state.display, glw_state.config, window, NULL );
-	}
-
+	glw_state.surface = qeglCreateWindowSurface( glw_state.display, glw_state.config, window, NULL );
 	if( glw_state.surface == EGL_NO_SURFACE )
 	{
 		ri.Com_Printf( "GLimp_Android_UpdateWindowSurface() - GLimp_Android_CreateWindowSurface failed\n" );
@@ -367,7 +348,6 @@ rserr_t GLimp_SetMode( int x, int y, int width, int height, int displayFrequency
 	glConfig.width = width;
 	glConfig.height = height;
 	glConfig.fullScreen = fullscreen;
-	glConfig.stereoEnabled = stereo;
 
 	if( !GLimp_InitGL() )
 	{

--- a/source/android/android_glw.c
+++ b/source/android/android_glw.c
@@ -233,10 +233,12 @@ static void GLimp_Android_UpdateWindowSurface( void )
 	ANativeWindow *window = glw_state.window;
 	EGLContext context = qeglGetCurrentContext();
 
+	if( context == EGL_NO_CONTEXT )
+		return;
+
 	if( glw_state.surface != EGL_NO_SURFACE )
 	{
-		if( context != EGL_NO_CONTEXT )
-			qeglMakeCurrent( glw_state.display, glw_state.noWindowPbuffer, glw_state.noWindowPbuffer, context );
+		qeglMakeCurrent( glw_state.display, glw_state.noWindowPbuffer, glw_state.noWindowPbuffer, context );
 		qeglDestroySurface( glw_state.display, glw_state.surface );
 		glw_state.surface = EGL_NO_SURFACE;
 	}
@@ -253,8 +255,8 @@ static void GLimp_Android_UpdateWindowSurface( void )
 		return;
 	}
 
-	if( context != EGL_NO_CONTEXT )
-		qeglMakeCurrent( glw_state.display, glw_state.surface, glw_state.surface, context );
+	qeglMakeCurrent( glw_state.display, glw_state.surface, glw_state.surface, context );
+	qeglSwapInterval( glw_state.display, glw_state.swapInterval );
 }
 
 /*
@@ -313,6 +315,8 @@ static bool GLimp_InitGL( void )
 	}
 
 	glw_state.windowMutex = ri.Mutex_Create();
+
+	glw_state.swapInterval = 1; // Default swap interval for new surfaces
 
 	// GLimp_Android_UpdateWindowSurface attaches the surface to the current context, so make one current to initialize
 	qeglMakeCurrent( glw_state.display, glw_state.noWindowPbuffer, glw_state.noWindowPbuffer, glw_state.context );
@@ -434,7 +438,11 @@ bool GLimp_RenderingEnabled( void )
 */
 void GLimp_SetSwapInterval( int swapInterval )
 {
-	qeglSwapInterval( glw_state.display, swapInterval );
+	if( glw_state.swapInterval != swapInterval )
+	{
+		glw_state.swapInterval = swapInterval;
+		qeglSwapInterval( glw_state.display, swapInterval );
+	}
 }
 
 /*

--- a/source/android/android_glw.c
+++ b/source/android/android_glw.c
@@ -422,11 +422,11 @@ void GLimp_SetGammaRamp( size_t stride, unsigned short size, unsigned short *ram
 }
 
 /*
-** GLimp_ScreenEnabled
+** GLimp_RenderingEnabled
 */
-bool GLimp_ScreenEnabled( void )
+bool GLimp_RenderingEnabled( void )
 {
-	return ( glw_state.surface != EGL_NO_SURFACE ) ? true : false;
+	return glw_state.window != NULL;
 }
 
 /*

--- a/source/android/android_glw.c
+++ b/source/android/android_glw.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2015 SiPlus, Chasseur de bots
+Copyright (C) 2016 SiPlus, Warsow Development Team
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -43,8 +43,7 @@ void GLimp_EndFrame( void )
 ** GLimp_Init
 **
 ** This routine is responsible for initializing the OS specific portions
-** of OpenGL.  Under Win32 this means dealing with the pixelformats and
-** doing the wgl interface stuff.
+** of OpenGL.
 */
 int GLimp_Init( const char *applicationName, void *hinstance, void *wndproc, void *parenthWnd,
 	int iconResource, const int *iconXPM )
@@ -64,6 +63,8 @@ int GLimp_Init( const char *applicationName, void *hinstance, void *wndproc, voi
 */
 void GLimp_Shutdown( void )
 {
+	if( glw_state.windowMutex )
+		ri.Mutex_Destroy( &glw_state.windowMutex );
 	if( glw_state.context != EGL_NO_CONTEXT )
 	{
 		qeglMakeCurrent( glw_state.display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT );
@@ -75,10 +76,15 @@ void GLimp_Shutdown( void )
 		qeglDestroySurface( glw_state.display, glw_state.surface );
 		glw_state.surface = EGL_NO_SURFACE;
 	}
-	if( glw_state.pbufferSurface != EGL_NO_SURFACE )
+	if( glw_state.noWindowPbuffer != EGL_NO_SURFACE )
 	{
-		qeglDestroySurface( glw_state.display, glw_state.pbufferSurface );
-		glw_state.pbufferSurface = EGL_NO_SURFACE;
+		qeglDestroySurface( glw_state.display, glw_state.noWindowPbuffer );
+		glw_state.noWindowPbuffer = EGL_NO_SURFACE;
+	}
+	if( glw_state.mainThreadPbuffer != EGL_NO_SURFACE )
+	{
+		qeglDestroySurface( glw_state.display, glw_state.mainThreadPbuffer );
+		glw_state.mainThreadPbuffer = EGL_NO_SURFACE;
 	}
 	if( glw_state.display != EGL_NO_DISPLAY )
 	{
@@ -209,40 +215,55 @@ static void GLimp_Android_ChooseConfig( void )
 }
 
 /**
+ * Creates a 1x1 pbuffer surface for contexts that don't use the main surface.
+ *
+ * @return 1x1 pbuffer surface
+ */
+static EGLSurface GLimp_Android_CreatePbufferSurface( void )
+{
+	const int pbufferAttribs[] = { EGL_WIDTH, 1, EGL_HEIGHT, 1, EGL_NONE };
+	return qeglCreatePbufferSurface( glw_state.display, glw_state.config, pbufferAttribs );
+}
+
+/**
  * Recreates and selects the surface for the newly created window, or selects a dummy buffer when there's no window.
  */
 static void GLimp_Android_UpdateWindowSurface( void )
 {
 	ANativeWindow *window = glw_state.window;
+	EGLContext context = qeglGetCurrentContext();
 
 	if( glw_state.surface != EGL_NO_SURFACE )
 	{
+		if( context != EGL_NO_CONTEXT )
+			qeglMakeCurrent( glw_state.display, glw_state.noWindowPbuffer, glw_state.noWindowPbuffer, context );
 		qeglDestroySurface( glw_state.display, glw_state.surface );
 		glw_state.surface = EGL_NO_SURFACE;
 	}
 
 	if( !window )
-	{
-		qeglMakeCurrent( glw_state.display, glw_state.pbufferSurface, glw_state.pbufferSurface, glw_state.context );
 		return;
-	}
 
 	ANativeWindow_setBuffersGeometry( window, glConfig.width, glConfig.height, glw_state.format );
 
+#if 0
 	if( glConfig.stereoEnabled )
 	{
 		const char *extensions = qglGetGLWExtensionsString();
 		if( extensions && strstr( extensions, "EGL_EXT_multiview_window" ) )
 		{
 			int attribs[] = { EGL_MULTIVIEW_VIEW_COUNT_EXT, 2, EGL_NONE };
-			glw_state.surface = qeglCreateWindowSurface( glw_state.display, glw_state.config, glw_state.window, attribs );
+			glw_state.surface = qeglCreateWindowSurface( glw_state.display, glw_state.config, window, attribs );
 		}
 	}
+#endif
 
 	if( glw_state.surface == EGL_NO_SURFACE ) // Try to create a non-stereo surface.
 	{
+#if 0
 		glConfig.stereoEnabled = false;
-		glw_state.surface = qeglCreateWindowSurface( glw_state.display, glw_state.config, glw_state.window, NULL );
+#endif
+		glw_state.surface = qeglCreateWindowSurface( glw_state.display, glw_state.config, window, NULL );
 	}
 
 	if( glw_state.surface == EGL_NO_SURFACE )
@@ -251,15 +272,8 @@ static void GLimp_Android_UpdateWindowSurface( void )
 		return;
 	}
 
-	if( !qeglMakeCurrent( glw_state.display, glw_state.surface, glw_state.surface, glw_state.context ) )
-	{
-		ri.Com_Printf( "GLimp_Android_UpdateWindowSurface() - eglMakeCurrent failed\n" );
-		qeglDestroySurface( glw_state.display, glw_state.surface );
-		glw_state.surface = EGL_NO_SURFACE;
-		return;
-	}
-
-	qeglSwapInterval( glw_state.display, glw_state.swapInterval );
+	if( context != EGL_NO_CONTEXT )
+		qeglMakeCurrent( glw_state.display, glw_state.surface, glw_state.surface, context );
 }
 
 /*
@@ -269,7 +283,6 @@ static bool GLimp_InitGL( void )
 {
 	int format;
 	EGLConfig config;
-	const int pbufferAttribs[] = { EGL_WIDTH, 1, EGL_HEIGHT, 1, EGL_NONE };
 	const int contextAttribs[] = { EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE };
 	EGLSurface surface;
 
@@ -297,10 +310,17 @@ static bool GLimp_InitGL( void )
 		return false;
 	}
 
-	glw_state.pbufferSurface = qeglCreatePbufferSurface( glw_state.display, glw_state.config, pbufferAttribs );
-	if( glw_state.pbufferSurface == EGL_NO_SURFACE )
+	glw_state.mainThreadPbuffer = GLimp_Android_CreatePbufferSurface();
+	if( glw_state.mainThreadPbuffer == EGL_NO_SURFACE )
 	{
-		ri.Com_Printf( "GLimp_InitGL() - eglCreatePbufferSurface failed\n" );
+		ri.Com_Printf( "GLimp_InitGL() - GLimp_Android_CreatePbufferSurface for mainThreadPbuffer failed\n" );
+		return false;
+	}
+
+	glw_state.noWindowPbuffer = GLimp_Android_CreatePbufferSurface();
+	if( glw_state.noWindowPbuffer == EGL_NO_SURFACE )
+	{
+		ri.Com_Printf( "GLimp_InitGL() - GLimp_Android_CreatePbufferSurface for noWindowPbuffer failed\n" );
 		return false;
 	}
 
@@ -311,8 +331,10 @@ static bool GLimp_InitGL( void )
 		return false;
 	}
 
-	glw_state.swapInterval = 1;
+	glw_state.windowMutex = ri.Mutex_Create();
 
+	// GLimp_Android_UpdateWindowSurface attaches the surface to the current context, so make one current to initialize
+	qeglMakeCurrent( glw_state.display, glw_state.noWindowPbuffer, glw_state.noWindowPbuffer, glw_state.context );
 	GLimp_Android_UpdateWindowSurface();
 
 	return true;
@@ -360,15 +382,40 @@ rserr_t GLimp_SetMode( int x, int y, int width, int height, int displayFrequency
 /*
 ** GLimp_SetWindow
 */
-rserr_t GLimp_SetWindow( void *hinstance, void *wndproc, void *parenthWnd )
+rserr_t GLimp_SetWindow( void *hinstance, void *wndproc, void *parenthWnd, bool *surfaceChangePending )
 {
 	ANativeWindow *window = ( ANativeWindow * )parenthWnd;
 
-	if( glw_state.window == window )
-		return rserr_ok;
+	if( surfaceChangePending )
+		*surfaceChangePending = false;
 
-	glw_state.window = window;
-	GLimp_Android_UpdateWindowSurface();
+	if( glw_state.context == EGL_NO_CONTEXT ) // not initialized yet
+	{
+		glw_state.window = window;
+		return rserr_ok;
+	}
+
+	if( glw_state.multithreadedRendering )
+		ri.Mutex_Lock( glw_state.windowMutex );
+
+	if( glw_state.window != window )
+	{
+		glw_state.window = window;
+		if( glw_state.multithreadedRendering )
+		{
+			glw_state.windowChanged = true;
+			if( surfaceChangePending )
+				*surfaceChangePending = true;
+		}
+		else
+		{
+			GLimp_Android_UpdateWindowSurface();
+		}
+	}
+
+	if( glw_state.multithreadedRendering )
+		ri.Mutex_Unlock( glw_state.windowMutex );
+
 	return rserr_ok;
 }
 
@@ -407,9 +454,36 @@ bool GLimp_ScreenEnabled( void )
 */
 void GLimp_SetSwapInterval( int swapInterval )
 {
-	glw_state.swapInterval = swapInterval;
-	if( glw_state.surface != EGL_NO_SURFACE )
-		qeglSwapInterval( glw_state.display, swapInterval );
+	qeglSwapInterval( glw_state.display, swapInterval );
+}
+
+/*
+** GLimp_EnableMultithreadedRendering
+*/
+void GLimp_EnableMultithreadedRendering( bool enable )
+{
+	EGLSurface surface;
+
+	if( glw_state.multithreadedRendering == enable )
+		return;
+
+	glw_state.multithreadedRendering = enable;
+
+	if( enable )
+	{
+		surface = glw_state.mainThreadPbuffer;
+	}
+	else
+	{
+		if( glw_state.windowChanged )
+		{
+			glw_state.windowChanged = false;
+			GLimp_Android_UpdateWindowSurface();
+		}
+		surface = ( glw_state.surface != EGL_NO_SURFACE ? glw_state.surface : glw_state.noWindowPbuffer );
+	}
+
+	qeglMakeCurrent( glw_state.display, surface, surface, glw_state.context );
 }
 
 /*
@@ -421,6 +495,32 @@ void GLimp_GetMainContext( void **context, void **surface )
 		*context = glw_state.context;
 	if( surface )
 		*surface = glw_state.surface;
+}
+
+/*
+** GLimp_GetWindowSurface
+*/
+void *GLimp_GetWindowSurface( bool *renderable )
+{
+	if( renderable )
+		*renderable = ( glw_state.surface != EGL_NO_SURFACE );
+	return ( glw_state.surface != EGL_NO_SURFACE ? glw_state.surface : glw_state.noWindowPbuffer );
+}
+
+/*
+** GLimp_UpdatePendingWindowSurface
+*/
+void GLimp_UpdatePendingWindowSurface( void )
+{
+	ri.Mutex_Lock( glw_state.windowMutex );
+
+	if( glw_state.windowChanged )
+	{
+		glw_state.windowChanged = false;
+		GLimp_Android_UpdateWindowSurface();
+	}
+
+	ri.Mutex_Unlock( glw_state.windowMutex );
 }
 
 /*
@@ -436,24 +536,28 @@ bool GLimp_MakeCurrent( void *context, void *surface )
 */
 bool GLimp_SharedContext_Create( void **context, void **surface )
 {
-	const int pbufferAttribs[] = { EGL_WIDTH, 1, EGL_HEIGHT, 1, EGL_NONE };
 	const int contextAttribs[] = { EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE };
-	EGLSurface pbuffer;
+	EGLSurface pbuffer = EGL_NO_SURFACE;
 	EGLContext ctx;
 
-	pbuffer = qeglCreatePbufferSurface( glw_state.display, glw_state.config, pbufferAttribs );
-	if( pbuffer == EGL_NO_SURFACE )
-		return false;
+	if( surface )
+	{
+		pbuffer = GLimp_Android_CreatePbufferSurface();
+		if( pbuffer == EGL_NO_SURFACE )
+			return false;
+	}
 
 	ctx = qeglCreateContext( glw_state.display, glw_state.config, glw_state.context, contextAttribs );
 	if( !ctx )
 	{
-		qeglDestroySurface( glw_state.display, pbuffer );
+		if( pbuffer != EGL_NO_SURFACE )
+			qeglDestroySurface( glw_state.display, pbuffer );
 		return false;
 	}
 
 	*context = ctx;
-	*surface = pbuffer;
+	if( surface )
+		*surface = pbuffer;
 	return true;
 }
 
@@ -463,5 +567,6 @@ bool GLimp_SharedContext_Create( void **context, void **surface )
 void GLimp_SharedContext_Destroy( void *context, void *surface )
 {
 	qeglDestroyContext( glw_state.display, context );
-	qeglDestroySurface( glw_state.display, surface );
+	if( surface )
+		qeglDestroySurface( glw_state.display, surface );
 }

--- a/source/android/android_glw.c
+++ b/source/android/android_glw.c
@@ -467,17 +467,6 @@ void GLimp_EnableMultithreadedRendering( bool enable )
 }
 
 /*
-** GLimp_GetMainContext
-*/
-void GLimp_GetMainContext( void **context, void **surface )
-{
-	if( context )
-		*context = glw_state.context;
-	if( surface )
-		*surface = glw_state.surface;
-}
-
-/*
 ** GLimp_GetWindowSurface
 */
 void *GLimp_GetWindowSurface( bool *renderable )

--- a/source/android/android_glw.h
+++ b/source/android/android_glw.h
@@ -42,6 +42,7 @@ typedef struct
 
 	// Window surface and fake minimized surface - used on the thread that is currently rendering
 	EGLSurface surface;
+	int swapInterval;
 	EGLSurface noWindowPbuffer;
 
 	// Window replacement in the rendering thread

--- a/source/android/android_glw.h
+++ b/source/android/android_glw.h
@@ -46,7 +46,7 @@ typedef struct
 
 	// Window replacement in the rendering thread
 	struct qmutex_s *windowMutex;
-	ANativeWindow *window;
+	ANativeWindow *window; // Only main can change
 	bool windowChanged;
 
 	void *EGLLib, *OpenGLLib;

--- a/source/android/android_glw.h
+++ b/source/android/android_glw.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2014 SiPlus, Chasseur de bots
+Copyright (C) 2016 SiPlus, Warsow Development Team
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -30,16 +30,24 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 typedef struct
 {
-	ANativeWindow *window;
-
 	EGLDisplay display;
 	EGLConfig config;
 	int format;
-	EGLSurface surface;
-	EGLSurface pbufferSurface;
-	EGLContext context;
 
-	int swapInterval;
+	bool multithreadedRendering;
+
+	EGLContext context; // Main thread context
+
+	EGLSurface mainThreadPbuffer; // Bound to the main thread when the rendering thread is active
+
+	// Window surface and fake minimized surface - used on the thread that is currently rendering
+	EGLSurface surface;
+	EGLSurface noWindowPbuffer;
+
+	// Window replacement in the rendering thread
+	struct qmutex_s *windowMutex;
+	ANativeWindow *window;
+	bool windowChanged;
 
 	void *EGLLib, *OpenGLLib;
 } glwstate_t;

--- a/source/android/android_glw.h
+++ b/source/android/android_glw.h
@@ -45,7 +45,7 @@ typedef struct
 	EGLSurface noWindowPbuffer;
 
 	// Window replacement in the rendering thread
-	struct qmutex_s *windowMutex;
+	qmutex_t *windowMutex;
 	ANativeWindow *window; // Only main can change
 	bool windowChanged;
 

--- a/source/client/cl_screen.c
+++ b/source/client/cl_screen.c
@@ -690,7 +690,7 @@ void SCR_UpdateScreen( void )
 		return;
 	}
 
-	if( !scr_initialized || !con_initialized || !cls.mediaInitialized || !re.ScreenEnabled() )
+	if( !scr_initialized || !con_initialized || !cls.mediaInitialized || !re.RenderingEnabled() )
 		return;     // not ready yet
 
 	Con_CheckResize();

--- a/source/ref_gl/qgl.h
+++ b/source/ref_gl/qgl.h
@@ -602,6 +602,7 @@ QGL_EGL(EGLSurface, eglCreateWindowSurface, (EGLDisplay dpy, EGLConfig config, E
 QGL_EGL(EGLBoolean, eglDestroyContext, (EGLDisplay dpy, EGLContext ctx));
 QGL_EGL(EGLBoolean, eglDestroySurface, (EGLDisplay dpy, EGLSurface surface));
 QGL_EGL(EGLBoolean, eglGetConfigAttrib, (EGLDisplay dpy, EGLConfig config, EGLint attribute, EGLint *value));
+QGL_EGL(EGLContext, eglGetCurrentContext, (void));
 QGL_EGL(EGLDisplay, eglGetCurrentDisplay, (void));
 QGL_EGL(EGLDisplay, eglGetDisplay, (EGLNativeDisplayType display_id));
 QGL_EGL(EGLint, eglGetError, (void));

--- a/source/ref_gl/qgl.h
+++ b/source/ref_gl/qgl.h
@@ -467,17 +467,6 @@ typedef unsigned short GLhalfARB;
 #endif
 #endif /* GL_ARB_half_float_vertex */
 
-/* GL_EXT_multiview_draw_buffers */
-#ifndef GL_EXT_multiview_draw_buffers
-#define GL_EXT_multiview_draw_buffers
-
-#define GL_COLOR_ATTACHMENT_EXT								0x90F0
-#define GL_MULTIVIEW_EXT									0x90F1
-#define GL_DRAW_BUFFER_EXT									0x0C01
-#define GL_READ_BUFFER_EXT									0x0C02
-#define GL_MAX_MULTIVIEW_BUFFERS_EXT						0x90F2
-#endif /* GL_EXT_multiview_draw_buffers */
-
 /* GL_ARB_get_program_binary */
 #ifndef GL_ARB_get_program_binary
 #define GL_PROGRAM_BINARY_RETRIEVABLE_HINT					0x8257
@@ -551,13 +540,6 @@ typedef unsigned short GLhalfARB;
 #define GL_TEXTURE_MAX_LOD_SGIS								0x813B
 #define GL_TEXTURE_BASE_LEVEL_SGIS							0x813C
 #define GL_TEXTURE_MAX_LEVEL_SGIS							0x813D
-#endif
-
-/* EGL_EXT_multiview_window */
-#ifndef EGL_EXT_multiview_window
-#define EGL_EXT_multiview_window
-
-#define EGL_MULTIVIEW_VIEW_COUNT_EXT						0x3134
 #endif
 
 #endif // QGL_H

--- a/source/ref_gl/r_cmdque.c
+++ b/source/ref_gl/r_cmdque.c
@@ -488,6 +488,7 @@ void RF_IssueSyncCmd( ref_cmdbuf_t *frame )
 
 static unsigned R_HandleInitReliableCmd( void *pcmd );
 static unsigned R_HandleShutdownReliableCmd( void *pcmd );
+static unsigned R_HandleSurfaceChangeReliableCmd( void *pcmd );
 static unsigned R_HandleScreenShotReliableCmd( void *pcmd );
 static unsigned R_HandleEnvShotReliableCmd( void *pcmd );
 
@@ -495,6 +496,7 @@ refReliableCmdHandler_t refReliableCmdHandlers[NUM_REF_RELIABLE_CMDS] =
 {
 	(refReliableCmdHandler_t)R_HandleInitReliableCmd,
     (refReliableCmdHandler_t)R_HandleShutdownReliableCmd,
+    (refReliableCmdHandler_t)R_HandleSurfaceChangeReliableCmd,
     (refReliableCmdHandler_t)R_HandleScreenShotReliableCmd,
 	(refReliableCmdHandler_t)R_HandleEnvShotReliableCmd,
 };
@@ -515,6 +517,15 @@ static unsigned R_HandleShutdownReliableCmd( void *pcmd )
 	refReliableCmdInitShutdown_t *cmd = pcmd;
 
 	RB_Shutdown();
+
+	return sizeof( *cmd );
+}
+
+static unsigned R_HandleSurfaceChangeReliableCmd( void *pcmd )
+{
+	refReliableCmdSurfaceChange_t *cmd = pcmd;
+
+	RF_UpdateBackendSurface();
 
 	return sizeof( *cmd );
 }
@@ -548,6 +559,12 @@ void RF_IssueInitReliableCmd( qbufPipe_t *pipe )
 void RF_IssueShutdownReliableCmd( qbufPipe_t *pipe )
 {
 	refReliableCmdInitShutdown_t cmd = { REF_RELIABLE_CMD_SHUTDOWN };
+	ri.BufPipe_WriteCmd( pipe, &cmd, sizeof( cmd ) );
+}
+
+void RF_IssueSurfaceChangeReliableCmd( qbufPipe_t *pipe )
+{
+	refReliableCmdSurfaceChange_t cmd = { REF_RELIABLE_CMD_SURFACE_CHANGE };
 	ri.BufPipe_WriteCmd( pipe, &cmd, sizeof( cmd ) );
 }
 

--- a/source/ref_gl/r_cmdque.c
+++ b/source/ref_gl/r_cmdque.c
@@ -243,6 +243,7 @@ static void RF_IssueDrawStretchPolyOrAddPolyToSceneCmd( ref_cmdbuf_t *frame, int
         cmd_len += numverts * sizeof( byte_vec4_t );
     if( poly->elems )
         cmd_len += poly->numelems * sizeof( elem_t );
+	cmd_len = ALIGN( cmd_len, sizeof( float ) );
     
     cmd.length = cmd_len;
     
@@ -402,7 +403,7 @@ void RF_IssueRenderSceneCmd( ref_cmdbuf_t *frame, const refdef_t *fd )
 #ifdef AREAPORTALS_MATRIX
         areabytes *= rsh.worldBrushModel->numareas;
 #endif
-        cmd_len += areabytes;
+		cmd_len = ALIGN( cmd_len + areabytes, sizeof( float ) );
     }
     
     cmd.length = cmd_len;

--- a/source/ref_gl/r_cmdque.c
+++ b/source/ref_gl/r_cmdque.c
@@ -526,7 +526,7 @@ static unsigned R_HandleSurfaceChangeReliableCmd( void *pcmd )
 {
 	refReliableCmdSurfaceChange_t *cmd = pcmd;
 
-	RF_UpdateBackendSurface();
+	GLimp_UpdatePendingWindowSurface();
 
 	return sizeof( *cmd );
 }

--- a/source/ref_gl/r_cmdque.h
+++ b/source/ref_gl/r_cmdque.h
@@ -166,6 +166,7 @@ enum
 {
 	REF_RELIABLE_CMD_INIT,
 	REF_RELIABLE_CMD_SHUTDOWN,
+	REF_RELIABLE_CMD_SURFACE_CHANGE,
     REF_RELIABLE_CMD_SCREEN_SHOT,
     REF_RELIABLE_CMD_ENV_SHOT,
 
@@ -182,6 +183,11 @@ typedef struct
 
 typedef struct
 {
+	int				id;
+} refReliableCmdSurfaceChange_t;
+
+typedef struct
+{
     int             id;
     unsigned        pixels;
     bool            silent;
@@ -191,6 +197,7 @@ typedef struct
 
 void RF_IssueInitReliableCmd( qbufPipe_t *pipe );
 void RF_IssueShutdownReliableCmd( qbufPipe_t *pipe );
+void RF_IssueSurfaceChangeReliableCmd( qbufPipe_t *pipe );
 void RF_IssueScreenShotReliableCmd( qbufPipe_t *pipe, const char *path, const char *name, bool silent );
 void RF_IssueEnvShotReliableCmd( qbufPipe_t *pipe, const char *path, const char *name, unsigned pixels );
 

--- a/source/ref_gl/r_cmds.c
+++ b/source/ref_gl/r_cmds.c
@@ -33,7 +33,7 @@ void R_TakeScreenShot( const char *path, const char *name, bool silent )
     size_t checkname_size = 0;
     int quality;
     
-    if( !RF_RenderingEnabled() )
+    if( !R_IsRenderingToScreen() )
         return;
     
     if( r_screenshot_jpeg->integer ) {
@@ -159,9 +159,6 @@ void R_ScreenShot_f( void )
 	size_t path_size;
 	char *path;
 
-    if( !R_RenderingEnabled() )
-		return;
-
 	name = ri.Cmd_Argv( 1 );
 
 	mediadir = ri.FS_MediaDirectory( FS_MEDIA_IMAGES );
@@ -203,7 +200,7 @@ void R_TakeEnvShot( const char *path, const char *name, unsigned maxPixels )
         { "nz", { 90, 180, 0 }, IT_FLIPDIAGONAL }
     };
     
-    if( !RF_RenderingEnabled() || !rsh.worldModel )
+    if( !R_IsRenderingToScreen() || !rsh.worldModel )
         return;
     
     maxSize = min( min( glConfig.width, glConfig.height ), glConfig.maxTextureSize );
@@ -263,7 +260,7 @@ void R_EnvShot_f( void )
 	int path_size;
 	char *path;
 
-	if( !RF_RenderingEnabled() || !rsh.worldModel )
+	if( !rsh.worldModel )
 		return;
 
 	if( ri.Cmd_Argc() != 3 )

--- a/source/ref_gl/r_cmds.c
+++ b/source/ref_gl/r_cmds.c
@@ -33,7 +33,7 @@ void R_TakeScreenShot( const char *path, const char *name, bool silent )
     size_t checkname_size = 0;
     int quality;
     
-    if( !R_ScreenEnabled() )
+    if( !R_RenderingEnabled() )
         return;
     
     if( r_screenshot_jpeg->integer ) {
@@ -159,7 +159,7 @@ void R_ScreenShot_f( void )
 	size_t path_size;
 	char *path;
 
-    if( !R_ScreenEnabled() )
+    if( !R_RenderingEnabled() )
 		return;
 
 	name = ri.Cmd_Argv( 1 );
@@ -203,7 +203,7 @@ void R_TakeEnvShot( const char *path, const char *name, unsigned maxPixels )
         { "nz", { 90, 180, 0 }, IT_FLIPDIAGONAL }
     };
     
-    if( !R_ScreenEnabled() || !rsh.worldModel )
+    if( !R_RenderingEnabled() || !rsh.worldModel )
         return;
     
     maxSize = min( min( glConfig.width, glConfig.height ), glConfig.maxTextureSize );
@@ -263,7 +263,7 @@ void R_EnvShot_f( void )
 	int path_size;
 	char *path;
 
-	if( !R_ScreenEnabled() || !rsh.worldModel )
+	if( !R_RenderingEnabled() || !rsh.worldModel )
 		return;
 
 	if( ri.Cmd_Argc() != 3 )

--- a/source/ref_gl/r_cmds.c
+++ b/source/ref_gl/r_cmds.c
@@ -33,7 +33,7 @@ void R_TakeScreenShot( const char *path, const char *name, bool silent )
     size_t checkname_size = 0;
     int quality;
     
-    if( !R_RenderingEnabled() )
+    if( !RF_RenderingEnabled() )
         return;
     
     if( r_screenshot_jpeg->integer ) {
@@ -203,7 +203,7 @@ void R_TakeEnvShot( const char *path, const char *name, unsigned maxPixels )
         { "nz", { 90, 180, 0 }, IT_FLIPDIAGONAL }
     };
     
-    if( !R_RenderingEnabled() || !rsh.worldModel )
+    if( !RF_RenderingEnabled() || !rsh.worldModel )
         return;
     
     maxSize = min( min( glConfig.width, glConfig.height ), glConfig.maxTextureSize );
@@ -263,7 +263,7 @@ void R_EnvShot_f( void )
 	int path_size;
 	char *path;
 
-	if( !R_RenderingEnabled() || !rsh.worldModel )
+	if( !RF_RenderingEnabled() || !rsh.worldModel )
 		return;
 
 	if( ri.Cmd_Argc() != 3 )

--- a/source/ref_gl/r_frontend.c
+++ b/source/ref_gl/r_frontend.c
@@ -108,10 +108,7 @@ static void RF_BackendFrame( void )
 */
 static void *RF_BackendThreadProc( void *param )
 {
-	void *surface;
-
-	surface = GLimp_GetWindowSurface( NULL );
-	GLimp_MakeCurrent( rrf.auxGLContext, surface );
+	GLimp_MakeCurrent( rrf.auxGLContext, GLimp_GetWindowSurface( NULL ) );
 
     while( !rrf.shutdown ) {
         RF_BackendFrame();
@@ -462,9 +459,11 @@ void RF_EnvShot( const char *path, const char *name, unsigned pixels )
     RF_IssueEnvShotReliableCmd( rrf.cmdPipe, path, name, pixels );
 }
 
-bool RF_ScreenEnabled( void )
+bool RF_RenderingEnabled( void )
 {
-    return GLimp_RenderingEnabled();
+	bool surfaceRenderable = true;
+	GLimp_GetWindowSurface( &surfaceRenderable );
+	return surfaceRenderable;
 }
 
 const char *RF_SpeedsMessage( char *out, size_t size )

--- a/source/ref_gl/r_frontend.c
+++ b/source/ref_gl/r_frontend.c
@@ -270,11 +270,6 @@ void RF_SurfaceChangePending( void )
 	RF_IssueSurfaceChangeReliableCmd( rrf.cmdPipe );
 }
 
-void RF_UpdateBackendSurface( void )
-{
-	GLimp_UpdatePendingWindowSurface();
-}
-
 static void RF_FrameSync( void )
 {
     if( rrf.frameSync ) {

--- a/source/ref_gl/r_frontend.c
+++ b/source/ref_gl/r_frontend.c
@@ -451,19 +451,19 @@ void RF_SetCustomColor( int num, int r, int g, int b )
 
 void RF_ScreenShot( const char *path, const char *name, bool silent )
 {
-    RF_IssueScreenShotReliableCmd( rrf.cmdPipe, path, name, silent );
+	if( RF_RenderingEnabled() )
+		RF_IssueScreenShotReliableCmd( rrf.cmdPipe, path, name, silent );
 }
 
 void RF_EnvShot( const char *path, const char *name, unsigned pixels )
 {
-    RF_IssueEnvShotReliableCmd( rrf.cmdPipe, path, name, pixels );
+	if( RF_RenderingEnabled() )
+		RF_IssueEnvShotReliableCmd( rrf.cmdPipe, path, name, pixels );
 }
 
 bool RF_RenderingEnabled( void )
 {
-	bool surfaceRenderable = true;
-	GLimp_GetWindowSurface( &surfaceRenderable );
-	return surfaceRenderable;
+	return GLimp_RenderingEnabled();
 }
 
 const char *RF_SpeedsMessage( char *out, size_t size )

--- a/source/ref_gl/r_frontend.c
+++ b/source/ref_gl/r_frontend.c
@@ -464,7 +464,7 @@ void RF_EnvShot( const char *path, const char *name, unsigned pixels )
 
 bool RF_ScreenEnabled( void )
 {
-    return GLimp_ScreenEnabled();
+    return GLimp_RenderingEnabled();
 }
 
 const char *RF_SpeedsMessage( char *out, size_t size )

--- a/source/ref_gl/r_frontend.c
+++ b/source/ref_gl/r_frontend.c
@@ -244,18 +244,6 @@ void RF_SurfaceChangePending( void )
 	RF_IssueSurfaceChangeReliableCmd( rrf.cmdPipe );
 }
 
-static void RF_FrameSync( void )
-{
-    if( rrf.frameSync ) {
-        if( glConfig.multithreading ) {
-            // synchronize data we might have uploaded this frame between the threads
-            // FIXME: only call this when absolutely necessary
-            R_Finish();
-        }
-        rrf.frameSync = false;
-    }
-}
-
 void RF_BeginFrame( float cameraSeparation, bool forceClear, bool forceVsync )
 {
 	// take the frame the backend is not busy processing

--- a/source/ref_gl/r_glimp.h
+++ b/source/ref_gl/r_glimp.h
@@ -271,7 +271,6 @@ bool	GLimp_GetGammaRamp( size_t stride, unsigned short *psize, unsigned short *r
 void	GLimp_SetGammaRamp( size_t stride, unsigned short   size, unsigned short *ramp );
 void	GLimp_SetSwapInterval( int swapInterval );
 
-void	GLimp_GetMainContext( void **context, void **surface );
 bool	GLimp_MakeCurrent( void *context, void *surface );
 
 void	GLimp_EnableMultithreadedRendering( bool enable );

--- a/source/ref_gl/r_glimp.h
+++ b/source/ref_gl/r_glimp.h
@@ -265,7 +265,7 @@ int		GLimp_Init( const char *applicationName, void *hinstance, void *wndproc, vo
 			int iconResource, const int *iconXPM );
 void	GLimp_Shutdown( void );
 rserr_t	GLimp_SetMode( int x, int y, int width, int height, int displayFrequency, bool fullscreen, bool stereo );
-rserr_t	GLimp_SetWindow( void *hinstance, void *wndproc, void *parenthWnd );
+rserr_t	GLimp_SetWindow( void *hinstance, void *wndproc, void *parenthWnd, bool *surfaceChangePending );
 rserr_t GLimp_SetFullscreenMode( int displayFrequency, bool fullscreen );
 void	GLimp_AppActivate( bool active, bool destroy );
 bool	GLimp_GetGammaRamp( size_t stride, unsigned short *psize, unsigned short *ramp );
@@ -274,6 +274,14 @@ void	GLimp_SetSwapInterval( int swapInterval );
 
 void	GLimp_GetMainContext( void **context, void **surface );
 bool	GLimp_MakeCurrent( void *context, void *surface );
+
+void	GLimp_EnableMultithreadedRendering( bool enable );
+// When multithreaded rendering is enabled, GetWindowSurface must be called from the rendering thread, not the main one.
+// The window surface may be managed by the rendering thread in this case, and the main thread may have a fake surface instead
+// if the context implementation doesn't support multiple contexts bound to the same surface.
+void	*GLimp_GetWindowSurface( bool *renderable );
+void	GLimp_UpdatePendingWindowSurface( void ); // Call from the rendering thread.
+
 bool	GLimp_SharedContext_Create( void **context, void **surface );
 void	GLimp_SharedContext_Destroy( void *context, void *surface );
 

--- a/source/ref_gl/r_glimp.h
+++ b/source/ref_gl/r_glimp.h
@@ -182,7 +182,6 @@ typedef struct
 				,framebuffer_blit
 				,depth24
 				,depth_nonlinear
-				,multiview_draw_buffers
 				,get_program_binary
 				,rgb8_rgba8
 				,ES3_compatibility

--- a/source/ref_gl/r_glimp.h
+++ b/source/ref_gl/r_glimp.h
@@ -257,7 +257,7 @@ IMPLEMENTATION SPECIFIC FUNCTIONS
 ====================================================================
 */
 
-bool	GLimp_ScreenEnabled( void );
+bool	GLimp_RenderingEnabled( void );
 void	GLimp_BeginFrame( void );
 void	GLimp_EndFrame( void );
 int		GLimp_Init( const char *applicationName, void *hinstance, void *wndproc, void *parenthWnd, 

--- a/source/ref_gl/r_image.c
+++ b/source/ref_gl/r_image.c
@@ -2073,7 +2073,7 @@ void R_ScreenShot( const char *filename, int x, int y, int width, int height, in
 	r_imginfo_t imginfo;
 	const char *extension;
 
-	if( !R_RenderingEnabled() )
+	if( !RF_RenderingEnabled() )
 		return;
 
 	extension = COM_FileExtension( filename );

--- a/source/ref_gl/r_image.c
+++ b/source/ref_gl/r_image.c
@@ -2073,7 +2073,7 @@ void R_ScreenShot( const char *filename, int x, int y, int width, int height, in
 	r_imginfo_t imginfo;
 	const char *extension;
 
-	if( !R_ScreenEnabled() )
+	if( !R_RenderingEnabled() )
 		return;
 
 	extension = COM_FileExtension( filename );

--- a/source/ref_gl/r_image.c
+++ b/source/ref_gl/r_image.c
@@ -2083,7 +2083,7 @@ void R_ScreenShot( const char *filename, int x, int y, int width, int height, in
 	r_imginfo_t imginfo;
 	const char *extension;
 
-	if( !RF_RenderingEnabled() )
+	if( !R_IsRenderingToScreen() )
 		return;
 
 	extension = COM_FileExtension( filename );

--- a/source/ref_gl/r_local.h
+++ b/source/ref_gl/r_local.h
@@ -623,7 +623,7 @@ void		R_FreeFile_( void *buffer, const char *filename, int fileline );
 #define		R_LoadCacheFile(path,buffer) R_LoadFile_(path,FS_CACHE,buffer,__FILE__,__LINE__)
 #define		R_FreeFile(buffer) R_FreeFile_(buffer,__FILE__,__LINE__)
 
-bool		R_RenderingEnabled( void );
+bool		R_IsRenderingToScreen( void );
 void		R_BeginFrame( float cameraSeparation, bool forceClear, bool forceVsync );
 void		R_EndFrame( void );
 void		R_Set2DMode( bool enable );

--- a/source/ref_gl/r_local.h
+++ b/source/ref_gl/r_local.h
@@ -383,7 +383,7 @@ void RF_ResetScissor( void );
 void RF_SetCustomColor( int num, int r, int g, int b );
 void RF_ScreenShot( const char *path, const char *name, bool silent );
 void RF_EnvShot( const char *path, const char *name, unsigned pixels );
-bool RF_ScreenEnabled( void );
+bool RF_RenderingEnabled( void );
 const char *RF_SpeedsMessage( char *out, size_t size );
 void RF_ReplaceRawSubPic( shader_t *shader, int x, int y, int width, int height, uint8_t *data );
 

--- a/source/ref_gl/r_local.h
+++ b/source/ref_gl/r_local.h
@@ -625,6 +625,7 @@ void		R_FreeFile_( void *buffer, const char *filename, int fileline );
 bool		R_IsRenderingToScreen( void );
 void		R_BeginFrame( float cameraSeparation, bool forceClear, bool forceVsync );
 void		R_EndFrame( void );
+void		R_SetSwapInterval( int swapInterval, bool force );
 void		R_Set2DMode( bool enable );
 void		R_RenderView( const refdef_t *fd );
 void		R_AppActivate( bool active, bool destroy );

--- a/source/ref_gl/r_local.h
+++ b/source/ref_gl/r_local.h
@@ -341,11 +341,7 @@ typedef struct
 	ref_cmdbuf_t	frames[3];			// triple-buffered
 	ref_cmdbuf_t	*frame;             // current frontend frame
 
-	void            *mainGLContext;
-    void            *mainGLSurface;
-
     void            *auxGLContext;
-    void            *auxGLSurface;
     
     qthread_t       *backendThread;
 	struct qmutex_s *backendFrameLock;
@@ -358,6 +354,8 @@ rserr_t RF_Init( const char *applicationName, const char *screenshotPrefix, int 
 	int iconResource, const int *iconXPM, void *hinstance, void *wndproc, void *parenthWnd,  bool verbose );
 rserr_t RF_SetMode( int x, int y, int width, int height, int displayFrequency, bool fullScreen, bool stereo );
 void RF_Shutdown( bool verbose );
+void RF_SurfaceChangePending( void );
+void RF_UpdateBackendSurface( void );
 void RF_BeginFrame( float cameraSeparation, bool forceClear, bool forceVsync );
 void RF_EndFrame( void );
 void RF_BeginRegistration( void );

--- a/source/ref_gl/r_local.h
+++ b/source/ref_gl/r_local.h
@@ -355,7 +355,6 @@ rserr_t RF_Init( const char *applicationName, const char *screenshotPrefix, int 
 rserr_t RF_SetMode( int x, int y, int width, int height, int displayFrequency, bool fullScreen, bool stereo );
 void RF_Shutdown( bool verbose );
 void RF_SurfaceChangePending( void );
-void RF_UpdateBackendSurface( void );
 void RF_BeginFrame( float cameraSeparation, bool forceClear, bool forceVsync );
 void RF_EndFrame( void );
 void RF_BeginRegistration( void );

--- a/source/ref_gl/r_local.h
+++ b/source/ref_gl/r_local.h
@@ -623,7 +623,7 @@ void		R_FreeFile_( void *buffer, const char *filename, int fileline );
 #define		R_LoadCacheFile(path,buffer) R_LoadFile_(path,FS_CACHE,buffer,__FILE__,__LINE__)
 #define		R_FreeFile(buffer) R_FreeFile_(buffer,__FILE__,__LINE__)
 
-bool		R_ScreenEnabled( void );
+bool		R_RenderingEnabled( void );
 void		R_BeginFrame( float cameraSeparation, bool forceClear, bool forceVsync );
 void		R_EndFrame( void );
 void		R_Set2DMode( bool enable );

--- a/source/ref_gl/r_main.c
+++ b/source/ref_gl/r_main.c
@@ -1442,11 +1442,13 @@ static void R_UpdateHWGamma( void )
 }
 
 /*
-* R_RenderingEnabled
+* R_IsRenderingToScreen
 */
-bool R_RenderingEnabled( void )
+bool R_IsRenderingToScreen( void )
 {
-	return GLimp_RenderingEnabled();
+	bool surfaceRenderable = true;
+	GLimp_GetWindowSurface( &surfaceRenderable );
+	return surfaceRenderable;
 }
 
 /*
@@ -1557,7 +1559,7 @@ void R_BeginFrame( float cameraSeparation, bool forceClear, bool forceVsync )
 	RB_BeginFrame();
 
 #ifndef GL_ES_VERSION_2_0
-	if( cameraSeparation && !glConfig.stereoEnabled || !RF_RenderingEnabled() )
+	if( cameraSeparation && !glConfig.stereoEnabled || !R_IsRenderingToScreen() )
 		cameraSeparation = 0;
 	}
 
@@ -1716,7 +1718,7 @@ void R_WriteAviFrame( int frame, bool scissor )
 	char *checkname;
 	const char *extension;
 
-	if( !RF_RenderingEnabled() )
+	if( !R_IsRenderingToScreen() )
 		return;
 
 	if( scissor )

--- a/source/ref_gl/r_main.c
+++ b/source/ref_gl/r_main.c
@@ -1442,11 +1442,11 @@ static void R_UpdateHWGamma( void )
 }
 
 /*
-* R_ScreenDisabled
+* R_RenderingEnabled
 */
-bool R_ScreenEnabled( void )
+bool R_RenderingEnabled( void )
 {
-	return GLimp_ScreenEnabled();
+	return GLimp_RenderingEnabled();
 }
 
 /*
@@ -1557,7 +1557,7 @@ void R_BeginFrame( float cameraSeparation, bool forceClear, bool forceVsync )
 	RB_BeginFrame();
 
 #ifndef GL_ES_VERSION_2_0
-	if( !glConfig.stereoEnabled || !R_ScreenEnabled() )
+	if( !glConfig.stereoEnabled || !R_RenderingEnabled() )
 		cameraSeparation = 0;
 
 	if( rf.cameraSeparation != cameraSeparation )
@@ -1715,7 +1715,7 @@ void R_WriteAviFrame( int frame, bool scissor )
 	char *checkname;
 	const char *extension;
 
-	if( !R_ScreenEnabled() )
+	if( !R_RenderingEnabled() )
 		return;
 
 	if( scissor )

--- a/source/ref_gl/r_main.c
+++ b/source/ref_gl/r_main.c
@@ -1557,12 +1557,8 @@ void R_BeginFrame( float cameraSeparation, bool forceClear, bool forceVsync )
 	RB_BeginFrame();
 
 #ifndef GL_ES_VERSION_2_0
-	if( cameraSeparation )
-	{
-		bool surfaceRenderable = true;
-		GLimp_GetWindowSurface( &surfaceRenderable );
-		if( !glConfig.stereoEnabled || !surfaceRenderable )
-			cameraSeparation = 0;
+	if( cameraSeparation && !glConfig.stereoEnabled || !RF_RenderingEnabled() )
+		cameraSeparation = 0;
 	}
 
 	if( rf.cameraSeparation != cameraSeparation )
@@ -1720,7 +1716,7 @@ void R_WriteAviFrame( int frame, bool scissor )
 	char *checkname;
 	const char *extension;
 
-	if( !R_RenderingEnabled() )
+	if( !RF_RenderingEnabled() )
 		return;
 
 	if( scissor )

--- a/source/ref_gl/r_main.c
+++ b/source/ref_gl/r_main.c
@@ -1556,28 +1556,21 @@ void R_BeginFrame( float cameraSeparation, bool forceClear, bool forceVsync )
 
 	RB_BeginFrame();
 
+#ifndef GL_ES_VERSION_2_0
 	if( !glConfig.stereoEnabled || !R_ScreenEnabled() )
 		cameraSeparation = 0;
 
 	if( rf.cameraSeparation != cameraSeparation )
 	{
 		rf.cameraSeparation = cameraSeparation;
-#ifdef GL_ES_VERSION_2_0
-		if( glConfig.ext.multiview_draw_buffers )
-		{
-			int location = GL_MULTIVIEW_EXT;
-			int index = ( cameraSeparation > 0 ) ? 1 : 0;
-			qglDrawBuffersIndexedEXT( 1, &location, &index );
-		}
-#else
 		if( cameraSeparation < 0 )
 			qglDrawBuffer( GL_BACK_LEFT );
 		else if( cameraSeparation > 0 )
 			qglDrawBuffer( GL_BACK_RIGHT );
 		else
 			qglDrawBuffer( GL_BACK );
-#endif
 	}
+#endif
 
 	// update gamma
 	if( r_gamma->modified )

--- a/source/ref_gl/r_main.c
+++ b/source/ref_gl/r_main.c
@@ -1404,13 +1404,17 @@ void R_FrameSync( void )
 }
 
 /*
-* R_SwapInterval
+* R_SetSwapInterval
 */
-static void R_SwapInterval( int swapInterval )
+void R_SetSwapInterval( int swapInterval, bool force )
 {
-	static int currentSwapInterval = 0;
+	static int currentSwapInterval = -1;
 
-	if( ( swapInterval != currentSwapInterval ) && !r_swapinterval_min->integer && !glConfig.stereoEnabled )
+	if( glConfig.stereoEnabled )
+		return;
+
+	clamp_low( swapInterval, r_swapinterval_min->integer );
+	if( force || swapInterval != currentSwapInterval )
 	{
 		GLimp_SetSwapInterval( swapInterval );
 		currentSwapInterval = swapInterval;
@@ -1645,7 +1649,7 @@ void R_BeginFrame( float cameraSeparation, bool forceClear, bool forceVsync )
 	}
 
 	// set swap interval (vertical synchronization)
-	R_SwapInterval( ( r_swapinterval->integer || forceVsync ) ? 1 : 0 );
+	R_SetSwapInterval( ( r_swapinterval->integer || forceVsync ) ? 1 : 0, false );
 
 	memset( &rf.stats, 0, sizeof( rf.stats ) );
 

--- a/source/ref_gl/r_main.c
+++ b/source/ref_gl/r_main.c
@@ -1557,8 +1557,13 @@ void R_BeginFrame( float cameraSeparation, bool forceClear, bool forceVsync )
 	RB_BeginFrame();
 
 #ifndef GL_ES_VERSION_2_0
-	if( !glConfig.stereoEnabled || !R_RenderingEnabled() )
-		cameraSeparation = 0;
+	if( cameraSeparation )
+	{
+		bool surfaceRenderable = true;
+		GLimp_GetWindowSurface( &surfaceRenderable );
+		if( !glConfig.stereoEnabled || !surfaceRenderable )
+			cameraSeparation = 0;
+	}
 
 	if( rf.cameraSeparation != cameraSeparation )
 	{

--- a/source/ref_gl/r_public.c
+++ b/source/ref_gl/r_public.c
@@ -107,7 +107,7 @@ QF_DLL_EXPORT ref_export_t *GetRefAPI( ref_import_t *import )
 
 	globals.TransformVectorToScreen = R_TransformVectorToScreen;
 
-	globals.RenderingEnabled = R_RenderingEnabled;
+	globals.RenderingEnabled = RF_RenderingEnabled;
 
 	globals.SpeedsMessage = RF_SpeedsMessage;
 

--- a/source/ref_gl/r_public.c
+++ b/source/ref_gl/r_public.c
@@ -107,7 +107,8 @@ QF_DLL_EXPORT ref_export_t *GetRefAPI( ref_import_t *import )
 
 	globals.TransformVectorToScreen = R_TransformVectorToScreen;
 
-	globals.ScreenEnabled = RF_ScreenEnabled;
+	globals.RenderingEnabled = R_RenderingEnabled;
+
 	globals.SpeedsMessage = RF_SpeedsMessage;
 
 	globals.BeginAviDemo = R_BeginAviDemo;

--- a/source/ref_gl/r_public.h
+++ b/source/ref_gl/r_public.h
@@ -210,7 +210,9 @@ typedef struct
 
 	void		( *TransformVectorToScreen )( const refdef_t *rd, const vec3_t in, vec2_t out );
 
-	bool		( *ScreenEnabled )( void );
+	// Should only be used as a hint - the renderer may keep drawing or not drawing to the window for a few frames when this changes
+	bool		( *RenderingEnabled )( void );
+
 	void		( *BeginFrame )( float cameraSeparation, bool forceClear, bool forceVsync );
 	void		( *EndFrame )( void );
 	const char *( *SpeedsMessage )( char *out, size_t size );

--- a/source/ref_gl/r_register.c
+++ b/source/ref_gl/r_register.c
@@ -1347,8 +1347,7 @@ static rserr_t R_PostInit( void )
 		return rserr_unknown;
 	}
 
-	// make sure vsync is disabled by default if possible - it is assumed by R_SwapInterval
-	GLimp_SetSwapInterval( r_swapinterval_min->integer );
+	R_SetSwapInterval( 0, true ); // initialize and flush swap interval
 
 	R_FillStartupBackgroundColor( COLOR_R( glConfig.startupColor ) / 255.0f,
 		COLOR_G( glConfig.startupColor ) / 255.0f, COLOR_B( glConfig.startupColor ) / 255.0f );

--- a/source/ref_gl/r_register.c
+++ b/source/ref_gl/r_register.c
@@ -382,24 +382,6 @@ static const gl_extension_func_t gl_ext_get_program_binary_OES_funcs[] =
 	,GL_EXTENSION_FUNC_EXT(NULL,NULL)
 };
 
-/* GL_EXT_multiview_draw_buffers */
-static const gl_extension_func_t gl_ext_multiview_draw_buffers_EXT_funcs[] =
-{
-	 GL_EXTENSION_FUNC(ReadBufferIndexedEXT)
-	,GL_EXTENSION_FUNC(DrawBuffersIndexedEXT)
-
-	,GL_EXTENSION_FUNC_EXT(NULL,NULL)
-};
-
-/* GL_NV_multiview_draw_buffers */
-static const gl_extension_func_t gl_ext_multiview_draw_buffers_NV_funcs[] =
-{
-	 GL_EXTENSION_FUNC_EXT("glReadBufferIndexedNV",&qglReadBufferIndexedEXT)
-	,GL_EXTENSION_FUNC_EXT("glDrawBuffersIndexedNV",&qglDrawBuffersIndexedEXT)
-
-	,GL_EXTENSION_FUNC_EXT(NULL,NULL)
-};
-
 /* GL_OES_texture_3D */
 static const gl_extension_func_t gl_ext_texture_3D_OES_funcs[] =
 {
@@ -505,8 +487,6 @@ static const gl_extension_t gl_extensions_decl[] =
 	,GL_EXTENSION( OES, get_program_binary, false, false, &gl_ext_get_program_binary_OES_funcs )
 	,GL_EXTENSION( OES, depth24, false, false, NULL )
 	,GL_EXTENSION( NV, depth_nonlinear, false, false, NULL )
-	,GL_EXTENSION( EXT, multiview_draw_buffers, true, false, &gl_ext_multiview_draw_buffers_EXT_funcs )
-	,GL_EXTENSION( NV, multiview_draw_buffers, true, false, &gl_ext_multiview_draw_buffers_NV_funcs )
 	,GL_EXTENSION( OES, rgb8_rgba8, true, false, NULL )
 	,GL_EXTENSION( OES, texture_3D, false, false, &gl_ext_texture_3D_OES_funcs )
 	,GL_EXTENSION( EXT, texture_array, false, false, &gl_ext_texture_3D_OES_funcs )
@@ -872,17 +852,6 @@ static void R_FinalizeGLExtensions( void )
 	}
 #endif
 
-	/* GL_EXT_multiview_draw_buffers */
-#ifdef GL_ES_VERSION_2_0
-	if( glConfig.ext.multiview_draw_buffers )
-	{
-		val = 0;
-		qglGetIntegerv( GL_MAX_MULTIVIEW_BUFFERS_EXT, &val );
-		if( val <= 1 )
-			glConfig.stereoEnabled = false;
-	}
-#endif
-
 	/* GL_EXT_texture3D and GL_EXT_texture_array */
 	glConfig.maxTexture3DSize = 0;
 	glConfig.maxTextureLayers = 0;
@@ -1031,23 +1000,16 @@ static void R_FillStartupBackgroundColor( float r, float g, float b )
 {
 	qglClearColor( r, g, b, 1.0 );
 	GLimp_BeginFrame();
+#ifndef GL_ES_VERSION_2_0
 	if( glConfig.stereoEnabled )
 	{
-#ifdef GL_ES_VERSION_2_0
-		int location = GL_MULTIVIEW_EXT;
-		int index = 1;
-		qglDrawBuffersIndexedEXT( 1, &location, &index );
-		qglClear( GL_COLOR_BUFFER_BIT );
-		index = 0;
-		qglDrawBuffersIndexedEXT( 1, &location, &index );
-#else
 		qglDrawBuffer( GL_BACK_LEFT );
 		qglClear( GL_COLOR_BUFFER_BIT );
 		qglDrawBuffer( GL_BACK_RIGHT );
 		qglClear( GL_COLOR_BUFFER_BIT );
 		qglDrawBuffer( GL_BACK );
-#endif
 	}
+#endif
 	qglClear( GL_COLOR_BUFFER_BIT );
 	qglFinish();
 	GLimp_EndFrame();

--- a/source/ref_gl/r_register.c
+++ b/source/ref_gl/r_register.c
@@ -1456,7 +1456,15 @@ rserr_t R_SetMode( int x, int y, int width, int height, int displayFrequency, bo
 */
 rserr_t R_SetWindow( void *hinstance, void *wndproc, void *parenthWnd )
 {
-	return GLimp_SetWindow( hinstance, wndproc, parenthWnd );
+	rserr_t err;
+	bool surfaceChangePending = false;
+
+	err = GLimp_SetWindow( hinstance, wndproc, parenthWnd, &surfaceChangePending );
+
+	if( err == rserr_ok && surfaceChangePending )
+		RF_SurfaceChangePending();
+
+	return err;
 }
 
 /*

--- a/source/sdl/sdl_glw.c
+++ b/source/sdl/sdl_glw.c
@@ -269,8 +269,11 @@ void GLimp_AppActivate( bool active, bool destroy )
 /*
 ** GLimp_SetWindow
 */
-rserr_t GLimp_SetWindow( void *hinstance, void *wndproc, void *parenthWnd )
+rserr_t GLimp_SetWindow( void *hinstance, void *wndproc, void *parenthWnd, bool *surfaceChangePending )
 {
+	if( surfaceChangePending )
+		*surfaceChangePending = false;
+
 	return rserr_ok; // surface cannot be lost
 }
 

--- a/source/sdl/sdl_glw.c
+++ b/source/sdl/sdl_glw.c
@@ -294,17 +294,6 @@ void GLimp_SetSwapInterval( int swapInterval )
 }
 
 /*
-** GLimp_GetMainContext
-*/
-void GLimp_GetMainContext( void **context, void **surface )
-{
-	if( context )
-		*context = glw_state.sdl_glcontext;
-	if( surface )
-		*surface = NULL;
-}
-
-/*
 ** GLimp_MakeCurrent
 */
 bool GLimp_MakeCurrent( void *context, void *surface )

--- a/source/sdl/sdl_glw.c
+++ b/source/sdl/sdl_glw.c
@@ -278,9 +278,9 @@ rserr_t GLimp_SetWindow( void *hinstance, void *wndproc, void *parenthWnd, bool 
 }
 
 /*
-** GLimp_ScreenEnabled
+** GLimp_RenderingEnabled
 */
-bool GLimp_ScreenEnabled( void )
+bool GLimp_RenderingEnabled( void )
 {
 	return true;
 }

--- a/source/sdl/sdl_glw.c
+++ b/source/sdl/sdl_glw.c
@@ -313,6 +313,30 @@ bool GLimp_MakeCurrent( void *context, void *surface )
 }
 
 /*
+** GLimp_EnableMultithreadedRendering
+*/
+void GLimp_EnableMultithreadedRendering( bool enable )
+{
+}
+
+/*
+** GLimp_GetWindowSurface
+*/
+void *GLimp_GetWindowSurface( bool *renderable )
+{
+	if( renderable )
+		*renderable = true;
+	return NULL;
+}
+
+/*
+** GLimp_UpdatePendingWindowSurface
+*/
+void GLimp_UpdatePendingWindowSurface( void )
+{
+}
+
+/*
 ** GLimp_SharedContext_Create
 */
 bool GLimp_SharedContext_Create( void **context, void **surface )
@@ -320,7 +344,8 @@ bool GLimp_SharedContext_Create( void **context, void **surface )
 	SDL_GL_SetAttribute( SDL_GL_SHARE_WITH_CURRENT_CONTEXT, 1 );
 	
 	*context = (void*)SDL_GL_CreateContext( glw_state.sdl_window );
-	*surface = NULL;
+	if( surface )
+		*surface = NULL;
 	
 	// SDL_GL_CreateContext makes the newly created context current
 	// we don't want that, so revert to our main context

--- a/source/unix/unix_glw.c
+++ b/source/unix/unix_glw.c
@@ -1086,8 +1086,11 @@ void GLimp_AppActivate( bool active, bool destroy )
 /*
 ** GLimp_SetWindow
 */
-rserr_t GLimp_SetWindow( void *hinstance, void *wndproc, void *parenthWnd )
+rserr_t GLimp_SetWindow( void *hinstance, void *wndproc, void *parenthWnd, bool *surfaceChangePending )
 {
+	if( surfaceChangePending )
+		*surfaceChangePending = false;
+
 	return rserr_ok; // surface cannot be lost
 }
 

--- a/source/unix/unix_glw.c
+++ b/source/unix/unix_glw.c
@@ -1095,9 +1095,9 @@ rserr_t GLimp_SetWindow( void *hinstance, void *wndproc, void *parenthWnd, bool 
 }
 
 /*
-** GLimp_ScreenEnabled
+** GLimp_RenderingEnabled
 */
-bool GLimp_ScreenEnabled( void )
+bool GLimp_RenderingEnabled( void )
 {
 	return true;
 }

--- a/source/unix/unix_glw.c
+++ b/source/unix/unix_glw.c
@@ -1112,6 +1112,30 @@ void GLimp_SetSwapInterval( int swapInterval )
 }
 
 /*
+** GLimp_EnableMultithreadedRendering
+*/
+void GLimp_EnableMultithreadedRendering( bool enable )
+{
+}
+
+/*
+** GLimp_GetWindowSurface
+*/
+void *GLimp_GetWindowSurface( bool *renderable )
+{
+	if( renderable )
+		*renderable = true;
+	return ( void * )x11dispay.gl_win;
+}
+
+/*
+** GLimp_UpdatePendingWindowSurface
+*/
+void GLimp_UpdatePendingWindowSurface( void )
+{
+}
+
+/*
 ** GLimp_SharedContext_Create
 */
 bool GLimp_SharedContext_Create( void **context, void **surface )
@@ -1121,7 +1145,8 @@ bool GLimp_SharedContext_Create( void **context, void **surface )
 		return false;
 
 	*context = (void *)ctx;
-	*surface = (void *)x11display.gl_win;
+	if( surface )
+		*surface = (void *)x11display.gl_win;
 	return true;
 }
 

--- a/source/win32/win_glw.c
+++ b/source/win32/win_glw.c
@@ -635,6 +635,30 @@ bool GLimp_MakeCurrent( void *context, void *surface )
 }
 
 /*
+** GLimp_EnableMultithreadedRendering
+*/
+void GLimp_EnableMultithreadedRendering( bool enable )
+{
+}
+
+/*
+** GLimp_GetWindowSurface
+*/
+void *GLimp_GetWindowSurface( bool *renderable )
+{
+	if( renderable )
+		*renderable = true;
+	return NULL;
+}
+
+/*
+** GLimp_UpdatePendingWindowSurface
+*/
+void GLimp_UpdatePendingWindowSurface( void )
+{
+}
+
+/*
 ** GLimp_SharedContext_Create
 */
 bool GLimp_SharedContext_Create( void **context, void **surface )
@@ -646,7 +670,8 @@ bool GLimp_SharedContext_Create( void **context, void **surface )
 
 	qwglShareLists( glw_state.hGLRC, ctx );
 	*context = ctx;
-	*surface = ( void * )1;
+	if( surface )
+		*surface = NULL;
 	return true;
 }
 

--- a/source/win32/win_glw.c
+++ b/source/win32/win_glw.c
@@ -596,9 +596,9 @@ rserr_t GLimp_SetWindow( void *hinstance, void *wndproc, void *parenthWnd, bool 
 }
 
 /*
-** GLimp_ScreenEnabled
+** GLimp_RenderingEnabled
 */
-bool GLimp_ScreenEnabled( void )
+bool GLimp_RenderingEnabled( void )
 {
 	return true;
 }

--- a/source/win32/win_glw.c
+++ b/source/win32/win_glw.c
@@ -613,17 +613,6 @@ void GLimp_SetSwapInterval( int swapInterval )
 }
 
 /*
-** GLimp_GetMainContext
-*/
-void GLimp_GetMainContext( void **context, void **surface )
-{
-	if( context )
-		*context = glw_state.hGLRC;
-	if( surface )
-		*surface = NULL;
-}
-
-/*
 ** GLimp_MakeCurrent
 */
 bool GLimp_MakeCurrent( void *context, void *surface )

--- a/source/win32/win_glw.c
+++ b/source/win32/win_glw.c
@@ -587,8 +587,11 @@ void GLimp_AppActivate( bool active, bool destroy )
 /*
 ** GLimp_SetWindow
 */
-rserr_t GLimp_SetWindow( void *hinstance, void *wndproc, void *parenthWnd )
+rserr_t GLimp_SetWindow( void *hinstance, void *wndproc, void *parenthWnd, bool *surfaceChangePending )
 {
+	if( surfaceChangePending )
+		*surfaceChangePending = false;
+
 	return rserr_ok; // surface cannot be lost
 }
 


### PR DESCRIPTION
Mostly to make the threaded renderer work correctly on Android, which makes EGLSurface invalid when going to background.
