### PR TITLE
Find also non-solid entities in a radius

### DIFF
--- a/source/game/ai/ai_class_dmbot.cpp
+++ b/source/game/ai/ai_class_dmbot.cpp
@@ -674,7 +674,7 @@ static bool BOT_DMclass_FindRocket( edict_t *self, vec3_t away_from_rocket )
 	float min_roxx_time = 1.0f;
 	bool any_rocket = false;
 
-	numtargets = GClip_FindRadius( self->s.origin, AI_ROCKET_DETECT_RADIUS, targets, MAX_EDICTS );
+	numtargets = GClip_FindInRadius( self->s.origin, AI_ROCKET_DETECT_RADIUS, targets, MAX_EDICTS );
 	for( i = 0; i < numtargets; i++ )
 	{
 		target = game.edicts + targets[i];

--- a/source/game/g_ascript.cpp
+++ b/source/game/g_ascript.cpp
@@ -3145,7 +3145,7 @@ static CScriptArrayInterface *asFunc_G_FindInRadius( asvec3_t *org, float radius
 	asIObjectType *ot = asEntityArrayType();
 
 	int touch[MAX_EDICTS];
-	int numtouch = GClip_FindRadius( org->v, radius, touch, MAX_EDICTS );
+	int numtouch = GClip_FindInRadius( org->v, radius, touch, MAX_EDICTS );
 	CScriptArrayInterface *arr = angelExport->asCreateArrayCpp( numtouch, ot );
 	for( int i = 0; i < numtouch; i++ ) {
 		*((edict_t **)arr->At( i )) = game.edicts + touch[i];

--- a/source/game/g_clip.cpp
+++ b/source/game/g_clip.cpp
@@ -1192,8 +1192,6 @@ int GClip_FindBoxInRadius4D( vec3_t org, float rad, int *list, int maxcount, int
 		// make absolute mins and maxs
 		if( !BoundsAndSphereIntersect( check->r.absmin, check->r.absmax, org, rad ) )
 			continue;
-		if( check->s.solid == SOLID_NOT )
-			continue;
 
 		if( listnum < maxcount ) {
 			list[listnum] = touch[i];

--- a/source/game/g_clip.cpp
+++ b/source/game/g_clip.cpp
@@ -1167,10 +1167,10 @@ void G_PMoveTouchTriggers( pmove_t *pm, vec3_t previous_origin )
 }
 
 /*
-* GClip_FindBoxInRadius
+* GClip_FindInRadius4D
 * Returns entities that have their boxes within a spherical area
 */
-int GClip_FindBoxInRadius4D( vec3_t org, float rad, int *list, int maxcount, int timeDelta )
+int GClip_FindInRadius4D( vec3_t org, float rad, int *list, int maxcount, int timeDelta )
 {
 	int i, num;
 	int listnum;
@@ -1203,13 +1203,13 @@ int GClip_FindBoxInRadius4D( vec3_t org, float rad, int *list, int maxcount, int
 }
 
 /*
-* GClip_FindRadius
+* GClip_FindInRadius
 * 
-* Returns entities that have origins within a spherical area
+* Returns entities that have their boxes within a spherical area
 */
-int GClip_FindRadius( vec3_t org, float rad, int *list, int maxcount )
+int GClip_FindInRadius( vec3_t org, float rad, int *list, int maxcount )
 {
-	return GClip_FindBoxInRadius4D( org, rad, list, maxcount, 0 );
+	return GClip_FindInRadius4D( org, rad, list, maxcount, 0 );
 }
 
 void G_SplashFrac4D( int entNum, vec3_t hitpoint, float maxradius, vec3_t pushdir, 

--- a/source/game/g_combat.cpp
+++ b/source/game/g_combat.cpp
@@ -734,7 +734,7 @@ void G_RadiusDamage( edict_t *inflictor, edict_t *attacker, cplane_t *plane, edi
 	clamp_high( minknockback, maxknockback );
 	clamp_high( minstun, maxstun );
 
-	numtouch = GClip_FindBoxInRadius4D( inflictor->s.origin, radius, touch, MAX_EDICTS, inflictor->timeDelta );
+	numtouch = GClip_FindInRadius4D( inflictor->s.origin, radius, touch, MAX_EDICTS, inflictor->timeDelta );
 	for( i = 0; i < numtouch; i++ )
 	{
 		ent = game.edicts + touch[i];

--- a/source/game/g_local.h
+++ b/source/game/g_local.h
@@ -598,7 +598,6 @@ bool Add_Armor( edict_t *ent, edict_t *other, bool pick_it );
 bool KillBox( edict_t *ent );
 float LookAtKillerYAW( edict_t *self, edict_t *inflictor, edict_t *attacker );
 edict_t *G_Find( edict_t *from, size_t fieldofs, const char *match );
-edict_t *G_FindBoxInRadius( edict_t *from, edict_t *to, vec3_t org, float rad );
 edict_t *G_PickTarget( const char *targetname );
 void G_UseTargets( edict_t *ent, edict_t *activator );
 void G_SetMovedir( vec3_t angles, vec3_t movedir );
@@ -744,7 +743,7 @@ void G_Trace( trace_t *tr, vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end, e
 int G_PointContents4D( vec3_t p, int timeDelta );
 void G_Trace4D( trace_t *tr, vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end, edict_t *passedict, int contentmask, int timeDelta );
 void GClip_BackUpCollisionFrame( void );
-int GClip_FindBoxInRadius4D( vec3_t org, float rad, int *list, int maxcount, int timeDelta );
+int GClip_FindInRadius4D( vec3_t org, float rad, int *list, int maxcount, int timeDelta );
 void G_SplashFrac4D( int entNum, vec3_t hitpoint, float maxradius, vec3_t pushdir, float *kickFrac, float *dmgFrac, int timeDelta );
 void GClip_ClearWorld( void );
 void GClip_SetBrushModel( edict_t *ent, const char *name );
@@ -754,7 +753,7 @@ void GClip_UnlinkEntity( edict_t *ent );
 void GClip_TouchTriggers( edict_t *ent );
 void G_PMoveTouchTriggers( pmove_t *pm, vec3_t previous_origin );
 entity_state_t *G_GetEntityStateForDeltaTime( int entNum, int deltaTime );
-int GClip_FindRadius( vec3_t org, float rad, int *list, int maxcount );
+int GClip_FindInRadius( vec3_t org, float rad, int *list, int maxcount );
 
 //
 // g_combat.c

--- a/source/tv_server/tv_module/tvm_clip.h
+++ b/source/tv_server/tv_module/tvm_clip.h
@@ -29,7 +29,7 @@ void	G_Trace( tvm_relay_t *relay, trace_t *tr, vec3_t start, vec3_t mins, vec3_t
 int	G_PointContents4D( tvm_relay_t *relay, vec3_t p, int timeDelta );
 void	G_Trace4D( tvm_relay_t *relay, trace_t *tr, vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end, edict_t *passedict, int contentmask, int timeDelta );
 void	GClip_BackUpCollisionFrame( tvm_relay_t *relay );
-edict_t	*GClip_FindBoxInRadius4D( tvm_relay_t *relay, edict_t *from, vec3_t org, float rad, int timeDelta );
+edict_t	*GClip_FindInRadius4D( tvm_relay_t *relay, edict_t *from, vec3_t org, float rad, int timeDelta );
 #endif
 void	GClip_ClearWorld( tvm_relay_t *relay );
 void	GClip_SetBrushModel( tvm_relay_t *relay, edict_t *ent, char *name );


### PR DESCRIPTION
As shown in #303, the function that finds entities in a radius ignores non-solid entities.
I disagree that a special function should be added to do this. If non-solid entities are wanted, the results should simply be filtered.

I have gone over the current uses of these functions. In the game code, there is apart from that bot rocket detection only the radiusdamage function. This function considers from the list only entities that take damage. For players there will thus be no difference after my change: non-solid players do not have the takedamage flag. I think if some other entity is non-solid but does take damage, then it should be damaged. Otherwise, we could still change it to filter these entities there.

There are several uses of these functions in the gametype code, but in all of these cases the code only considers those entities that are non-ghosting players. Thus, there is no change here.

I have also made the function names a bit more consistent.
FindRadius was just the same as FindBoxInRadius4D, but without timedelta, so I named them FindInRadius and FindInRadius4D, respectively.

These have GClip_ prefixes. According to g_local.h there should also be a G_FindBoxInRadius function in g_utils.c, but this is not the case, so I removed that declaration.
