### PR TITLE
Enable console output when using SDL

### DIFF
--- a/source/client/CMakeLists.txt
+++ b/source/client/CMakeLists.txt
@@ -56,6 +56,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
             "../win32/win_fs.c"
             "../win32/win_net.c"
             "../win32/win_sys.c"
+            "../win32/win_console.c"
             "../win32/win_threads.c"
             "../null/sys_vfs_null.c"
 
@@ -108,6 +109,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
         "../unix/unix_fs.c"
         "../unix/unix_net.c"
         "../unix/unix_sys.c"
+        "../unix/unix_console.c"
         "../unix/unix_threads.c"
         "../null/sys_vfs_null.c"
 
@@ -148,6 +150,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
             "../unix/unix_fs.c"
             "../unix/unix_net.c"
             "../unix/unix_sys.c"
+            "../unix/unix_console.c"
             "../unix/unix_threads.c"
             "../null/sys_vfs_null.c"
 

--- a/source/qcommon/cvar.c
+++ b/source/qcommon/cvar.c
@@ -67,9 +67,17 @@ static bool Cvar_InfoValidate( const char *s, bool name )
 }
 
 /*
+* Cvar_Initialized
+*/
+bool Cvar_Initialized( void )
+{
+	return cvar_initialized;
+}
+
+/*
 * Cvar_Find
 */
-cvar_t *Cvar_Find ( const char *var_name )
+cvar_t *Cvar_Find( const char *var_name )
 {
 	cvar_t *cvar;
 	assert( cvar_trie );

--- a/source/qcommon/cvar.h
+++ b/source/qcommon/cvar.h
@@ -14,6 +14,9 @@
    interface from being ambiguous.
  */
 
+// checks if the cvar system can still be used
+bool Cvar_Initialized( void );
+
 // flag manipulation routines
 static inline cvar_flag_t Cvar_FlagSet( cvar_flag_t *flags, cvar_flag_t flag );
 static inline cvar_flag_t Cvar_FlagUnset( cvar_flag_t *flags, cvar_flag_t flag );

--- a/source/sdl/sdl_sys.c
+++ b/source/sdl/sdl_sys.c
@@ -89,15 +89,6 @@ void Sys_SendKeyEvents( void )
 	sys_frame_time = Sys_Milliseconds();
 }
 
-char *Sys_ConsoleInput( void )
-{
-	return NULL;
-}
-
-void Sys_ConsoleOutput( char *string )
-{
-}
-
 /*****************************************************************************/
 
 int main( int argc, char **argv )

--- a/source/unix/unix_console.c
+++ b/source/unix/unix_console.c
@@ -5,8 +5,8 @@
 #include "../qcommon/qcommon.h"
 
 bool stdin_active = true;
-extern cvar_t *nostdout;
-extern bool nostdout_backup_val;
+cvar_t *nostdout = NULL;
+bool nostdout_backup_val = false;
 
 char *Sys_ConsoleInput( void )
 {
@@ -108,8 +108,13 @@ static void Sys_AnsiColorPrint( const char *msg )
 
 void Sys_ConsoleOutput( char *string )
 {
-	if( nostdout && nostdout->integer )
-		return;
+	if( Cvar_Initialized() )
+	{
+		if( !nostdout )
+			nostdout = Cvar_Get( "nostdout", "0", 0 );
+		nostdout_backup_val = nostdout && nostdout->integer;
+	}
+
 	if( nostdout_backup_val )
 		return;
 

--- a/source/unix/unix_sys.c
+++ b/source/unix/unix_sys.c
@@ -52,9 +52,6 @@ FIXME:  This will be remidied once a native Mac port is complete
 
 #if !defined(USE_SDL2) || defined(DEDICATED_ONLY)
 
-cvar_t *nostdout;
-bool nostdout_backup_val = false;
-
 unsigned sys_frame_time;
 
 uid_t saved_euid;
@@ -133,11 +130,6 @@ static void InitSig( void )
 */
 void Sys_Quit( void )
 {
-	// Qcommon_Shutdown is going destroy the cvar, so backup its value now
-	// and invalidate the pointer
-	nostdout_backup_val = (nostdout && nostdout->integer ? true : false);
-	nostdout = NULL;
-
 	fcntl( 0, F_SETFL, fcntl( 0, F_GETFL, 0 ) & ~O_NONBLOCK );
 
 	Qcommon_Shutdown();
@@ -323,12 +315,6 @@ int main( int argc, char **argv )
 	Qcommon_Init( argc, argv );
 
 	fcntl( 0, F_SETFL, fcntl( 0, F_GETFL, 0 ) | O_NONBLOCK );
-
-	nostdout = Cvar_Get( "nostdout", "0", 0 );
-	if( !nostdout->integer )
-	{
-		fcntl( 0, F_SETFL, fcntl( 0, F_GETFL, 0 ) | O_NONBLOCK );
-	}
 
 	oldtime = Sys_Milliseconds();
 	while( true )

--- a/source/win32/win_console.c
+++ b/source/win32/win_console.c
@@ -1,7 +1,8 @@
 #include "../qcommon/qcommon.h"
 #include "winquake.h"
 
-extern HANDLE hinput, houtput;
+HANDLE hinput = NULL;
+HANDLE houtput = NULL;
 
 #define MAX_CONSOLETEXT 256
 static char console_text[MAX_CONSOLETEXT];
@@ -45,6 +46,11 @@ char *Sys_ConsoleInput( void )
 
 	if( !dedicated || !dedicated->integer )
 		return NULL;
+
+	if( !hinput )
+		hinput = GetStdHandle( STD_INPUT_HANDLE );
+	if( !houtput )
+		houtput = GetStdHandle( STD_OUTPUT_HANDLE );
 
 	for(;; )
 	{
@@ -159,6 +165,9 @@ void Sys_ConsoleOutput( char *string )
 
 	if( !dedicated || !dedicated->integer )
 		return;
+
+	if( !houtput )
+		houtput = GetStdHandle( STD_OUTPUT_HANDLE );
 
 	if( console_textlen )
 	{

--- a/source/win32/win_sys.c
+++ b/source/win32/win_sys.c
@@ -44,8 +44,6 @@ int ActiveApp;
 int Minimized;
 int AppFocused;
 
-HANDLE hinput, houtput;
-
 unsigned sys_msg_time;
 unsigned sys_frame_time;
 
@@ -131,8 +129,6 @@ void Sys_Init( void )
 
 		if( !AllocConsole() )
 			Sys_Error( "Couldn't create dedicated server console" );
-		hinput = GetStdHandle( STD_INPUT_HANDLE );
-		houtput = GetStdHandle( STD_OUTPUT_HANDLE );
 
 		// let QHOST hook in
 		InitConProc( argc, argv );


### PR DESCRIPTION
Fixes #178.

There is a slight impairment compared to the old code: the nostdout cvar will only be backed up (for prints after a shutdown) when something is printed. Thus, after changing nostdout there must be a print before the shutdown, or the shutting down stuff will be printed/not printed contrary to the cvar.

Note that if the cvar system is not initialized yet I chose to always print anyway. This is mainly the loading of the pk3 files and a few other lines. The old code also did it this way.

I can't test the Windows part (nor the Mac part, but that is probably fine). I found that these HANDLE things are void pointers, so I hope this is the right way to do it.
