### PR TITLE
More efficient spectator drawing

### DIFF
--- a/source/cgame/cg_scoreboard.cpp
+++ b/source/cgame/cg_scoreboard.cpp
@@ -366,8 +366,8 @@ static int SCR_DrawSpectators( const char **ptrptr, int x, int y, int panelWidth
 	columns = fullwidth / maxwidth;
 	if( count < columns )
 		columns = count;
-	else if( columns < 3 )
-		columns = 3;
+	else if( columns < 3 && count >= 3 )
+		columns = 3; // force 3 columns if less than 3 fit
 
 	// determine column width
 	colwidth = fullwidth / columns;
@@ -403,7 +403,7 @@ static int SCR_DrawSpectators( const char **ptrptr, int x, int y, int panelWidth
 
 		if( pass )
 			trap_SCR_DrawClampString( x + xoffset, y + yoffset, string, x + xoffset, y + yoffset,
-					x + xoffset + colwidth, y + yoffset + height, font, colorWhite );
+					x + xoffset + width, y + yoffset + height, font, colorWhite );
 
 		count++;
 		if( count % columns == 0 )

--- a/source/cgame/cg_scoreboard.cpp
+++ b/source/cgame/cg_scoreboard.cpp
@@ -341,9 +341,9 @@ static int SCR_DrawSpectators( const char **ptrptr, int x, int y, int panelWidth
 
 	assert( ptrptr && *ptrptr );
 
-	fullwidth = panelWidth * 1.5;
-	if( fullwidth > cgs.vidWidth * 0.7 )
-		fullwidth = cgs.vidWidth * 0.7;
+	fullwidth = panelWidth * 1.75;
+	if( fullwidth > cgs.vidWidth * 0.8 )
+		fullwidth = cgs.vidWidth * 0.8;
 
 	height = trap_SCR_FontHeight( font );
 	yoffset = height;

--- a/source/cgame/cg_scoreboard.cpp
+++ b/source/cgame/cg_scoreboard.cpp
@@ -332,7 +332,7 @@ static int SCR_TableRows( int columns, int count )
 
 static bool SCR_NiceSpecConfig( int rows, int columns, int count )
 {
-	return rows != 2 || columns <= 3 || ( count % columns ) % 2 == columns % 2;
+	return rows > 2 || columns == 1 || ( rows == columns && count % columns == 0 );
 }
 
 /*

--- a/source/cgame/cg_scoreboard.cpp
+++ b/source/cgame/cg_scoreboard.cpp
@@ -341,9 +341,7 @@ static int SCR_DrawSpectators( const char **ptrptr, int x, int y, int panelWidth
 
 	assert( ptrptr && *ptrptr );
 
-	fullwidth = panelWidth * 1.75;
-	if( fullwidth > cgs.vidWidth * 0.8 )
-		fullwidth = cgs.vidWidth * 0.8;
+	fullwidth = cgs.vidWidth * 0.8;
 
 	height = trap_SCR_FontHeight( font );
 	yoffset = height;

--- a/source/cgame/cg_scoreboard.cpp
+++ b/source/cgame/cg_scoreboard.cpp
@@ -319,10 +319,10 @@ static int SCR_DrawChallengers( const char **ptrptr, int x, int y, int panelWidt
 
 static int SCR_CountFromCenter( int index, int items )
 {
-	int result = ( index + 1 ) >> 1; // calculate distance from center
-	if( ( items % 2 ) ^ ( index % 2 ) )
-		result *= -1; // swap sides in half of the cases
-	return result + ( items >> 1 ); // relative to center
+	int result = ( index + 1 ) >> 1; // distance from center
+	if( items % 2 == index % 2 )
+		result *= -1; // swap sides half of the cases
+	return result + ( ( items - 1 ) >> 1 ); // relative to center
 }
 
 /*

--- a/source/cgame/cg_scoreboard.cpp
+++ b/source/cgame/cg_scoreboard.cpp
@@ -360,12 +360,18 @@ static int SCR_DrawSpectators( const char **ptrptr, int x, int y, int panelWidth
 		columns = count;
 	else if( columns < 3 )
 		columns = 3;
+
+	// determine column width
 	colwidth = fullwidth / columns;
+	// use smaller columns if possible, and adjust the width of the whole area
+	if( maxwidth < colwidth )
+		colwidth = maxwidth;
+	fullwidth = colwidth * columns;
 
 	*ptrptr = backup;
 	count = 0;
 
-	// draw spectators
+	// draw the spectators
 	while( *ptrptr )
 	{
 		if( !SCR_ParseSpectator( &spec, ptrptr, havePing ) )
@@ -381,10 +387,10 @@ static int SCR_DrawSpectators( const char **ptrptr, int x, int y, int panelWidth
 		}
 
 		SCR_SpectatorString( string, sizeof( string ), spec, havePing );
-		index = count % columns;
 		width = trap_SCR_strWidth( string, font, 0 );
 		if( width > colwidth )
 			width = colwidth;
+		index = count % columns;
 		xoffset = -fullwidth / 2 + ( ( index + 1 ) / ( ( columns % 2 ) ^ ( index % 2 ) ? -2 : 2 ) + columns / 2 ) * colwidth +
 			CG_HorizontalAlignForWidth( colwidth / 2, ALIGN_CENTER_TOP, width );
 

--- a/source/cgame/cg_scoreboard.cpp
+++ b/source/cgame/cg_scoreboard.cpp
@@ -372,12 +372,12 @@ static int SCR_DrawSpectators( const char **ptrptr, int x, int y, int panelWidth
 		columns = 3; // force 3 columns if less than 3 fit
 
 	int rows = count / columns + ( count % columns ? 1 : 0 );
-	// decrease columns if the number of rows stays equal
-	while( columns > 1 && count / ( columns - 1 ) + ( count % ( columns - 1 ) ? 1 : 0 ) == rows )
+	while( ( columns > 1 && count / ( columns - 1 ) + ( count % ( columns - 1 ) ? 1 : 0 ) == rows ) // optimize number of columns
+			|| ( rows == 2 && columns > 3 && ( count % columns ) % 2 != columns % 2 ) ) // avoid ugly configurations
+	{
 		columns--;
-	// prevent ugly situations
-	if( rows == 2 && columns > 3 && count % 2 != columns % 2 )
-		columns++;
+		rows = count / columns + ( count % columns ? 1 : 0 );
+	}
 
 	// determine column width
 	colwidth = fullwidth / columns;

--- a/source/cgame/cg_scoreboard.cpp
+++ b/source/cgame/cg_scoreboard.cpp
@@ -362,7 +362,9 @@ static int SCR_DrawSpectators( const char **ptrptr, int x, int y, int panelWidth
 	if( !maxwidth )
 		return yoffset;
 	columns = fullwidth / maxwidth;
-	if( count < columns )
+	if( columns == 0 )
+		columns = 1;
+	else if( count < columns )
 		columns = count;
 	else if( columns < 3 && count >= 3 )
 		columns = 3; // force 3 columns if less than 3 fit

--- a/source/cgame/cg_scoreboard.cpp
+++ b/source/cgame/cg_scoreboard.cpp
@@ -317,6 +317,14 @@ static int SCR_DrawChallengers( const char **ptrptr, int x, int y, int panelWidt
 	return yoffset;
 }
 
+static int SCR_CountFromCenter( int index, int items )
+{
+	int result = ( index + 1 ) >> 1; // calculate distance from center
+	if( ( items % 2 ) ^ ( index % 2 ) )
+		result *= -1; // swap sides in half of the cases
+	return result + ( items >> 1 ); // relative to center
+}
+
 /*
 * SCR_DrawSpectators
 */
@@ -327,7 +335,7 @@ static int SCR_DrawSpectators( const char **ptrptr, int x, int y, int panelWidth
 	char string[MAX_STRING_CHARS];
 	int yoffset = 0, xoffset = 0;
 	int fullwidth, height;
-	int columns, colwidth, width, maxwidth = 0, index;
+	int columns, colwidth, width, maxwidth = 0;
 	int count = 0;
 	bool titleDrawn = false;
 
@@ -390,8 +398,7 @@ static int SCR_DrawSpectators( const char **ptrptr, int x, int y, int panelWidth
 		width = trap_SCR_strWidth( string, font, 0 );
 		if( width > colwidth )
 			width = colwidth;
-		index = count % columns;
-		xoffset = -fullwidth / 2 + ( ( index + 1 ) / ( ( columns % 2 ) ^ ( index % 2 ) ? -2 : 2 ) + columns / 2 ) * colwidth +
+		xoffset = -fullwidth / 2 + SCR_CountFromCenter( count % columns, columns ) * colwidth +
 			CG_HorizontalAlignForWidth( colwidth / 2, ALIGN_CENTER_TOP, width );
 
 		if( pass )


### PR DESCRIPTION
Currently, spectators are drawn in three columns. The left is aligned left, the middle one is centered and the right is aligned at the right. On a wide screen, there can be a lot of horizontal space between these columns, and precious vertical space is easily lost due to the small number of columns.

I propose a more dynamic approach that tries to scale the number of columns according to the width of the names. All the columns will be aligned at their center.
The columns are assigned equal horizontal space based on the maximum name width. For instance, with 5 spectators the result may be this:
![5 items](https://dl.dropboxusercontent.com/u/22044693/qfusion/scb5a.jpg)
With 4 spectators, it could look like this:
![4 items](https://dl.dropboxusercontent.com/u/22044693/qfusion/scb4.jpg)

Names are added outwards, starting from the middle column. If the number of columns is even, the counting is biased to the left:
![5 items](https://dl.dropboxusercontent.com/u/22044693/qfusion/scb5b.jpg)

Columns are positioned as close together as possible to improve readability:
![3 items](https://dl.dropboxusercontent.com/u/22044693/qfusion/scb3.jpg)

The patch includes some refactoring.
