### PR TITLE
Add and use Pmove() hints for bot movement prediction

### DIFF
--- a/source/game/ai/bot.cpp
+++ b/source/game/ai/bot.cpp
@@ -82,6 +82,8 @@ Bot::Bot( edict_t *self_, float skillLevel_ )
 	lastChosenLostOrHiddenEnemy( nullptr ),
 	lastChosenLostOrHiddenEnemyInstanceId( 0 ) {
 	self->r.client->movestyle = GS_CLASSICBUNNY;
+	// Enable skimming for bots (since it is useful and should not be noticed from a 3rd person POV).
+	self->r.client->ps.pmove.stats[PM_STAT_FEATURES] &= PMFEAT_CORNERSKIMMING;
 	SetTag( self->r.client->netname );
 }
 

--- a/source/game/ai/bot_movement.cpp
+++ b/source/game/ai/bot_movement.cpp
@@ -472,6 +472,10 @@ static void Intercepted_Trace( trace_t *t, vec3_t start, vec3_t mins, vec3_t max
 	trap_CM_TransformedBoxTrace( t, start, end, mins, maxs, nullptr, contentmask, nullptr, nullptr );
 }
 
+static int Intercepted_PointContents( vec3_t p, int timeDelta ) {
+	return trap_CM_TransformedPointContents( p, nullptr, nullptr, nullptr );
+}
+
 void BotMovementPredictionContext::OnInterceptedPredictedEvent( int ev, int parm ) {
 	switch( ev ) {
 		case EV_JUMP:
@@ -1113,10 +1117,17 @@ void BotMovementPredictionContext::NextMovementStep() {
 	auto oldModuleTrace = module_Trace;
 	module_Trace = Intercepted_Trace;
 
+	// Do not test entities contents for same reasons
+	// Save the G_PointContents4D() pointer
+	auto oldModulePointContents = module_PointContents;
+	module_PointContents = Intercepted_PointContents;
+
 	Pmove( &pm );
 
 	// Restore the G_GS_Trace() pointer
 	module_Trace = oldModuleTrace;
+	// Restore the G_PointContents4D() pointer
+	module_PointContents = oldModulePointContents;
 
 	// Update the entity physics state that is going to be used in the next prediction frame
 	entityPhysicsState->UpdateFromPMove( &pm );

--- a/source/game/ai/bot_movement.cpp
+++ b/source/game/ai/bot_movement.cpp
@@ -1462,6 +1462,10 @@ inline unsigned BotBaseMovementAction::SequenceDuration( const BotMovementPredic
 // Height threshold should be set according to used time step
 // (we might miss crouch sliding activation if its low and the time step is large)
 inline bool ShouldPrepareForCrouchSliding( BotMovementPredictionContext *context, float heightThreshold = 12.0f ) {
+	if( !(context->currPlayerState->pmove.stats[PM_STAT_FEATURES ] & PMFEAT_CROUCHSLIDING ) ) {
+		return false;
+	}
+
 	const auto &entityPhysicsState = context->movementState->entityPhysicsState;
 	if( entityPhysicsState.GroundEntity() ) {
 		return false;
@@ -1612,6 +1616,10 @@ bool BotDummyMovementAction::HandleClimbJumpReachability( BotMovementPredictionC
 }
 
 bool BotDummyMovementAction::ShouldCrouchSlideNow( BotMovementPredictionContext *context ) const {
+	if( !( context->currPlayerState->pmove.stats[PM_STAT_FEATURES] & PMFEAT_CROUCHSLIDING ) ) {
+		return false;
+	}
+
 	if( context->currPlayerState->pmove.pm_flags & PMF_CROUCH_SLIDING ) {
 		if( context->currPlayerState->pmove.stats[PM_STAT_CROUCHSLIDETIME] > PM_CROUCHSLIDE_FADE ) {
 			return true;

--- a/source/game/ai/bot_movement.h
+++ b/source/game/ai/bot_movement.h
@@ -654,6 +654,7 @@ private:
 	TraceResult results[16];
 	unsigned resultsMask;
 	bool didAreaTest;
+	bool hasNoFullHeightObstaclesAround;
 
 	template <typename T>
 	static inline void Assert( T condition ) {
@@ -740,9 +741,11 @@ public:
 		return ResultForIndex( JumpableHeightMask( BACK_RIGHT ), 15 );
 	}
 
-	inline BotEnvironmentTraceCache() : resultsMask( 0 ), didAreaTest( false ) {}
+	inline BotEnvironmentTraceCache() : resultsMask( 0 ), didAreaTest( false ), hasNoFullHeightObstaclesAround( false ) {}
 
 	void TestForResultsMask( class BotMovementPredictionContext *context, unsigned requiredResultsMask );
+
+	bool CanSkipPMoveCollision( class BotMovementPredictionContext *context );
 
 	inline ObstacleAvoidanceResult TryAvoidJumpableObstacles( class BotMovementPredictionContext *context,
 																  Vec3 *intendedLookVec, float correctionFraction ) {

--- a/source/gameshared/q_comref.h
+++ b/source/gameshared/q_comref.h
@@ -465,6 +465,9 @@ typedef struct {
 	// command (in)
 	usercmd_t cmd;
 
+	// A hint (in)
+	bool skipCollision;
+
 	// results (out)
 	int numtouch;
 	int touchents[MAXTOUCH];
@@ -473,10 +476,15 @@ typedef struct {
 	vec3_t mins, maxs;          // bounding box size
 
 	int groundentity;
+	cplane_t groundplane;       // valid if groundentity >= 0
+	int groundsurfFlags;        // valid if groundentity >= 0
+	int groundcontents;         // valid if groundentity >= 0
 	int watertype;
 	int waterlevel;
 
 	int contentmask;
+
+	bool ladder;
 } pmove_t;
 
 


### PR DESCRIPTION
This is the first of the promised improvement patches to the merged bot code.

1) Bot movement code has been made aware of `PMFEAT_CROUCHSLIDING`. I have forced skimming for bot clients though (it is useful for bot movement and should not have been noticed from a 3rd person POV, bot movement is hacked anyway if one spectates a bot).

2) I have added Pmove() hints to skip collision tests in bot movement prediction if there is no obstacles around (Here http://webmshare.com/m8OOG is the old video showing a-priori obstacle testing results). The naive solution of setting `module_Trace` in this case to a dummy routine that fills a trace by zero and sets fraction = 1 does not work (it has been tested and rejected). One has to add this flag and several condition tests in `Pmove()` for each `module_Trace()` use. 

3) Test only contents of solid world in bot movement prediction.

4) Add some extra output fields filled by `Pmove()` call for future bot development. (Like ground normal/contents/surface flags to determine whether a bot is on a ramp/on an ice without additional sampling overhead).

The speedup exists but is not easy to measure since it is situational (depends of what actually bots do). I tried to look at a sustained value of Load Average while running a dedicated server with 40 bots playing FFA at wbomb1 to produce a measurable CPU load (about 50%). The speedup is around 20-25%. While the performance is quite good even before these changes, running a listen server with a huge number of bots having set a high `cl_maxfps` value demands an extra speedup. Thats why these changes are proposed.