### PR TITLE
Forward centerprints to spectators

### DIFF
--- a/source/game/g_awards.cpp
+++ b/source/game/g_awards.cpp
@@ -82,7 +82,7 @@ void G_PlayerAward( edict_t *ent, const char *awardMsg )
 		if( !other->r.client || !other->r.inuse || !other->r.client->resp.chase.active )
 			continue;
 
-		if( other->r.client->ps.POVnum == (unsigned)ENTNUM( ent ) ) {
+		if( other->r.client->resp.chase.target == ENTNUM( ent ) ) {
 			trap_GameCmd( other, va( "aw \"%s\"", awardMsg ) );
 		}
 	}

--- a/source/game/g_awards.cpp
+++ b/source/game/g_awards.cpp
@@ -31,6 +31,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 void G_PlayerAward( edict_t *ent, const char *awardMsg )
 {
 	edict_t *other;
+	char cmd[MAX_STRING_CHARS];
 	gameaward_t *ga;
 	int i, size;
 	score_stats_t *stats;
@@ -38,7 +39,8 @@ void G_PlayerAward( edict_t *ent, const char *awardMsg )
 	if( !awardMsg || !awardMsg[0] || !ent->r.client )
 		return;
 
-	trap_GameCmd( ent, va( "aw \"%s\"", awardMsg ) );
+	Q_snprintfz( cmd, sizeof( cmd ), "aw \"%s\"", awardMsg );
+	trap_GameCmd( ent, cmd );
 
 	if( dedicated->integer )
 		G_Printf( "%s", COM_RemoveColorTokens( va( "%s receives a '%s' award.\n", ent->r.client->netname, awardMsg ) ) );
@@ -82,9 +84,8 @@ void G_PlayerAward( edict_t *ent, const char *awardMsg )
 		if( !other->r.client || !other->r.inuse || !other->r.client->resp.chase.active )
 			continue;
 
-		if( other->r.client->resp.chase.target == ENTNUM( ent ) ) {
-			trap_GameCmd( other, va( "aw \"%s\"", awardMsg ) );
-		}
+		if( other->r.client->resp.chase.target == ENTNUM( ent ) )
+			trap_GameCmd( other, cmd );
 	}
 }
 

--- a/source/game/g_utils.cpp
+++ b/source/game/g_utils.cpp
@@ -1250,6 +1250,7 @@ void G_CenterPrintMsg( edict_t *ent, const char *format, ... )
 	char msg[1024];
 	va_list	argptr;
 	char *p;
+	edict_t *other;
 
 	va_start( argptr, format );
 	Q_vsnprintfz( msg, sizeof( msg ), format, argptr );
@@ -1261,6 +1262,19 @@ void G_CenterPrintMsg( edict_t *ent, const char *format, ... )
 		*p = '\'';
 
 	trap_GameCmd( ent, va( "cp \"%s\"", msg ) );
