### PR TITLE
Add spree end notifications

### DIFF
--- a/source/game/g_awards.cpp
+++ b/source/game/g_awards.cpp
@@ -411,9 +411,12 @@ void G_AwardPlayerKilled( edict_t *self, edict_t *inflictor, edict_t *attacker, 
 			Q_strncpyz( s, S_COLOR_YELLOW "Extermination!", sizeof( s ) );
 			G_PrintMsg( NULL, "%s" S_COLOR_YELLOW " is Exterminating!\n", attacker->r.client->netname );
 			break;
-		default:
+		case 5:
 			Q_strncpyz( s, S_COLOR_YELLOW "God Mode!", sizeof( s ) );
 			G_PrintMsg( NULL, "%s" S_COLOR_YELLOW " is in God Mode!\n", attacker->r.client->netname );
+		default:
+			Q_strncpyz( s, S_COLOR_YELLOW "God Mode!", sizeof( s ) );
+			G_PrintMsg( NULL, "%s" S_COLOR_YELLOW " is in God Mode! " S_COLOR_WHITE "%d" S_COLOR_YELLOW " frags!\n", attacker->r.client->netname, attacker->r.client->resp.awardInfo.frag_count );
 			break;
 		}
 
@@ -538,4 +541,11 @@ void G_AwardFairPlay( edict_t *ent )
 	client->level.stats.fairplay_count++;
 	client->resp.awardInfo.fairplay_award = true;
 	G_PlayerAward( ent, S_COLOR_CYAN "Fair Play!" );
+}
+
+void G_DeathAwards( edict_t *ent )
+{
+	int frag_count = ent->r.client->resp.awardInfo.frag_count;
+	if( frag_count >= 5 )
+		G_PrintMsg( NULL, "%s" S_COLOR_YELLOW " made a spree of " S_COLOR_WHITE "%d" S_COLOR_YELLOW "!\n", ent->r.client->netname, frag_count );
 }

--- a/source/game/g_local.h
+++ b/source/game/g_local.h
@@ -987,6 +987,7 @@ void G_AwardPlayerKilled( edict_t *self, edict_t *inflictor, edict_t *attacker, 
 void G_AwardPlayerPickup( edict_t *self, edict_t *item );
 void G_AwardResetPlayerComboStats( edict_t *ent );
 void G_AwardRaceRecord( edict_t *self );
+void G_DeathAwards( edict_t *ent );
 
 /**
  * Gives the player the Fair Play award if all conditions are met.

--- a/source/game/p_client.cpp
+++ b/source/game/p_client.cpp
@@ -460,6 +460,8 @@ void G_ClientClearStats( edict_t *ent )
 */
 void G_GhostClient( edict_t *ent )
 {
+	G_DeathAwards( ent );
+
 	ent->movetype = MOVETYPE_NONE;
 	ent->r.solid = SOLID_NOT;
 
@@ -502,6 +504,8 @@ void G_ClientRespawn( edict_t *self, bool ghost )
 	vec3_t spawn_origin, spawn_angles;
 	gclient_t *client;
 	int old_team;
+
+	G_DeathAwards( self );
 
 	G_SpawnQueue_RemoveClient( self );
 


### PR DESCRIPTION
It often annoyed me that I made a nice fragging spree and there was no final information telling me and the other players how many frags I made exactly. A long time ago when I played some Enemy Territory mod I felt that this really added another dimension of competitiveness to the game. Similarly, the agungame gametype that appeared in Warsow some years ago had this, which particularly suited the elitist flavor of the gametype (see my old video https://www.youtube.com/watch?v=KHYfWq4roLc for example).

Since the awards "On Fire", "Raging", etc. are notified using a global message in any gametype, I think it makes sense to also have this final message with the spree size regardless of the gametype.

I have added a short message that on the death of a player (or some other event by which the award data is reset) notifies about the spree if it was at least 5 frags. Additionally, the god mode message after the first one (so 25 frags or more) will now contain the current frag count.

It is easy to overdo this (notify about the player fragging the player with the spree, keeping track of match top sprees, etc), but in my opinion that would not suit qfusion/Warsow.
