### PR TITLE
Make teleport effects respect cg_raceGhosts

### DIFF
--- a/source/cgame/cg_lents.cpp
+++ b/source/cgame/cg_lents.cpp
@@ -1084,10 +1084,11 @@ void CG_PModel_SpawnTeleportEffect( centity_t *cent )
 			else
 			{
 				VectorCopy( cent->teleportedTo, teleportOrigin );
-				if( ISVIEWERENTITY( cent->current.number ) ) {
+				if( ISVIEWERENTITY( cent->current.number ) )
 					VectorSet( rgb, 0.1, 0.1, 0.1 );
-				}
 			}
+			if( cg_raceGhosts->integer && !ISVIEWERENTITY( cent->current.number ) )
+				VectorScale( rgb, cg_raceGhostsAlpha->value, rgb );
 
 			// spawn a dummy model
 			le = CG_AllocModel( LE_RGB_FADE, teleportOrigin, vec3_origin, 10, 

--- a/source/cgame/cg_lents.cpp
+++ b/source/cgame/cg_lents.cpp
@@ -1087,7 +1087,7 @@ void CG_PModel_SpawnTeleportEffect( centity_t *cent )
 				if( ISVIEWERENTITY( cent->current.number ) )
 					VectorSet( rgb, 0.1, 0.1, 0.1 );
 			}
-			if( cg_raceGhosts->integer && !ISVIEWERENTITY( cent->current.number ) )
+			if( cg_raceGhosts->integer && !ISVIEWERENTITY( cent->current.number ) && GS_RaceGametype() )
 				VectorScale( rgb, cg_raceGhostsAlpha->value, rgb );
 
 			// spawn a dummy model


### PR DESCRIPTION
The cg_raceGhosts and associated cg_raceGhostsAlpha cvars control visibility of other players in race to reduce distraction.
At the moment this does not include their teleport effects, which leads to annoyances because teleport effects are used at respawn, and in race players often spawn frequently and all at the same spot.
