### PR TITLE
GB splash radius 70->80

### DIFF
--- a/source/gameshared/gs_weapondefs.c
+++ b/source/gameshared/gs_weapondefs.c
@@ -131,7 +131,7 @@ gs_weapon_definition_t gs_weaponDefs[] =
 			1.0,							// selfdamage ratio
 			90,								// knockback
 			0,								// stun
-			70,								// splash radius
+			80,								// splash radius
 			8,								// splash minimum damage
 			10,                             // splash minimum knockback
 


### PR DESCRIPTION
**GB splash radius 70->80**
- 70 raduis is too low so it makes GB jumps hard even for skilled players, 80 adds a bit more consistency of performing jumps. Also it would make the gun a bit more easier for the splash shots.
