### PR TITLE
Allow CROUCH animation while model is in the AIR

### DIFF
--- a/source/gameshared/gs_players.c
+++ b/source/gameshared/gs_players.c
@@ -94,10 +94,6 @@ static void GS_SetBaseAnimLower( pm_anim_t *pmanim ) {
 			pmanim->animState[LOWER] = LEGS_SWIM_NEUTRAL;
 		}
 	}
-	//FALLING
-	else if( pmanim->moveflags & ANIMMOVE_AIR ) {
-		pmanim->animState[LOWER] = LEGS_JUMP_NEUTRAL;
-	}
 	//CROUCH
 	else if( pmanim->moveflags & ANIMMOVE_DUCK ) {
 		if( pmanim->moveflags & ( ANIMMOVE_WALK | ANIMMOVE_RUN ) ) {
@@ -105,6 +101,10 @@ static void GS_SetBaseAnimLower( pm_anim_t *pmanim ) {
 		} else {
 			pmanim->animState[LOWER] = LEGS_CROUCH_IDLE;
 		}
+	}
+	//FALLING
+	else if( pmanim->moveflags & ANIMMOVE_AIR ) {
+		pmanim->animState[LOWER] = LEGS_JUMP_NEUTRAL;
 	}
 	// RUN
 	else if( pmanim->moveflags & ANIMMOVE_RUN ) {


### PR DESCRIPTION
Before there was no CROUCH animation while model was in the AIR/FALLING.
Now CROUCHing is shown even in the AIR (but not while jumping):
https://youtu.be/mmSu8av-S_k