### PR TITLE
Add more fixes of coverity issues found in AI code

### DIFF
--- a/source/game/ai/bot_movement.h
+++ b/source/game/ai/bot_movement.h
@@ -13,7 +13,7 @@ class alignas ( 2 )AiCampingSpot
 	short lookAtPoint[3];
 	unsigned char radius;
 	unsigned char alertness : 7;
-	AiCampingSpot() = default;
+	AiCampingSpot() : radius( 32 ), alertness( 127 ), hasLookAtPoint( false ) {}
 
 public:
 	bool hasLookAtPoint : 1;

--- a/source/game/ai/bot_weapon_selector.h
+++ b/source/game/ai/bot_weapon_selector.h
@@ -16,7 +16,12 @@ class GenericFireDef
 	short weaponNum;
 	bool isBuiltin;
 
-	GenericFireDef() = default;
+	GenericFireDef()
+		: projectileSpeed( 0 ),
+		splashRadius( 0 ),
+		aimType( AI_WEAPON_AIM_TYPE_INSTANT_HIT ),
+		weaponNum( -1 ),
+		isBuiltin( false ) {}
 
 public:
 	GenericFireDef( int weaponNum_, const firedef_t *builtinFireDef ) {


### PR DESCRIPTION
Yes, it's mine fault. Fields still were remaining uninitialized in this kind of definition

```
Constructor() = default;
```

Although as I said uninitialized memory is not really accessed (the analyzer cannot follow the entire control flow).