### PR TITLE
Keep scores when switching between player teams

### DIFF
--- a/source/game/g_callvotes.cpp
+++ b/source/game/g_callvotes.cpp
@@ -1851,8 +1851,7 @@ static void G_VoteRebalancePassed( callvotedata_t *vote )
 
 		if( e->s.team != newteam )
 			G_Teams_SetTeam( e, newteam );
-		else
-			memset( &e->r.client->level.stats, 0, sizeof( e->r.client->level.stats ) ); // clear scores
+		memset( &e->r.client->level.stats, 0, sizeof( e->r.client->level.stats ) ); // clear scores
 
 		if( i % 2 == 0 )
 			team++;
@@ -2503,6 +2502,12 @@ void G_OperatorVote_Cmd( edict_t *ent )
 		if( ( playerEnt = G_PlayerForText( splayer ) ) == NULL )
 		{
 			G_PrintMsg( ent, "The player '%s' couldn't be found.\n", splayer );
+			return;
+		}
+
+		if( playerEnt->s.team == newTeam )
+		{
+			G_PrintMsg( ent, "The player '%s' is already in team '%s'.\n", playerEnt->r.client->netname, GS_TeamName( newTeam ) );
 			return;
 		}
 


### PR DESCRIPTION
To not discourage players from switching teams, scores should be preserved.
This change does still reset when the origin or target team is spectators, to prevent some weird situations.

(Unfortunately, the Warsow UI does not seem to allow a direct change between player teams... but this is not a qfusion issue, and players can still make use of the new feature through the commandline.)

No partial MM report is recorded for these score preserving switches.
The only part of the teamstate used by the MM is the timestamp, which is also preserved.

The rebalance callvote had to be adjusted to make sure it always does reset scores.

As a bonus, the putteam operator command now checks if the player already was in the requested team (to prevent a respawn in case of a mistake).
