### PR TITLE
Smarter walljump choices

### DIFF
--- a/source/gameshared/gs_pmove.c
+++ b/source/gameshared/gs_pmove.c
@@ -146,20 +146,30 @@ static vec_t VectorNormalize2D( vec3_t v ) // ByMiK : normalize horizontally (do
 // usage : nbTestDir = nb of direction to test around the player
 // maxZnormal is the Z value of the normal of a poly to considere it as a wall
 // normal is a pointer to the normal of the nearest wall
-
 static void PlayerTouchWall( int nbTestDir, float maxZnormal, vec3_t *normal )
 {
 	vec3_t zero, dir;
 	int i;
 	trace_t trace;
-	float r = 0.0, d = 0.0;
-	float dx, dy, m;
+	float r, d, dx, dy, m;
 
 	VectorClear( zero );
 
+	// determine the primary direction
+	if( pml.sidePush > 0 )
+		r = M_PI / 2.0f;
+	else if( pml.sidePush < 0 )
+		r = -M_PI / 2.0f;
+	else if( pml.forwardPush < 0 )
+		r = M_PI;
+	else
+		r = 0.0f;
+
+	d = 0.0f; // current distance from the primary direction
+
 	for( i = 0; i < nbTestDir; i++ )
 	{
-		// start in the view direction and alternate with its opposite while moving away from these
+		// start checking in the primary direction and alternate with its opposite while moving away from these
 		if( i != 0 )
 			r += M_PI; // switch front and back
 		if( i % 4 == 0 && i != 0 )
@@ -167,10 +177,12 @@ static void PlayerTouchWall( int nbTestDir, float maxZnormal, vec3_t *normal )
 			r -= 2 * d;
 		}
 		else if( i % 4 == 2 )
-		{ // move further away
+		{ // switch left and right and move further away
 			r += 2 * d + M_TWOPI / nbTestDir;
 			d += M_TWOPI / nbTestDir;
 		}
+
+		// determine the relative offsets from the origin
 		dx = cos( DEG2RAD( pm->playerState->viewangles[YAW] ) + r );
 		dy = sin( DEG2RAD( pm->playerState->viewangles[YAW] ) + r );
 

--- a/source/gameshared/gs_pmove.c
+++ b/source/gameshared/gs_pmove.c
@@ -197,7 +197,7 @@ static void PlayerTouchWall( int nbTestDir, float maxZnormal, vec3_t *normal )
 			m = fabs( pm->maxs[1] / dy );
 
 		// allow a gap between the player and the wall
-		m *= 2.0f;
+		m += pm->maxs[0];
 
 		dir[0] = pml.origin[0] + dx * m + pml.velocity[0] * 0.015f;
 		dir[1] = pml.origin[1] + dy * m + pml.velocity[1] * 0.015f;

--- a/source/gameshared/gs_pmove.c
+++ b/source/gameshared/gs_pmove.c
@@ -141,11 +141,10 @@ static vec_t VectorNormalize2D( vec3_t v ) // ByMiK : normalize horizontally (do
 	return length;
 }
 
-// Could be used to test if player walk touching a wall, if not used in any other part of pm code i'll integrate
-// this function to the walljumpcheck function.
-// usage : nbTestDir = nb of direction to test around the player
-// maxZnormal is the Z value of the normal of a poly to considere it as a wall
-// normal is a pointer to the normal of the nearest wall
+// Walljump wall availability check
+// nbTestDir is the number of directions to test around the player
+// maxZnormal is the max Z value of the normal of a poly to consider it a wall
+// normal becomes a pointer to the normal of the most appropriate wall
 static void PlayerTouchWall( int nbTestDir, float maxZnormal, vec3_t *normal )
 {
 	vec3_t zero, dir;

--- a/source/gameshared/gs_pmove.c
+++ b/source/gameshared/gs_pmove.c
@@ -155,6 +155,7 @@ static void PlayerTouchWall( int nbTestDir, float maxZnormal, vec3_t *normal )
 	VectorClear( zero );
 
 	// if there is nothing at all within the checked area, we can skip the individual checks
+	// this optimization must always overapproximate the combination of those checks
 	mins[0] = pm->mins[0] - pm->maxs[0];
 	mins[1] = pm->mins[1] - pm->maxs[0];
 	maxs[0] = pm->maxs[0] + pm->maxs[0];

--- a/source/gameshared/gs_pmove.c
+++ b/source/gameshared/gs_pmove.c
@@ -1278,7 +1278,7 @@ static void PM_CheckWallJump( void )
 			|| ( trace.fraction == 1 ) || ( !ISWALKABLEPLANE( &trace.plane ) && !trace.startsolid ) )
 		{
 			VectorClear( normal );
-			PlayerTouchWall( 12, 0.3f, &normal );
+			PlayerTouchWall( 18, 0.3f, &normal );
 			if( !VectorLength( normal ) )
 				return;
 

--- a/source/gameshared/gs_pmove.c
+++ b/source/gameshared/gs_pmove.c
@@ -147,12 +147,30 @@ static vec_t VectorNormalize2D( vec3_t v ) // ByMiK : normalize horizontally (do
 // normal becomes a pointer to the normal of the most appropriate wall
 static void PlayerTouchWall( int nbTestDir, float maxZnormal, vec3_t *normal )
 {
-	vec3_t zero, dir;
+	vec3_t zero, dir, mins, maxs;
 	int i;
 	trace_t trace;
 	float r, d, dx, dy, m;
 
 	VectorClear( zero );
+
+	// if there is nothing at all within the checked area, we can skip the individual checks
+	mins[0] = pm->mins[0] - pm->maxs[0];
+	mins[1] = pm->mins[1] - pm->maxs[0];
+	maxs[0] = pm->maxs[0] + pm->maxs[0];
+	maxs[1] = pm->maxs[1] + pm->maxs[0];
+	if( pml.velocity[0] > 0 )
+		maxs[0] += pml.velocity[0] * 0.015f;
+	else
+		mins[0] += pml.velocity[0] * 0.015f;
+	if( pml.velocity[1] > 0 )
+		maxs[1] += pml.velocity[1] * 0.015f;
+	else
+		mins[1] += pml.velocity[1] * 0.015f;
+	mins[2] = maxs[2] = 0;
+	module_Trace( &trace, pml.origin, mins, maxs, pml.origin, pm->playerState->POVnum, pm->contentmask, 0 );
+	if( !trace.allsolid && trace.fraction == 1 )
+		return;
 
 	// determine the primary direction
 	if( pml.sidePush > 0 )

--- a/source/gameshared/gs_pmove.c
+++ b/source/gameshared/gs_pmove.c
@@ -160,10 +160,10 @@ static void PlayerTouchWall( int nbTestDir, float maxZnormal, vec3_t *normal )
 		r = M_PI / 2.0f;
 	else if( pml.sidePush < 0 )
 		r = -M_PI / 2.0f;
-	else if( pml.forwardPush < 0 )
-		r = M_PI;
-	else
+	else if( pml.forwardPush > 0 )
 		r = 0.0f;
+	else
+		r = M_PI;
 
 	d = 0.0f; // current distance from the primary direction
 

--- a/source/gameshared/gs_pmove.c
+++ b/source/gameshared/gs_pmove.c
@@ -1279,7 +1279,7 @@ static void PM_CheckWallJump( void )
 			|| ( trace.fraction == 1 ) || ( !ISWALKABLEPLANE( &trace.plane ) && !trace.startsolid ) )
 		{
 			VectorClear( normal );
-			PlayerTouchWall( 18, 0.3f, &normal );
+			PlayerTouchWall( 20, 0.3f, &normal );
 			if( !VectorLength( normal ) )
 				return;
 


### PR DESCRIPTION
The current walljump code prefers, out of the walls found around the player within a reasonable distance, the wall that is closest to the player. This leads to unpredictable and often undesired results. If two walls are close (for instance because we stand in a corner) it is unclear what wall will be jumped against when a walljump is performed.

Within this reasonable distance, the wall that is to be jumped against should be chosen based on the viewangles and the buttons pressed by the player. The control that is thus added is a new little element that could benefit from some skill, but at the same time it is quite natural.

The proposed check works as follows. There is a primary direction relative to the viewangles that is determined as follows:
- If left is pressed, the direction is to the left of the player's viewangles.
- If right is pressed, it is to the right.
- If forward is pressed, it is in front.
- Otherwise, it is behind.
  The reason for defaulting behind is that after the walljump we should prefer to move forward if possible.

The order of directions in which walls are checked is indicated very roughly here (using 6 directions instead of 12), where the first is the primary direction:
https://dl.dropboxusercontent.com/u/22044693/wjdir.png
The first valid wall that is found is returned.

The traces now use zero vector mins/maxs in order to give us control over the preferred walls. This will not lead to problems unless there are several holes in the walls at unfortunate positions. We could increase the number of checks if necessary.

The old code checked in a circle around the player origin. I took a fixed distance around the player box, which I think is more sensible for collision-like events. I have chosen this distance to mimic the old minimum walljump distance as closely as possible.
The locations are still shifted along to the velocity in order to avoid actual collisions.
