### PR TITLE
Keep firing animations with cg_gunbob 0

### DIFF
--- a/source/cgame/cg_events.cpp
+++ b/source/cgame/cg_events.cpp
@@ -436,7 +436,7 @@ static void CG_FireWeaponEvent( int entNum, int weapon, int fireMode )
 	}
 
 	// add animation to the view weapon model
-	if( ISVIEWERENTITY( entNum ) && !cg.view.thirdperson && cg_gunbob->integer )
+	if( ISVIEWERENTITY( entNum ) && !cg.view.thirdperson )
 		CG_ViewWeapon_StartAnimationEvent( fireMode == FIRE_MODE_STRONG ? WEAPMODEL_ATTACK_STRONG : WEAPMODEL_ATTACK_WEAK );
 }
 

--- a/source/cgame/cg_vweap.cpp
+++ b/source/cgame/cg_vweap.cpp
@@ -137,10 +137,7 @@ static int CG_ViewWeapon_baseanimFromWeaponState( int weaponState )
 		/* fall through. Not used */
 	default:
 	case WEAPON_STATE_READY:
-		if( cg_gunbob->integer )
 		anim = WEAPMODEL_STANDBY;
-		else
-		anim = WEAPMODEL_NOANIM;
 		break;
 	}
 

--- a/source/cgame/cg_vweap.cpp
+++ b/source/cgame/cg_vweap.cpp
@@ -137,7 +137,10 @@ static int CG_ViewWeapon_baseanimFromWeaponState( int weaponState )
 		/* fall through. Not used */
 	default:
 	case WEAPON_STATE_READY:
-		anim = WEAPMODEL_STANDBY;
+		if( cg_gunbob->integer )
+			anim = WEAPMODEL_STANDBY;
+		else
+			anim = WEAPMODEL_NOANIM;
 		break;
 	}
 
@@ -183,7 +186,7 @@ void CG_ViewWeapon_RefreshAnimation( cg_viewweapon_t *viewweapon )
 	weaponInfo = CG_GetWeaponInfo( viewweapon->weapon );
 
 	// Full restart
-	if( !viewweapon->baseAnim || !viewweapon->baseAnimStartTime )
+	if( !viewweapon->baseAnimStartTime )
 	{
 		viewweapon->baseAnim = baseAnim;
 		viewweapon->baseAnimStartTime = cg.time;


### PR DESCRIPTION
Firing animations were probably disabled because with the static weapon model they gave very unsmooth results.
However, this is due to a bug that disables lerping with this static model.
