### PR TITLE
Request configstrings using AS

### DIFF
--- a/source/game/g_ascript.cpp
+++ b/source/game/g_ascript.cpp
@@ -3064,7 +3064,7 @@ static asstring_t *asFunc_GetConfigString( int index )
 	return angelExport->asStringFactoryBuffer( (char *)cs, cs ? strlen( cs ) : 0 );
 }
 
-static void asFunc_ConfigString( int index, asstring_t *str )
+static void asFunc_SetConfigString( int index, asstring_t *str )
 {
 	if( !str || !str->buffer )
 		return;
@@ -3377,8 +3377,8 @@ static const asglobfuncs_t asGlobFuncs[] =
 	{ "int G_SoundIndex( const String &in, bool pure )", asFUNCTION(asFunc_SoundIndexExt), NULL },
 	{ "void G_RegisterCommand( const String &in )", asFUNCTION(asFunc_RegisterCommand), NULL },
 	{ "void G_RegisterCallvote( const String &in, const String &in, const String &in, const String &in )", asFUNCTION(asFunc_RegisterCallvote), NULL },
-	{ "const String @G_GetConfigString( int index )", asFUNCTION(asFunc_GetConfigString), NULL },
-	{ "void G_ConfigString( int index, const String &in )", asFUNCTION(asFunc_ConfigString), NULL },
+	{ "const String @G_ConfigString( int index )", asFUNCTION(asFunc_GetConfigString), NULL },
+	{ "void G_ConfigString( int index, const String &in )", asFUNCTION(asFunc_SetConfigString), NULL },
 
 	// projectile firing
 	{ "void G_FireInstaShot( const Vec3 &in origin, const Vec3 &in angles, int range, int damage, int knockback, int stun, Entity @owner )", asFUNCTION(asFunc_FireInstaShot), NULL },

--- a/source/game/g_ascript.cpp
+++ b/source/game/g_ascript.cpp
@@ -3061,7 +3061,7 @@ static void asFunc_RegisterCallvote( asstring_t *asname, asstring_t *asusage, as
 static asstring_t *asFunc_GetConfigString( int index )
 {
 	const char *cs = trap_GetConfigString( index );
-	return angelExport->asStringFactoryBuffer( (char *)cs, strlen( cs ) );
+	return angelExport->asStringFactoryBuffer( (char *)cs, cs ? strlen( cs ) : 0 );
 }
 
 static void asFunc_ConfigString( int index, asstring_t *str )

--- a/source/game/g_ascript.cpp
+++ b/source/game/g_ascript.cpp
@@ -3058,6 +3058,12 @@ static void asFunc_RegisterCallvote( asstring_t *asname, asstring_t *asusage, as
 		ashelp ? ashelp->buffer : NULL );
 }
 
+static asstring_t *asFunc_GetConfigString( int index )
+{
+	const char *cs = trap_GetConfigString( index );
+	return angelExport->asStringFactoryBuffer( (char *)cs, strlen( cs ) );
+}
+
 static void asFunc_ConfigString( int index, asstring_t *str )
 {
 	if( !str || !str->buffer )
@@ -3371,6 +3377,7 @@ static const asglobfuncs_t asGlobFuncs[] =
 	{ "int G_SoundIndex( const String &in, bool pure )", asFUNCTION(asFunc_SoundIndexExt), NULL },
 	{ "void G_RegisterCommand( const String &in )", asFUNCTION(asFunc_RegisterCommand), NULL },
 	{ "void G_RegisterCallvote( const String &in, const String &in, const String &in, const String &in )", asFUNCTION(asFunc_RegisterCallvote), NULL },
+	{ "const String @G_GetConfigString( int index )", asFUNCTION(asFunc_GetConfigString), NULL },
 	{ "void G_ConfigString( int index, const String &in )", asFUNCTION(asFunc_ConfigString), NULL },
 
 	// projectile firing


### PR DESCRIPTION
This should be available anyhow, but the concrete motivation is that my randmap vote is not able to function as it should.

The randmap vote picks a random map and prints it to all players to help them make up their minds. This printing happens when the vote is validated, but at the moment there are some issues because it is impossible to find out whether the validation is the first validation of a new vote or a successive validation of a previous vote, which happen at certain events because votes may not remain valid.

When a vote is validated, there is a flag to indicate whether this is the first validation that occurs when the vote is called. Unfortunately, this flag is not passed to the callvotevalidate command that is handled in the AS.
Adding this flag as an argument would break existing gametypes.

The gametype finds out when a vote passes, but not when it fails or is otherwise canceled. If this information could be obtained, randmap can be implemented properly.
Adding a callvotecanceled command again breaks existing gametypes.

Allowing gametypes to inspect configstrings gives them in particular access to the CS_ACTIVE_CALLVOTE configstring, which can be used to detect a vote having been canceled.

(The current randmap uses that shortly after the first validation there is another validation, but this is not waterproof: it sometimes chooses a new map halfway through the vote.)