+
+	if( ent != NULL )
+	{
+		// add it to every player who's chasing this player
+		for( other = game.edicts + 1; PLAYERNUM( other ) < gs.maxclients; other++ )
+		{
+			if( !other->r.client || !other->r.inuse || !other->r.client->resp.chase.active )
+				continue;
+
+			if( other->r.client->ps.POVnum == (unsigned)ENTNUM( ent ) )
+				trap_GameCmd( other, va( "cp \"%s\"", msg ) );
+		}
+	}
 }
 
 /*
@@ -1278,6 +1292,7 @@ void G_CenterPrintFormatMsg( edict_t *ent, const char *format, ... )
 	char *p, *arg_p;
 	int num_args;
 	bool overflow = false;
+	edict_t *other;
 
 	Q_strncpyz( cmd, "cpf ", sizeof( cmd ) );
 
@@ -1336,6 +1351,19 @@ void G_CenterPrintFormatMsg( edict_t *ent, const char *format, ... )
 	}
 
 	trap_GameCmd( ent, cmd );
+
+	if( ent != NULL )
+	{
+		// add it to every player who's chasing this player
+		for( other = game.edicts + 1; PLAYERNUM( other ) < gs.maxclients; other++ )
+		{
+			if( !other->r.client || !other->r.inuse || !other->r.client->resp.chase.active )
+				continue;
+
+			if( other->r.client->ps.POVnum == (unsigned)ENTNUM( ent ) )
+				trap_GameCmd( other, cmd );
+		}
+	}
 }
 
 

--- a/source/game/g_utils.cpp
+++ b/source/game/g_utils.cpp
@@ -1248,6 +1248,7 @@ void G_ChatMsg( edict_t *ent, edict_t *who, bool teamonly, const char *format, .
 void G_CenterPrintMsg( edict_t *ent, const char *format, ... )
 {
 	char msg[1024];
+	char cmd[MAX_STRING_CHARS];
 	va_list	argptr;
 	char *p;
 	edict_t *other;
@@ -1261,7 +1262,8 @@ void G_CenterPrintMsg( edict_t *ent, const char *format, ... )
 	while( ( p = strchr( p, '\"' ) ) != NULL )
 		*p = '\'';
 
-	trap_GameCmd( ent, va( "cp \"%s\"", msg ) );
+	Q_snprintfz( cmd, sizeof( cmd ), "cp \"%s\"", msg );
+	trap_GameCmd( ent, cmd );
 
 	if( ent != NULL )
 	{
@@ -1272,7 +1274,7 @@ void G_CenterPrintMsg( edict_t *ent, const char *format, ... )
 				continue;
 
 			if( other->r.client->resp.chase.target == ENTNUM( ent ) )
-				trap_GameCmd( other, va( "cp \"%s\"", msg ) );
+				trap_GameCmd( other, cmd );
 		}
 	}
 }

--- a/source/game/g_utils.cpp
+++ b/source/game/g_utils.cpp
@@ -1271,7 +1271,7 @@ void G_CenterPrintMsg( edict_t *ent, const char *format, ... )
 			if( !other->r.client || !other->r.inuse || !other->r.client->resp.chase.active )
 				continue;
 
-			if( other->r.client->ps.POVnum == (unsigned)ENTNUM( ent ) )
+			if( other->r.client->resp.chase.target == ENTNUM( ent ) )
 				trap_GameCmd( other, va( "cp \"%s\"", msg ) );
 		}
 	}
@@ -1360,7 +1360,7 @@ void G_CenterPrintFormatMsg( edict_t *ent, const char *format, ... )
 			if( !other->r.client || !other->r.inuse || !other->r.client->resp.chase.active )
 				continue;
 
-			if( other->r.client->ps.POVnum == (unsigned)ENTNUM( ent ) )
+			if( other->r.client->resp.chase.target == ENTNUM( ent ) )
 				trap_GameCmd( other, cmd );
 		}
 	}


### PR DESCRIPTION
Being displayed at the center of the screen, centerprints generally form a part of the gameplay experience and should thus be forwarded to spectators chasing the player who receives them.

Centerprints are used to inform the player about protection wearing off and the time before respawning in ctftactics. Race uses centerprints to display sector and finish times. Entities may emit a centerprinted message (e.g. https://github.com/Warsow/qfusion/blob/master/source/game/g_func.cpp#L841). At the moment, chasing spectators are missing all this.

Additionally, I noticed the ps.POVnum test that was used for forwarding awards (from which I borrowed the code) is rather unstable. For instance, it seems that when the window is not in focus, this variable is reset to the chasers own entity number, sabotaging my two window test setup.
Already it is tested that resp.chase.active, so it seemed sensible to adjust to the test to resp.chase.target. This works fine.

On the negative side, centerprints are sometimes used for warnings that are not really related to the gameplay. The worst example I could find (there isn't much else really) is the team balance warning (https://github.com/Warsow/qfusion/blob/master/source/game/g_gametypes.cpp#L1761).
A "private" variation on the function could be added, but I think that is not worth the effort. The message can hardly confuse spectators, and it adds to the consistency anyway.
