### PR TITLE
Remove unused define of S_GIBS_EXPLOSION

### DIFF
--- a/source/gameshared/gs_qrespath.h
+++ b/source/gameshared/gs_qrespath.h
@@ -263,7 +263,6 @@ extern "C" {
 #define S_CHAT          "sounds/misc/chat"
 #define S_TIMER_BIP_BIP     "sounds/misc/timer_bip_bip"
 #define S_TIMER_PLOINK      "sounds/misc/timer_ploink"
-#define S_GIBS_EXPLOSION    "sounds/misc/gibs_explosion"
 
 //wsw: pb disable unreferenced sounds
 //#define S_LAND					"sounds/misc/land"


### PR DESCRIPTION
That define was obsolete since this commit https://github.com/Qfusion/qfusion/commit/d4d43cc0548faf454eb9b5cfa85288c3139f0a1b