### PR TITLE
Walljump height minimum

### DIFF
--- a/source/gameshared/gs_pmove.c
+++ b/source/gameshared/gs_pmove.c
@@ -1223,11 +1223,12 @@ static void PM_CheckWallJump( void )
 		point[2] = pml.origin[2] - STEPSIZE;
 
 		// don't walljump if our height is smaller than a step 
-		// unless the player is moving faster than dash speed and upwards
+		// unless jump is pressed or the player is moving faster than dash speed and upwards
 		hspeed = VectorLengthFast( tv( pml.velocity[0], pml.velocity[1], 0 ) );
 		module_Trace( &trace, pml.origin, pm->mins, pm->maxs, point, pm->playerState->POVnum, pm->contentmask, 0 );
 		
-		if( ( hspeed > pm->playerState->pmove.stats[PM_STAT_DASHSPEED] && pml.velocity[2] > 8 ) 
+		if( pml.upPush >= 10
+			|| ( hspeed > pm->playerState->pmove.stats[PM_STAT_DASHSPEED] && pml.velocity[2] > 8 )
 			|| ( trace.fraction == 1 ) || ( !ISWALKABLEPLANE( &trace.plane ) && !trace.startsolid ) )
 		{
 			VectorClear( normal );


### PR DESCRIPTION
This disables the minimum walljump height if jump is pressed, as discussed on the forums. See my [latest post](https://www.warsow.gg/forum/thread/t/231393#post-231393) for some considerations.

The value 10 is taken from PM_CheckJump. This would deserve a macro if I could come up with a suitable name.
