### PR TITLE
Avoid triggering coverity on some parts of AI code

### DIFF
--- a/source/game/ai/ai_manager.cpp
+++ b/source/game/ai/ai_manager.cpp
@@ -76,6 +76,7 @@ AiManager::AiManager( const char *gametype, const char *mapname )
 	REGISTER_BUILTIN_GOAL( BotReactToThreatGoal );
 	REGISTER_BUILTIN_GOAL( BotReactToEnemyLostGoal );
 	REGISTER_BUILTIN_GOAL( BotAttackOutOfDespairGoal );
+	REGISTER_BUILTIN_GOAL( BotRoamGoal );
 
 	// Do not clear built-in goals later
 	registeredGoals.MarkClearLimit();

--- a/source/game/ai/bot.cpp
+++ b/source/game/ai/bot.cpp
@@ -274,7 +274,10 @@ void Bot::UpdateKeptInFovPoint() {
 
 		Vec3 origin( lostOrHiddenEnemy->LastSeenPosition() );
 		if( !GetMiscTactics().shouldKeepXhairOnEnemy ) {
-			float distanceThreshold = ( !selectedEnemies.HaveQuad() && !selectedEnemies.HaveCarrier() ) ? 768 : 2048;
+			float distanceThreshold = 768.0f;
+			if( lostOrHiddenEnemy->ent && lostOrHiddenEnemy->ent->s.effects & ( EF_QUAD | EF_CARRIER ) ) {
+				distanceThreshold = 2048.0f;
+			}
 			if( origin.SquareDistanceTo( self->s.origin ) > distanceThreshold * distanceThreshold ) {
 				lastChosenLostOrHiddenEnemy = nullptr;
 				return;

--- a/source/game/ai/bot_fire.cpp
+++ b/source/game/ai/bot_fire.cpp
@@ -90,12 +90,14 @@ void Bot::FireWeapon( BotInput *input ) {
 	AimParams *aimParams;
 	if( selectedWeapons.PreferBuiltinWeapon() ) {
 		aimParams = &builtinWeaponAimParams;
+		assert( builtinFireDef );
 		primaryFireDef = builtinFireDef;
 		if( scriptFireDef ) {
 			secondaryFireDef = scriptFireDef;
 		}
 	} else {
 		aimParams = &scriptWeaponAimParams;
+		assert( scriptFireDef );
 		primaryFireDef = scriptFireDef;
 		if( builtinFireDef ) {
 			secondaryFireDef = builtinFireDef;

--- a/source/game/ai/bot_goals.h
+++ b/source/game/ai/bot_goals.h
@@ -58,7 +58,9 @@ class BotAttackOutOfDespairGoal : public BotBaseGoal
 	float oldOffensiveness;
 
 public:
-	BotAttackOutOfDespairGoal( Ai *ai_ ) : BotBaseGoal( ai_, "BotAttackOutOfDespairGoal", 400 ) {}
+	BotAttackOutOfDespairGoal( Ai *ai_ )
+		: BotBaseGoal( ai_, "BotAttackOutOfDespairGoal", 400 ),
+		oldOffensiveness( 1.0f ) {}
 
 	void UpdateWeight( const WorldState &currWorldState ) override;
 	void GetDesiredWorldState( WorldState *worldState ) override;

--- a/source/game/ai/bot_movement.cpp
+++ b/source/game/ai/bot_movement.cpp
@@ -1957,8 +1957,8 @@ void BotRidePlatformMovementAction::TrySaveExitAreas( BotMovementPredictionConte
 	for( unsigned i = 1, end = savedAreas.size(); i < end; ++i ) {
 		int area = savedAreas[i];
 		int travelTime = areaTravelTimes[i];
-		unsigned j = i - 1;
-		for(; j < std::numeric_limits<unsigned>::max() && areaTravelTimes[j] < travelTime; --j ) {
+		int j = i - 1;
+		for(; j >= 0 && areaTravelTimes[j] < travelTime; j-- ) {
 			savedAreas[j + 1] = savedAreas[j];
 			areaTravelTimes[j + 1] = areaTravelTimes[j];
 		}
@@ -3245,7 +3245,7 @@ void BotBunnyStraighteningReachChainMovementAction::SaveSuggestedLookDirs( BotMo
 	const AiAasWorld *aasWorld = AiAasWorld::Instance();
 	const aas_reachability_t *aasReachabilities = aasWorld->Reachabilities();
 
-	unsigned lastValidReachIndex = std::numeric_limits<unsigned>::max();
+	int lastValidReachIndex = -1;
 	constexpr unsigned MAX_TESTED_REACHABILITIES = 16U;
 	const unsigned maxTestedReachabilities = std::min( MAX_TESTED_REACHABILITIES, nextReachChain.size() );
 	const aas_reachability_t *reachStoppedAt = nullptr;
@@ -3258,18 +3258,17 @@ void BotBunnyStraighteningReachChainMovementAction::SaveSuggestedLookDirs( BotMo
 			}
 		}
 
-		// Wraps on the first increment
 		lastValidReachIndex++;
 	}
 
-	if( lastValidReachIndex > maxTestedReachabilities ) {
+	if( lastValidReachIndex < 0 || lastValidReachIndex >= maxTestedReachabilities ) {
 		Debug( "There were no supported for bunnying reachabilities\n" );
 		return;
 	}
 	Assert( lastValidReachIndex < maxTestedReachabilities );
 
 	AreaAndScore candidates[MAX_TESTED_REACHABILITIES];
-	AreaAndScore *candidatesEnd = SelectCandidateAreas( context, candidates, lastValidReachIndex );
+	AreaAndScore *candidatesEnd = SelectCandidateAreas( context, candidates, (unsigned)lastValidReachIndex );
 
 	SaveCandidateAreaDirs( context, candidates, candidatesEnd );
 

--- a/source/game/ai/bot_weapon_selector.cpp
+++ b/source/game/ai/bot_weapon_selector.cpp
@@ -1157,11 +1157,9 @@ int BotWeaponSelector::SuggestQuadBearerWeapon( const WorldState &worldState ) {
 	auto lgRange = ( lgDef->firedef.timeout + lgDef->firedef_weak.timeout ) / 2.0f;
 	int lasersCount = 0;
 	if( Inventory()[WEAP_LASERGUN] && distance < lgRange ) {
-		if( ( lgDef->firedef.timeout + lgDef->firedef_weak.timeout ) / 2 < distance ) {
-			lasersCount = Inventory()[AMMO_LASERS] + Inventory()[AMMO_WEAK_LASERS];
-			if( lasersCount > 7 ) {
-				return WEAP_LASERGUN;
-			}
+		lasersCount = Inventory()[AMMO_LASERS] + Inventory()[AMMO_WEAK_LASERS];
+		if( lasersCount > 7 ) {
+			return WEAP_LASERGUN;
 		}
 	}
 	int bulletsCount = BulletsReadyToFireCount();

--- a/source/game/ai/bot_weapon_selector.h
+++ b/source/game/ai/bot_weapon_selector.h
@@ -16,7 +16,7 @@ class GenericFireDef
 	short weaponNum;
 	bool isBuiltin;
 
-	GenericFireDef() {}
+	GenericFireDef() = default;
 
 public:
 	GenericFireDef( int weaponNum_, const firedef_t *builtinFireDef ) {
@@ -107,7 +107,11 @@ class SelectedEnemies
 #endif
 	}
 
-	SelectedEnemies( const edict_t *self_ ) : self( self_ ) {}
+	explicit SelectedEnemies( const edict_t *self_ )
+		: self( self_ ),
+        primaryEnemy( nullptr ),
+        timeoutAt( 0 ),
+        instanceId( 0 ) {}
 
 public:
 	bool AreValid() const;

--- a/source/game/ai/tactical_spots_registry.cpp
+++ b/source/game/ai/tactical_spots_registry.cpp
@@ -1231,7 +1231,7 @@ void TacticalSpotsRegistry::SortByVisAndOtherFactors( const OriginParams &origin
 		float score = result[i].score;
 
 		// The maximum possible visibility score for a pair of spots is 255
-		float visFactor = visibilitySum / ( ( result.size() - 1 ) * 255 );
+		float visFactor = visibilitySum / ( ( result.size() - 1 ) * 255.0f );
 		visFactor = 1.0f / Q_RSqrt( visFactor );
 		score *= visFactor;
 


### PR DESCRIPTION
I'm not sure about completeness of the fix, since I do not have an access to the actual updated reports.

All warnings you have posted might be split in 4 parts:

1) `"rand" should not be used for security related applications`. These warnings are obviously false positives in relation to the bot code. Also I'm not even sure how to suppress ones.

2) `Uninitialized members (UNINIT_CTOR)`. These members are really initialized before first use, e.g. for each movement action additional fields are (re)set to default values in `OnBeforePlanning()` calls. I have modified constructors in these cases to shut up the analyzer.

3) `Incorrect expression (UNINTENDED_INTEGER_DIVISION)`. These warnings have spotted real glitches and have been fixed.

4) Miscellanea. Here is the list of the rest with comments for each warning:

```
*** CID 172317:  Incorrect expression  (IDENTICAL_BRANCHES)
/game/ai/bot_movement.cpp: 33 in BotMovementPredictionContext::GetRunSpeed() const()
27
28     inline float BotMovementPredictionContext::GetDashSpeed() const {
29      return GetPMoveStatValue( this->currPlayerState, PM_STAT_DASHSPEED, DEFAULT_DASHSPEED );
30     }
31
32     inline float BotMovementPredictionContext::GetRunSpeed() const {
>>>     CID 172317:  Incorrect expression  (IDENTICAL_BRANCHES)
>>>     Ternary expression on condition "(gs.gameState.stats[GAMESTAT_FLAGS] & 4L) ? true : false" has identical then and else expressions: "320f". Should one of the expressions be modified, or the entire ternary expression replaced?
33      return GetPMoveStatValue( this->currPlayerState, PM_STAT_MAXSPEED, DEFAULT_PLAYERSPEED );
34     }
35
36     inline Vec3 BotMovementPredictionContext::NavTargetOrigin() const {
37      return self->ai->botRef->NavTargetOrigin();
38 }
```

The `GetPMoveStatValue()` call definition  
```
inline float GetPMoveStatValue( const player_state_t *playerState, int statIndex, float defaultValue ) {
	float value = playerState->pmove.stats[statIndex];
	// Put likely case (the value is not specified) first
	return value < 0 ? defaultValue : value;
}
```

expands to something like 
```
inline float BotMovementPredictionContext::GetRunSpeed() const {
        float value = this->currPlayerState->pmove.stats[PM_STAT_MAXSPEED];
        return value < 0 ? DEFAULT_PLAYERSPEED : value;
}
```

in this case, and these numeric macros used in the expansion are just numeric constants. I'm not sure what is the warning about.

==============================================================================

```
** CID 172309:    (FORWARD_NULL)
/game/ai/bot_fire.cpp: 93 in Bot::FireWeapon(BotInput *)()
/game/ai/bot_fire.cpp: 93 in Bot::FireWeapon(BotInput *)()
/game/ai/bot_fire.cpp: 99 in Bot::FireWeapon(BotInput *)()
/game/ai/bot_fire.cpp: 99 in Bot::FireWeapon(BotInput *)() 
```

The analyzer is unaware of the `PreferBuiltinWeapon()` condition that puts nullity limitations on `builtinFireDef`, `scriptFireDef`. I'm not sure if putting assertions as below on these values mitigates this warning.
```
        const GenericFireDef *primaryFireDef = nullptr;
	const GenericFireDef *secondaryFireDef = nullptr;
	AimParams *aimParams;
	if( selectedWeapons.PreferBuiltinWeapon() ) {
		aimParams = &builtinWeaponAimParams;
		assert( builtinFireDef );
		primaryFireDef = builtinFireDef;
		if( scriptFireDef ) {
			secondaryFireDef = scriptFireDef;
		}
	} else {
		aimParams = &scriptWeaponAimParams;
		assert( scriptFireDef );
		primaryFireDef = scriptFireDef;
		if( builtinFireDef ) {
			secondaryFireDef = builtinFireDef;
		}
	}
```

==============================================================================

```
*** CID 172304:  Memory - illegal accesses  (OVERRUN)
/game/ai/bot_movement.cpp: 1961 in BotRidePlatformMovementAction::TrySaveExitAreas(BotMovementPredictionContext *, const edict_s *)()
1955
1956            // Sort areas
1957            for( unsigned i = 1, end = savedAreas.size(); i < end; ++i ) {
1958                    int area = savedAreas[i];
1959                    int travelTime = areaTravelTimes[i];
1960                    unsigned j = i - 1;
>>>     CID 172304:  Memory - illegal accesses  (OVERRUN)
>>>     Overrunning array "areaTravelTimes" of 16 4-byte elements at element index 4294967294 (byte offset 17179869176) using index "j" (which evaluates to 4294967294).
1961                    for(; j < std::numeric_limits<unsigned>::max() && areaTravelTimes[j] < travelTime; --j ) {
1962                            savedAreas[j + 1] = savedAreas[j];
1963                            areaTravelTimes[j + 1] = areaTravelTimes[j];
1964 }

```

It's not a bug (the array cannot be accessed by this huge index since there is a shortcut in conditions evaluations). I relied on unsinged wrapping in this case (0 unsigned value becomes the max value after a decrement). I agree it is not clear, I used unsigned here to avoid signed/unsinged mismatch. The loop has been rewritten using a singed integer.

==============================================================================
```
*** CID 172300:  Incorrect expression  (DIVIDE_BY_ZERO)
/game/ai/bot_movement.cpp: 3262 in BotBunnyStraighteningReachChainMovementAction::SaveSuggestedLookDirs(BotMovementPredictionContext *)()
3256                                    reachStoppedAt = &reach;
3257                                    break;
3258                            }
3259                    }
3260
3261                    // Wraps on the first increment
>>>     CID 172300:  Incorrect expression  (DIVIDE_BY_ZERO)
>>>     Incrementing "lastValidReachIndex". The value of "lastValidReachIndex" is now 0.
3262                    lastValidReachIndex++;
3263            }
3264
3265            if( lastValidReachIndex > maxTestedReachabilities ) {
3266                    Debug( "There were no supported for bunnying reachabilities\n" );
3267 return;
```

This is almost the same as the case above. I have rewritten it using signed integers too.