### PR TITLE
Make only one GL context own FBO GL handles

### DIFF
--- a/source/ref_gl/r_backend.c
+++ b/source/ref_gl/r_backend.c
@@ -52,6 +52,9 @@ void RB_Init( void )
 	RB_RegisterStreamVBOs();
 	
 	RP_PrecachePrograms();
+
+	// enable the usage of framebuffer objects
+	RFB_InitRendering();
 }
 
 /*
@@ -59,6 +62,8 @@ void RB_Init( void )
 */
 void RB_Shutdown( void )
 {
+	RFB_ShutdownRendering();
+
 	RP_StorePrecacheList();
 
 	R_FreePool( &rb.mempool );

--- a/source/ref_gl/r_local.h
+++ b/source/ref_gl/r_local.h
@@ -501,6 +501,7 @@ enum
 };
 
 void		RFB_Init( void );
+void		RFB_InitRendering( void );
 int			RFB_RegisterObject( int width, int height, bool builtin, bool depthRB, bool stencilRB );
 void		RFB_UnregisterObject( int object );
 void		RFB_TouchObject( int object );
@@ -512,6 +513,7 @@ void		RFB_BlitObject( int dest, int bitMask, int mode );
 bool	RFB_CheckObjectStatus( void );
 void		RFB_GetObjectSize( int object, int *width, int *height );
 void		RFB_FreeUnusedObjects( void );
+void		RFB_ShutdownRendering( void );
 void		RFB_Shutdown( void );
 
 //


### PR DESCRIPTION
The OpenGL standard allows sharing of textures and renderbuffers between contexts, but sharing framebuffer objects causes an undefined behavior. Nvidia Tegra K1 driver doesn't share FBOs between contexts.

This commit makes sure the actual GL FBOs are created only when the backend is running, while also allowing render target textures and renderbuffers to be preserved between the contexts (so internal post-processing framebuffers can still be created on the main thread and don't have to be destroyed when the backend shuts down).
