### PR TITLE
Fix string comparison at surfaceparm check

### DIFF
--- a/source/qcommon/cm_q3bsp.c
+++ b/source/qcommon/cm_q3bsp.c
@@ -357,7 +357,7 @@ static void CMod_LoadSurfaces( cmodel_state_t *cms, lump_t *l )
 		cms->map_shaderrefs[i].name = buffer + ( size_t )( ( void * )cms->map_shaderrefs[i].name );
 
 	// For non-FBSP maps (i.e. Q3, RTCW), unset FBSP-specific surface flags
-	if( cms->cmap_bspFormat->header != QFBSPHEADER )
+	if( strcmp( cms->cmap_bspFormat->header, QFBSPHEADER ) )
 	{
 		for( i = 0; i < count; i++ )
 			cms->map_shaderrefs[i].flags &= SURF_FBSP_START - 1;


### PR DESCRIPTION
The bspformat thing passed to this function is actually one of the defined constants, so the pointer check actually works correctly and the warning could be suppressed by casting to char *.

Still, I switched to using strcmp to prevent weird bugs in future implementations. The additional computations are negligible.
