### PR TITLE
Improve bot input inversion

### DIFF
--- a/source/game/ai/bot.h
+++ b/source/game/ai/bot.h
@@ -471,6 +471,10 @@ public:
 	};
 
 	KeptInFovPoint keptInFovPoint;
+	int64_t nextRotateInputAttemptAt;
+	int64_t inputRotationBlockingTimer;
+	int64_t lastInputRotationFailureAt;
+
 	const Enemy *lastChosenLostOrHiddenEnemy;
 	unsigned lastChosenLostOrHiddenEnemyInstanceId;
 
@@ -495,8 +499,13 @@ public:
 
 	void ApplyPendingTurnToLookAtPoint( BotInput *input, BotMovementPredictionContext *context = nullptr ) const;
 	void ApplyInput( BotInput *input, BotMovementPredictionContext *context = nullptr );
-	bool CheckInputInversion( BotInput *input, BotMovementPredictionContext *context = nullptr );
-	inline void InvertKeys( BotInput *input, BotMovementPredictionContext *context = nullptr );
+
+	void CheckBlockingDueToInputRotation();
+
+	inline void InvertInput( BotInput *input, BotMovementPredictionContext *context = nullptr );
+	inline void TurnInputToSide( vec3_t sideDir, int sign, BotInput *input, BotMovementPredictionContext *context = nullptr );
+
+	inline bool TryRotateInput( BotInput *input, BotMovementPredictionContext *context = nullptr );
 
 	// Returns true if current look angle worth pressing attack
 	bool CheckShot( const AimParams &aimParams, const BotInput *input,


### PR DESCRIPTION
There is a description of introduced changes in the extended commit message. An "input inversion" has already existed for a long time (was coded a year ago and re-introduced just before the last major merge). There is a "kept in fov point" set and updated by bot logic (introduced recently). In order to keep the point in fov the bot can fully invert input or move sideways (a side movement has been just introduced). The "kept in fov point" is currently set to an actual/potential enemy origin. https://webmshare.com/DxQ5j. The "kept in fov" point usage is planned to be extended (e.g. its a good idea to keep in fov an origin of an incoming damage), thats why better quality of input inversion/rotation is required.