### PR TITLE
Scale DrawDebugGraph for width > 1024

### DIFF
--- a/source/client/cl_screen.c
+++ b/source/client/cl_screen.c
@@ -461,7 +461,7 @@ void SCR_DebugGraph( float value, float r, float g, float b )
 */
 static void SCR_DrawDebugGraph( void )
 {
-	int a, x, y, w, i, h;
+	int a, x, y, w, i, h, s;
 	float v;
 
 	//
@@ -473,6 +473,8 @@ static void SCR_DrawDebugGraph( void )
 	SCR_DrawFillRect( x, y-scr_graphheight->integer,
 		w, scr_graphheight->integer, colorBlack );
 
+	s = ( w + 1024 - 1 ) / 1024; //scale for resolutions with width >1024
+
 	for( a = 0; a < w; a++ )
 	{
 		i = ( current-1-a+1024 ) & 1023;
@@ -482,7 +484,7 @@ static void SCR_DrawDebugGraph( void )
 		if( v < 0 )
 			v += scr_graphheight->integer * ( 1+(int)( -v/scr_graphheight->integer ) );
 		h = (int)v % scr_graphheight->integer;
-		SCR_DrawFillRect( x+w-1-a, y - h, 1, h, values[i].color );
+		SCR_DrawFillRect( x+w-1-a*s, y - h, s, h, values[i].color );
 	}
 }
 


### PR DESCRIPTION
This fixes graph not being drawn properly in resolutions with width more than 1024 as it was reported long time here https://www.warsow.gg/forum/thread/15754/1 Graph gets repeated every on 1024 pixels
![4](https://cloud.githubusercontent.com/assets/4707112/13557741/0299aa50-e407-11e5-8fad-7c1817a5e5c0.png)

Fix roundly scales the graph, so every peak would be doubled for 1025~2048 widths, tripled for 2049-3072 widths and so on.
