### PR TITLE
Grenade angles

### DIFF
--- a/source/game/g_weapon.cpp
+++ b/source/game/g_weapon.cpp
@@ -725,7 +725,7 @@ edict_t *W_Fire_Grenade( edict_t *self, vec3_t start, vec3_t angles, int speed, 
 		damage = 9999;
 
 	if( aim_up )
-		angles[PITCH] -= 5.0f * ( 90.0f - fabs( angles[PITCH] ) ) / 90.0f; // aim some degrees upwards from view dir
+		angles[PITCH] -= 5.0f * cos( angles[PITCH] * M_TWOPI / 360.0f ); // aim some degrees upwards from view dir
 
 	grenade = W_Fire_TossProjectile( self, start, angles, speed, damage, minKnockback, maxKnockback, stun, minDamage, radius, timeout, timeDelta );
 	VectorClear( grenade->s.angles );

--- a/source/game/g_weapon.cpp
+++ b/source/game/g_weapon.cpp
@@ -725,7 +725,7 @@ edict_t *W_Fire_Grenade( edict_t *self, vec3_t start, vec3_t angles, int speed, 
 		damage = 9999;
 
 	if( aim_up )
-		angles[PITCH] -= 5.0f * cos( angles[PITCH] * M_TWOPI / 360.0f ); // aim some degrees upwards from view dir
+		angles[PITCH] -= 5.0f * cos( DEG2RAD( angles[PITCH] ) ); // aim some degrees upwards from view dir
 
 	grenade = W_Fire_TossProjectile( self, start, angles, speed, damage, minKnockback, maxKnockback, stun, minDamage, radius, timeout, timeDelta );
 	VectorClear( grenade->s.angles );

--- a/source/game/g_weapon.cpp
+++ b/source/game/g_weapon.cpp
@@ -726,7 +726,7 @@ edict_t *W_Fire_Grenade( edict_t *self, vec3_t start, vec3_t angles, int speed, 
 
 	if( aim_up )
 	{
-		angles[PITCH] -= 5; // aim some degrees upwards from view dir
+		angles[PITCH] -= 5.0f * ( 90.0f - fabs( angles[PITCH] ) ) / 90.0f; // aim some degrees upwards from view dir
 
 		// clamp to front side of the player
 		angles[PITCH] += -90; // rotate to make easier the check

--- a/source/game/g_weapon.cpp
+++ b/source/game/g_weapon.cpp
@@ -725,16 +725,7 @@ edict_t *W_Fire_Grenade( edict_t *self, vec3_t start, vec3_t angles, int speed, 
 		damage = 9999;
 
 	if( aim_up )
-	{
 		angles[PITCH] -= 5.0f * ( 90.0f - fabs( angles[PITCH] ) ) / 90.0f; // aim some degrees upwards from view dir
-
-		// clamp to front side of the player
-		angles[PITCH] += -90; // rotate to make easier the check
-		while( angles[PITCH] < -360 ) angles[PITCH] += 360;
-		clamp( angles[PITCH], -180, 0 );
-		angles[PITCH] += 90;
-		while( angles[PITCH] > 360 ) angles[PITCH] -= 360;
-	}
 
 	grenade = W_Fire_TossProjectile( self, start, angles, speed, damage, minKnockback, maxKnockback, stun, minDamage, radius, timeout, timeDelta );
 	VectorClear( grenade->s.angles );


### PR DESCRIPTION
To help players fight gravity when shooting grenades, qfusion offsets the angle at which the grenade is shot a little upwards. Currently, this offset is a constant of 5 degrees, which means that it is impossible to shoot straight down.

Thinking about the intended effect of compensating gravity, it seems more natural to regulate the offset according to the extent to which the viewing direction is orthogonal to the direction of gravity.
Thus, I propose to turn the adjustment into a monotone bijection by means of the cosine function.

Initially, the idea was to use this for grenade jumps as it enables shooting straight down, but the grenade settings are not so well suited to make a nice jump. Still, I find the change satisfying conceptually.

Of course, the intuition of compensating gravity is a bit off considering that the trajectory is often much longer when shooting somewhat up than when shooting somewhat down, but that cannot really (and should not) be accounted for.

Note that due to the cosine the effect does not diminish very quickly around the horizon (25 degrees up/down gives an offset of 4.5 instead of 5), so I expect players will not really notice the change. The value 5 could be raised a little to make it on average more like the old situation.

(The thing is bijective on [-90, 90] as long as that value 5 is not raised above 57 something.)
