### PR TITLE
Remove projectiles of a specific entity

### DIFF
--- a/source/game/g_ascript.cpp
+++ b/source/game/g_ascript.cpp
@@ -2756,7 +2756,7 @@ static void asFunc_G_Match_RemoveProjectiles( edict_t *owner )
 
 static void asFunc_G_Match_RemoveAllProjectiles( void )
 {
-	G_Match_RemoveAllProjectiles();
+	G_Match_RemoveProjectiles( NULL );
 }
 
 static void asFunc_G_ResetLevel( void )

--- a/source/game/g_ascript.cpp
+++ b/source/game/g_ascript.cpp
@@ -2749,6 +2749,11 @@ static gsitem_t *asFunc_GS_FindItemByClassname( asstring_t *name )
 	return ( !name || !name->len ) ? NULL : GS_FindItemByClassname( name->buffer );
 }
 
+static void asFunc_G_Match_RemoveProjectiles( edict_t *owner )
+{
+	G_Match_RemoveProjectiles( owner );
+}
+
 static void asFunc_G_Match_RemoveAllProjectiles( void )
 {
 	G_Match_RemoveAllProjectiles();
@@ -3314,6 +3319,7 @@ static const asglobfuncs_t asGlobFuncs[] =
 	{ "array<Entity @> @G_FindByClassname( const String &in )", asFUNCTION(asFunc_G_FindByClassname), NULL },
 
 	// misc management utils
+	{ "void G_RemoveProjectiles( Entity @ )", asFUNCTION(asFunc_G_Match_RemoveProjectiles), NULL },
 	{ "void G_RemoveAllProjectiles()", asFUNCTION(asFunc_G_Match_RemoveAllProjectiles), NULL },
 	{ "void G_ResetLevel()", asFUNCTION(asFunc_G_ResetLevel), NULL },
 	{ "void G_RemoveDeadBodies()", asFUNCTION(asFunc_G_Match_FreeBodyQueue), NULL },

--- a/source/game/g_gametypes.cpp
+++ b/source/game/g_gametypes.cpp
@@ -1366,7 +1366,7 @@ void G_Match_ToggleReady( edict_t *ent )
 }
 
 /*
-* G_Match_RemoveAllProjectiles
+* G_Match_RemoveProjectiles
 */
 void G_Match_RemoveProjectiles( edict_t *owner )
 {

--- a/source/game/g_gametypes.cpp
+++ b/source/game/g_gametypes.cpp
@@ -64,7 +64,7 @@ void G_Gametype_GENERIC_SetUpCountdown( void )
 	bool any = false;
 	int team;
 
-	G_Match_RemoveAllProjectiles();
+	G_Match_RemoveProjectiles( NULL );
 	G_Items_RespawnByType( 0, 0, 0 ); // respawn all items
 
 	level.gametype.readyAnnouncementEnabled = false;
@@ -1374,23 +1374,8 @@ void G_Match_RemoveProjectiles( edict_t *owner )
 
 	for( ent = game.edicts + gs.maxclients; ENTNUM( ent ) < game.numentities; ent++ )
 	{
-		if( ent->r.inuse && !ent->r.client && ent->r.svflags & SVF_PROJECTILE && ent->r.solid != SOLID_NOT && ent->r.owner->s.number == owner->s.number )
-		{
-			G_FreeEdict( ent );
-		}
-	}
-}
-
-/*
-* G_Match_RemoveAllProjectiles
-*/
-void G_Match_RemoveAllProjectiles( void )
-{
-	edict_t *ent;
-
-	for( ent = game.edicts + gs.maxclients; ENTNUM( ent ) < game.numentities; ent++ )
-	{
-		if( ent->r.inuse && !ent->r.client && ent->r.svflags & SVF_PROJECTILE && ent->r.solid != SOLID_NOT )
+		if( ent->r.inuse && !ent->r.client && ent->r.svflags & SVF_PROJECTILE && ent->r.solid != SOLID_NOT &&
+				( owner == NULL || ent->r.owner->s.number == owner->s.number ) )
 		{
 			G_FreeEdict( ent );
 		}

--- a/source/game/g_gametypes.cpp
+++ b/source/game/g_gametypes.cpp
@@ -1368,6 +1368,22 @@ void G_Match_ToggleReady( edict_t *ent )
 /*
 * G_Match_RemoveAllProjectiles
 */
+void G_Match_RemoveProjectiles( edict_t *owner )
+{
+	edict_t *ent;
+
+	for( ent = game.edicts + gs.maxclients; ENTNUM( ent ) < game.numentities; ent++ )
+	{
+		if( ent->r.inuse && !ent->r.client && ent->r.svflags & SVF_PROJECTILE && ent->r.solid != SOLID_NOT && ent->r.owner->s.number == owner->s.number )
+		{
+			G_FreeEdict( ent );
+		}
+	}
+}
+
+/*
+* G_Match_RemoveAllProjectiles
+*/
 void G_Match_RemoveAllProjectiles( void )
 {
 	edict_t *ent;

--- a/source/game/g_gametypes.h
+++ b/source/game/g_gametypes.h
@@ -207,7 +207,6 @@ extern char clockstring[16];
 bool G_Match_Tied( void );
 bool G_Match_CheckExtendPlayTime( void );
 void G_Match_RemoveProjectiles( edict_t *owner );
-void G_Match_RemoveAllProjectiles( void );
 void G_Match_CleanUpPlayerStats( edict_t *ent );
 void G_Match_FreeBodyQueue( void );
 void G_Match_LaunchState( int matchState );

--- a/source/game/g_gametypes.h
+++ b/source/game/g_gametypes.h
@@ -206,6 +206,7 @@ extern char clockstring[16];
 //
 bool G_Match_Tied( void );
 bool G_Match_CheckExtendPlayTime( void );
+void G_Match_RemoveProjectiles( edict_t *owner );
 void G_Match_RemoveAllProjectiles( void );
 void G_Match_CleanUpPlayerStats( edict_t *ent );
 void G_Match_FreeBodyQueue( void );


### PR DESCRIPTION
For race it would be nice to be able to remove projectiles associated with a specific entity.

At the moment players can abuse weapons by shooting at the spawn area and then respawning.
