### PR TITLE
Fix walljump on defrag maps that use surfaceparm noob

### DIFF
--- a/source/gameshared/q_collision.h
+++ b/source/gameshared/q_collision.h
@@ -82,6 +82,8 @@ extern "C" {
 #define SURF_DUST				0x40000		// leave a dust trail when walking on this surface
 #define SURF_NOWALLJUMP			0x80000		// can not perform walljumps on this surface
 
+#define SURF_FBSP_START			0x40000		// FBSP specific extensions to BSP
+
 // content masks
 #define	MASK_ALL			( -1 )
 #define	MASK_SOLID			( CONTENTS_SOLID )

--- a/source/qcommon/cm_q3bsp.c
+++ b/source/qcommon/cm_q3bsp.c
@@ -365,19 +365,6 @@ static void CMod_LoadSurfaces( cmodel_state_t *cms, lump_t *l )
 }
 
 /*
-* CMod_FilterDfNoOverbounceParms Filter defrag's "surfaceparm noob" flag which qfusion sees as "nowalljump"
-*/
-static void CMod_FilterDfNoOverbounceParms( cmodel_state_t *cms )
-{
-	int i;
-	if( cms->cmap_bspFormat->header == QFBSPHEADER ) // ignore qfusion maps
-		return;
-
-	for( i = 0; i < cms->numshaderrefs; i++ )
-		cms->map_shaderrefs[i].flags = cms->map_shaderrefs[i].flags & ~SURF_NOWALLJUMP;
-}
-
-/*
 * CMod_LoadVertexes
 */
 static void CMod_LoadVertexes( cmodel_state_t *cms, lump_t *l )

--- a/source/qcommon/cm_q3bsp.c
+++ b/source/qcommon/cm_q3bsp.c
@@ -355,6 +355,13 @@ static void CMod_LoadSurfaces( cmodel_state_t *cms, lump_t *l )
 
 	for( i = 0; i < count; i++ )
 		cms->map_shaderrefs[i].name = buffer + ( size_t )( ( void * )cms->map_shaderrefs[i].name );
+
+	// For non-FBSP maps (i.e. Q3, RTWC), unset FBSP specific surface flags
+	if( cms->cmap_bspFormat->header != QFBSPHEADER )
+	{
+		for( i = 0; i < cms->numshaderrefs; i++ )
+			cms->map_shaderrefs[i].flags = cms->map_shaderrefs[i].flags & ( SURF_FBSP_START - 1 );
+	}
 }
 
 /*
@@ -877,7 +884,6 @@ void CM_LoadQ3BrushModel( cmodel_state_t *cms, void *parent, void *buf, bspForma
 
 	// load into heap
 	CMod_LoadSurfaces( cms, &header.lumps[LUMP_SHADERREFS] );
-	CMod_FilterDfNoOverbounceParms( cms );
 	CMod_LoadPlanes( cms, &header.lumps[LUMP_PLANES] );
 	if( cms->cmap_bspFormat->flags & BSP_RAVEN )
 		CMod_LoadBrushSides_RBSP( cms, &header.lumps[LUMP_BRUSHSIDES] );

--- a/source/qcommon/cm_q3bsp.c
+++ b/source/qcommon/cm_q3bsp.c
@@ -358,6 +358,22 @@ static void CMod_LoadSurfaces( cmodel_state_t *cms, lump_t *l )
 }
 
 /*
+* CMod_FilterDfNoOverbounceParms Filter defrag's "surfaceparm noob" flag which qfusion sees as "nowalljump"
+*/
+static void CMod_FilterDfNoOverbounceParms( cmodel_state_t *cms )
+{
+	int i;
+	if( cms->cmap_bspFormat->header == QFBSPHEADER ) // ignore qfusion maps
+		return;
+
+	for( i = 0; i < cms->numshaderrefs; i++ )
+	{
+		if( cms->map_shaderrefs[i].flags & SURF_NOWALLJUMP )
+			cms->map_shaderrefs[i].flags = 0;
+	}
+}
+
+/*
 * CMod_LoadVertexes
 */
 static void CMod_LoadVertexes( cmodel_state_t *cms, lump_t *l )
@@ -864,6 +880,7 @@ void CM_LoadQ3BrushModel( cmodel_state_t *cms, void *parent, void *buf, bspForma
 
 	// load into heap
 	CMod_LoadSurfaces( cms, &header.lumps[LUMP_SHADERREFS] );
+	CMod_FilterDfNoOverbounceParms( cms );
 	CMod_LoadPlanes( cms, &header.lumps[LUMP_PLANES] );
 	if( cms->cmap_bspFormat->flags & BSP_RAVEN )
 		CMod_LoadBrushSides_RBSP( cms, &header.lumps[LUMP_BRUSHSIDES] );

--- a/source/qcommon/cm_q3bsp.c
+++ b/source/qcommon/cm_q3bsp.c
@@ -367,10 +367,7 @@ static void CMod_FilterDfNoOverbounceParms( cmodel_state_t *cms )
 		return;
 
 	for( i = 0; i < cms->numshaderrefs; i++ )
-	{
-		if( cms->map_shaderrefs[i].flags & SURF_NOWALLJUMP )
-			cms->map_shaderrefs[i].flags = 0;
-	}
+		cms->map_shaderrefs[i].flags = cms->map_shaderrefs[i].flags & ~SURF_NOWALLJUMP;
 }
 
 /*


### PR DESCRIPTION
Defrag maps made since 2014 may contain the surfaceparm: `noob 0x80000       // no overbounces on this surface`, this can be found in the last download at http://q3defrag.org/files/defrag/

However, Warsow already uses 0x80000 for the surfaceparm nowalljump, making some DF maps have non-walljumpable maps. An example is https://ws.q3df.org/map/kabcorp-parkour/, applying the fix makes the walls walljumpable again.

The presented solution is to erase the 0x80000 surfaceparm in all non-qfusion maps during loading of the bsp.
