### PR TITLE
Expose ucmd.serverTimeStamp to gametypes

### DIFF
--- a/source/game/g_ascript.cpp
+++ b/source/game/g_ascript.cpp
@@ -2033,6 +2033,7 @@ static const asProperty_t gameclient_Properties[] =
 	{ ASLIB_PROPERTY_DECL(const int16, pendingWeapon), ASLIB_FOFFSET(gclient_t, ps.stats[STAT_PENDING_WEAPON]) },
 	{ ASLIB_PROPERTY_DECL(bool, takeStun), ASLIB_FOFFSET(gclient_t, resp.takeStun) },
 	{ ASLIB_PROPERTY_DECL(uint, lastActivity), ASLIB_FOFFSET(gclient_t, level.last_activity) },
+	{ ASLIB_PROPERTY_DECL(const uint, uCmdTimeStamp), ASLIB_FOFFSET(gclient_t, ucmd.serverTimeStamp) },
 
 	ASLIB_PROPERTY_NULL
 };


### PR DESCRIPTION
Using one of the direct current server timestamps to track player times in race is unreliable. Execution of ucmds is delayed by latency in the connection from the client to the server. If this latency changes during a run in race, the relative times are affected.

The ucmds carry a timestamp, which when used as reference for the times seem to give consistently correct results.
Ideally, we would just use a direct system timestamp from the client, but I think thanks to the magic by which cl.serverTime is maintained this is good enough.

The other part of this fix is available in this branch for the gametype: https://github.com/hettoo/wsw-race/tree/qf

I found and fixed this for racesow back before 1.0. It has been tested ever since.
See here: https://github.com/Racenet/racesow/pull/1
and the actual patch applied to racesow: https://github.com/Racenet/racesow/commit/35870e3517e374e5b84624691d49c4ab8729b67e
