### PR TITLE
Fix jerky skimming behavior

### DIFF
--- a/source/gameshared/gs_pmove.c
+++ b/source/gameshared/gs_pmove.c
@@ -415,7 +415,8 @@ static int PM_SlideMove( void )
 
 	if( pm->numtouch )
 	{
-		if( pm->playerState->pmove.pm_time || ( pm->groundentity == -1 && pm->playerState->pmove.skim_time > 0 && old_velocity[2] >= pml.velocity[2] ) )
+		if( pm->playerState->pmove.pm_time || ( pm->groundentity == -1 && pm->waterlevel < 2
+					&& pm->playerState->pmove.skim_time > 0 && old_velocity[2] >= pml.velocity[2] ) )
 			VectorCopy( old_velocity, pml.velocity );
 		pm->playerState->pmove.skim_time -= pm->cmd.msec;
 		if( pm->playerState->pmove.skim_time < 0 )

--- a/source/gameshared/gs_pmove.c
+++ b/source/gameshared/gs_pmove.c
@@ -415,7 +415,7 @@ static int PM_SlideMove( void )
 
 	if( pm->numtouch )
 	{
-		if( pm->playerState->pmove.pm_time || ( pm->playerState->pmove.skim_time > 0 && old_velocity[2] >= pml.velocity[2] ) )
+		if( pm->playerState->pmove.pm_time || ( pm->groundentity == -1 && pm->playerState->pmove.skim_time > 0 && old_velocity[2] >= pml.velocity[2] ) )
 			VectorCopy( old_velocity, pml.velocity );
 		pm->playerState->pmove.skim_time -= pm->cmd.msec;
 	}

--- a/source/gameshared/gs_pmove.c
+++ b/source/gameshared/gs_pmove.c
@@ -418,6 +418,8 @@ static int PM_SlideMove( void )
 		if( pm->playerState->pmove.pm_time || ( pm->groundentity == -1 && pm->playerState->pmove.skim_time > 0 && old_velocity[2] >= pml.velocity[2] ) )
 			VectorCopy( old_velocity, pml.velocity );
 		pm->playerState->pmove.skim_time -= pm->cmd.msec;
+		if( pm->playerState->pmove.skim_time < 0 )
+			pm->playerState->pmove.skim_time = 0;
 	}
 
 	return blockedmask;


### PR DESCRIPTION
I had allowed the skimming timer to run below zero, but it is sent over the network as a byte. This caused prediction misses.

The patch additionally makes sure skimming does not set in while walking or swimming.
