### PR TITLE
Monospace console font

### DIFF
--- a/source/cgame/cg_hud.cpp
+++ b/source/cgame/cg_hud.cpp
@@ -2171,6 +2171,10 @@ static bool CG_LFuncFontFamily( struct cg_layoutnode_s *commandnode, struct cg_l
 	{
 		Q_strncpyz( layout_cursor_font_name, cgs.fontSystemFamily, sizeof( layout_cursor_font_name ) );
 	}
+	else if( !Q_stricmp( fontname, "con_fontSystemMono" ) )
+	{
+		Q_strncpyz( layout_cursor_font_name, cgs.fontSystemMonoFamily, sizeof( layout_cursor_font_name ) );
+	}
 	else
 	{
 		Q_strncpyz( layout_cursor_font_name, fontname, sizeof( layout_cursor_font_name ) );

--- a/source/cgame/cg_local.h
+++ b/source/cgame/cg_local.h
@@ -440,6 +440,7 @@ typedef struct
 
 	// fonts
 	char fontSystemFamily[MAX_QPATH];
+	char fontSystemMonoFamily[MAX_QPATH];
 	int fontSystemSmallSize;
 	int fontSystemMediumSize;
 	int fontSystemBigSize;

--- a/source/cgame/cg_media.cpp
+++ b/source/cgame/cg_media.cpp
@@ -462,12 +462,14 @@ void CG_RegisterLevelMinimap( void )
 void CG_RegisterFonts( void )
 {
 	cvar_t *con_fontSystemFamily = trap_Cvar_Get( "con_fontSystemFamily", DEFAULT_SYSTEM_FONT_FAMILY, CVAR_ARCHIVE );
+	cvar_t *con_fontSystemMonoFamily = trap_Cvar_Get( "con_fontSystemMonoFamily", DEFAULT_SYSTEM_FONT_FAMILY_MONO, CVAR_ARCHIVE );
 	cvar_t *con_fontSystemSmallSize = trap_Cvar_Get( "con_fontSystemSmallSize", STR_TOSTR( DEFAULT_SYSTEM_FONT_SMALL_SIZE ), CVAR_ARCHIVE );
 	cvar_t *con_fontSystemMediumSize = trap_Cvar_Get( "con_fontSystemMediumSize", STR_TOSTR( DEFAULT_SYSTEM_FONT_MEDIUM_SIZE ), CVAR_ARCHIVE );
 	cvar_t *con_fontSystemBigSize = trap_Cvar_Get( "con_fontSystemBigSize", STR_TOSTR( DEFAULT_SYSTEM_FONT_BIG_SIZE ), CVAR_ARCHIVE );
 
 	// register system fonts
 	Q_strncpyz( cgs.fontSystemFamily, con_fontSystemFamily->string, sizeof( cgs.fontSystemFamily ) );
+	Q_strncpyz( cgs.fontSystemMonoFamily, con_fontSystemMonoFamily->string, sizeof( cgs.fontSystemMonoFamily ) );
 	if( con_fontSystemSmallSize->integer <= 0 ) {
 		trap_Cvar_Set( con_fontSystemSmallSize->name, con_fontSystemSmallSize->dvalue );
 	}

--- a/source/client/cl_screen.c
+++ b/source/client/cl_screen.c
@@ -54,6 +54,7 @@ static cvar_t *scr_graphshift;
 
 static cvar_t *con_fontSystemFamily;
 static cvar_t *con_fontSystemFallbackFamily;
+static cvar_t *con_fontSystemMonoFamily;
 static cvar_t *con_fontSystemConsoleSize;
 
 //
@@ -91,7 +92,7 @@ static void SCR_RegisterConsoleFont( void )
 	float pixelRatio = Con_GetPixelRatio();
 
 	// register system fonts
-	con_fontSystemFamilyName = con_fontSystemFamily->string;
+	con_fontSystemFamilyName = con_fontSystemMonoFamily->string;
 	if( !con_fontSystemConsoleSize->integer ) {
 		Cvar_SetValue( con_fontSystemConsoleSize->name, DEFAULT_SYSTEM_FONT_SMALL_SIZE );
 	} else if( con_fontSystemConsoleSize->integer > DEFAULT_SYSTEM_FONT_SMALL_SIZE * 2 ) {
@@ -104,13 +105,13 @@ static void SCR_RegisterConsoleFont( void )
 	cls.consoleFont = SCR_RegisterFont( con_fontSystemFamilyName, con_fontSystemStyle, size );
 	if( !cls.consoleFont )
 	{
-		Cvar_ForceSet( con_fontSystemFamily->name, con_fontSystemFamily->dvalue );
-		con_fontSystemFamilyName = con_fontSystemFamily->dvalue;
+		Cvar_ForceSet( con_fontSystemMonoFamily->name, con_fontSystemMonoFamily->dvalue );
+		con_fontSystemFamilyName = con_fontSystemMonoFamily->dvalue;
 
 		size = DEFAULT_SYSTEM_FONT_SMALL_SIZE;
 		cls.consoleFont = SCR_RegisterFont( con_fontSystemFamilyName, con_fontSystemStyle, size );
 		if( !cls.consoleFont )
-			Com_Error( ERR_FATAL, "Couldn't load default font \"%s\"", con_fontSystemFamily->dvalue );
+			Com_Error( ERR_FATAL, "Couldn't load default font \"%s\"", con_fontSystemMonoFamily->dvalue );
 
 		Con_CheckResize();
 	}
@@ -123,6 +124,7 @@ static void SCR_RegisterConsoleFont( void )
 static void SCR_InitFonts( void )
 {
 	con_fontSystemFamily = Cvar_Get( "con_fontSystemFamily", DEFAULT_SYSTEM_FONT_FAMILY, CVAR_ARCHIVE );
+	con_fontSystemMonoFamily = Cvar_Get( "con_fontSystemMonoFamily", DEFAULT_SYSTEM_FONT_FAMILY_MONO, CVAR_ARCHIVE );
 	con_fontSystemFallbackFamily = Cvar_Get( "con_fontSystemFallbackFamily", DEFAULT_SYSTEM_FONT_FAMILY_FALLBACK, CVAR_ARCHIVE|CVAR_LATCH_VIDEO );
 	con_fontSystemConsoleSize = Cvar_Get( "con_fontSystemConsoleSize", STR_TOSTR( DEFAULT_SYSTEM_FONT_SMALL_SIZE ), CVAR_ARCHIVE );
 

--- a/source/client/cl_screen.c
+++ b/source/client/cl_screen.c
@@ -157,6 +157,7 @@ static void SCR_CheckSystemFontsModified( void )
 		|| con_fontSystemConsoleSize->modified 
 		) {
 		SCR_RegisterConsoleFont();
+		con_fontSystemMonoFamily->modified = false;
 		con_fontSystemConsoleSize->modified = false;
 	}
 }

--- a/source/client/cl_screen.c
+++ b/source/client/cl_screen.c
@@ -149,11 +149,11 @@ static void SCR_ShutdownFonts( void )
 */
 static void SCR_CheckSystemFontsModified( void )
 {
-	if( !con_fontSystemFamily ) {
+	if( !con_fontSystemMonoFamily ) {
 		return;
 	}
 
-	if( con_fontSystemFamily->modified 
+	if( con_fontSystemMonoFamily->modified
 		|| con_fontSystemConsoleSize->modified 
 		) {
 		SCR_RegisterConsoleFont();

--- a/source/client/console.c
+++ b/source/client/console.c
@@ -1214,6 +1214,8 @@ static void Con_DisplayList( char **list )
 
 	if( i % columns != 0 )
 		Com_Printf( "\n" );
+
+	Com_Printf( "\n" );
 }
 
 /*

--- a/source/client/console.c
+++ b/source/client/console.c
@@ -1173,42 +1173,47 @@ void Con_DrawConsole( void )
 */
 static void Con_DisplayList( char **list )
 {
-	int i = 0;
-	int pos = 0;
+	int i, j;
 	int len = 0;
 	int maxlen = 0;
-	int width = ( con.linewidth - 4 );
-	char **walk = list;
+	int width = con.linewidth - 4;
+	int columns;
+	int columnwidth;
+	int items = 0;
 
-	while( *walk )
+	while( list[items] )
 	{
-		len = (int)strlen( *walk );
+		len = (int)strlen( list[items] );
 		if( len > maxlen )
 			maxlen = len;
-		walk++;
+		items++;
 	}
-	maxlen += 1;
+	maxlen += 2;
+	columns = width / maxlen;
 
-	while( *list )
+	for( i = 0; i < items; i++ )
 	{
-		len = (int)strlen( *list );
-
-		if( pos + maxlen >= width )
+		columnwidth = 0;
+		for( j = i % columns; j < items; j += columns )
 		{
-			Com_Printf( "\n" );
-			pos = 0;
+			len = (int)strlen( list[j] );
+			if( len > columnwidth )
+				columnwidth = len;
 		}
+		columnwidth += 2;
 
-		Com_Printf( "%s", *list );
-		for( i = 0; i < ( maxlen - len ); i++ )
+		len = (int)strlen( list[i] );
+
+		Com_Printf( "%s", list[i] );
+		for( j = 0; j < columnwidth - len; j++ )
 			Com_Printf( " " );
 
-		pos += maxlen;
-		list++;
+		if( i % columns == columns - 1 )
+			Com_Printf( "\n" );
 	}
 
-	if( pos )
-		Com_Printf( "\n\n" );
+	if( i % columns != 0 )
+		Com_Printf( "\n" );
 }
 
 /*

--- a/source/client/console.c
+++ b/source/client/console.c
@@ -1191,29 +1191,38 @@ static void Con_DisplayList( char **list )
 	maxlen += 2;
 	columns = width / maxlen;
 
-	for( i = 0; i < items; i++ )
+	if( columns == 0 )
 	{
-		columnwidth = 0;
-		for( j = i % columns; j < items; j += columns )
+		for( i = 0; i < items; i++ )
+			Com_Printf( "%s ", list[i] );
+		Com_Printf( "\n" );
+	}
+	else
+	{
+		for( i = 0; i < items; i++ )
 		{
-			len = (int)strlen( list[j] );
-			if( len > columnwidth )
-				columnwidth = len;
+			columnwidth = 0;
+			for( j = i % columns; j < items; j += columns )
+			{
+				len = (int)strlen( list[j] );
+				if( len > columnwidth )
+					columnwidth = len;
+			}
+			columnwidth += 2;
+
+			len = (int)strlen( list[i] );
+
+			Com_Printf( "%s", list[i] );
+			for( j = 0; j < columnwidth - len; j++ )
+				Com_Printf( " " );
+
+			if( i % columns == columns - 1 )
+				Com_Printf( "\n" );
 		}
-		columnwidth += 2;
 
-		len = (int)strlen( list[i] );
-
-		Com_Printf( "%s", list[i] );
-		for( j = 0; j < columnwidth - len; j++ )
-			Com_Printf( " " );
-
-		if( i % columns == columns - 1 )
+		if( i % columns != 0 )
 			Com_Printf( "\n" );
 	}
-
-	if( i % columns != 0 )
-		Com_Printf( "\n" );
 
 	Com_Printf( "\n" );
 }

--- a/source/gameshared/q_shared.h
+++ b/source/gameshared/q_shared.h
@@ -80,6 +80,7 @@ extern float ( *LittleFloat )(float l);
 
 #define DEFAULT_SYSTEM_FONT_FAMILY			"Droid Sans"
 #define DEFAULT_SYSTEM_FONT_FAMILY_FALLBACK	"Droid Sans Fallback"
+#define DEFAULT_SYSTEM_FONT_FAMILY_MONO		"Droid Sans Mono"
 #define DEFAULT_SYSTEM_FONT_SMALL_SIZE		14
 #define DEFAULT_SYSTEM_FONT_MEDIUM_SIZE		16
 #define DEFAULT_SYSTEM_FONT_BIG_SIZE		24


### PR DESCRIPTION
Several features rely on the console being rendered in a monospace font, which at present is not the case.

For instance, consider the output for mapname completion:
https://dl.dropboxusercontent.com/u/22044693/qfusion/nonmono.png
This is quite unacceptable, and it will certainly make a bad impression on, say, experienced players coming from another quake.
After the proposed changes, the above output becomes like this:
https://dl.dropboxusercontent.com/u/22044693/qfusion/mono.png

Warsow huds typically use the default console font for many elements. For most of these, it is undesired to have a monospace font replacement.
Thus, I have added a different cvar for a monospace console font family. The huds are not affected by my proposition.

It may be strange that the console does not really use con_fontSystemFamily anymore, but the interpretation should be as follows: con_fontSystemFamily is the "normal" variant belonging to con_fontSystemMonoFamily.

Additionally, I have improved the list display (for completions etc.) as follows. Before, each item was padded relative to the maximum length item in the whole list. With this change, it is padded relative to the maximum length item in its own column.
Furthermore, it seemed to be more visually pleasing (and better readable) to separate columns by two spaces.
