### PR TITLE
Improve G_AddEvent

### DIFF
--- a/source/game/g_utils.cpp
+++ b/source/game/g_utils.cpp
@@ -909,31 +909,21 @@ void G_AddEvent( edict_t *ent, int event, int parm, bool highPriority )
 	if( !event )
 		return;
 
-	// replace the most outdated low-priority event
-	if( !highPriority )
-	{
-		int oldEventNum = -1;
+	int eventNum = ent->numEvents & 1;
 
-		if( !ent->eventPriority[0] && !ent->eventPriority[1] )
-			oldEventNum = ( ent->numEvents + 1 ) & 2;
-		else if( !ent->eventPriority[0] )
-			oldEventNum = 0;
+	if( !highPriority && ( ent->eventPriority[0] || ent->eventPriority[1] ) )
+	{ // replace the most outdated low-priority event
+		if( !ent->eventPriority[0] )
+			eventNum = 0;
 		else if( !ent->eventPriority[1] )
-			oldEventNum = 1;
-
-		// no luck
-		if( oldEventNum == -1 )
+			eventNum = 1;
+		else // no luck
 			return;
-
-		ent->s.events[oldEventNum] = event;
-		ent->s.eventParms[oldEventNum] = parm & 0xFF;
-		ent->eventPriority[oldEventNum] = false;
-		return;
 	}
 
-	ent->s.events[ent->numEvents & 1] = event;
-	ent->s.eventParms[ent->numEvents & 1] = parm & 0xFF;
-	ent->eventPriority[ent->numEvents & 1] = highPriority;
+	ent->s.events[eventNum] = event;
+	ent->s.eventParms[eventNum] = parm & 0xFF;
+	ent->eventPriority[eventNum] = highPriority;
 	ent->numEvents++;
 }
 

--- a/source/game/g_utils.cpp
+++ b/source/game/g_utils.cpp
@@ -910,21 +910,16 @@ void G_AddEvent( edict_t *ent, int event, int parm, bool highPriority )
 		return;
 
 	int eventNum = ent->numEvents & 1;
-
-	if( !highPriority && ( ent->eventPriority[0] || ent->eventPriority[1] ) )
-	{ // replace the most outdated low-priority event
-		if( !ent->eventPriority[0] )
-			eventNum = 0;
-		else if( !ent->eventPriority[1] )
-			eventNum = 1;
-		else // no luck
-			return;
-	}
+	if( ent->eventPriority[eventNum] && !ent->eventPriority[( eventNum + 1 ) & 1] )
+		eventNum = ( eventNum + 1 ) & 1; // prefer overwriting low priority events
+	else if( !highPriority && ent->eventPriority[eventNum] )
+		return; // no low priority event to overwrite
+	else
+		ent->numEvents++; // numEvents is only used to vary the overwritten event
 
 	ent->s.events[eventNum] = event;
 	ent->s.eventParms[eventNum] = parm & 0xFF;
 	ent->eventPriority[eventNum] = highPriority;
-	ent->numEvents++;
 }
 
 /*


### PR DESCRIPTION
G_AddEvent adds an event to an entity. For each entity there are two slots for events.
I looked at this function by accident and was very suspicious of the line

```
  oldEventNum = ( ent->numEvents + 1 ) & 2;
```

which would appear to allow oldEventNum to be more than 1, thus exceeding the event slots. On closer examination, though, this line is only reached when there are only low priority events, and in this case numEvents is never increased. Thus, the above line is simply equivalent to

```
  oldEventNum = 0;
```

This in turn means that there will not be more than one low priority event stored, which is an unnecessary limitation (as high priority events simply overwrite low priority ones). I have fixed this.

The fix is probably nothing that will be noticed, but whatever, it saves some lines. :)
