### PR TITLE
Fix builtin entity brushes bounds

### DIFF
--- a/source/qcommon/cm_local.h
+++ b/source/qcommon/cm_local.h
@@ -132,6 +132,7 @@ struct cmodel_state_s {
 	cmodel_t map_cmodel_empty;
 	cmodel_t *map_cmodels;          // = &map_cmodel_empty;
 	vec3_t world_mins, world_maxs;
+	vec3_t entity_brush_mins, entity_brush_maxs; // oct/box builtin brushes bounds
 
 	int numbrushes;
 	cbrush_t *map_brushes;

--- a/source/qcommon/cm_q3bsp.c
+++ b/source/qcommon/cm_q3bsp.c
@@ -558,6 +558,7 @@ static void CMod_LoadNodes( cmodel_state_t *cms, lump_t *l ) {
 	int count;
 	dnode_t *in;
 	cnode_t *out;
+	vec_t maxside;
 
 	in = ( void * )( cms->cmod_base + l->fileofs );
 	if( l->filelen % sizeof( *in ) ) {
@@ -575,6 +576,18 @@ static void CMod_LoadNodes( cmodel_state_t *cms, lump_t *l ) {
 		cms->world_mins[i] = LittleFloat( in->mins[i] );
 		cms->world_maxs[i] = LittleFloat( in->maxs[i] );
 	}
+
+	// Compute extended bounds for builtin box/oct brushes
+	// to avoid rejection by bounds checking in CM_CollideBox()
+	maxside = 0.0f;
+	for( i = 0; i < 3; i++ ) {
+		maxside = max( maxside, fabsf( cms->world_mins[i] ) );
+		maxside = max( maxside, fabsf( cms->world_maxs[i] ) );
+	}
+
+	maxside += 1.0f;
+	VectorSet( cms->entity_brush_mins, -maxside, -maxside, -maxside );
+	VectorSet( cms->entity_brush_maxs, +maxside, +maxside, +maxside );
 
 	for( i = 0; i < count; i++, out++, in++ ) {
 		out->plane = cms->map_planes + LittleLong( in->planenum );

--- a/source/qcommon/cm_trace.c
+++ b/source/qcommon/cm_trace.c
@@ -37,8 +37,8 @@ void CM_InitBoxHull( cmodel_state_t *cms ) {
 	cms->box_brush->brushsides = cms->box_brushsides;
 	cms->box_brush->contents = CONTENTS_BODY;
 	// Make sure CM_CollideBox() will not reject the brush by its bounds
-	VectorCopy( cms->world_mins, cms->box_brush->mins );
-	VectorCopy( cms->world_maxs, cms->box_brush->maxs );
+	VectorCopy( cms->entity_brush_mins, cms->box_brush->mins );
+	VectorCopy( cms->entity_brush_maxs, cms->box_brush->maxs );
 
 	cms->box_markbrushes[0] = cms->box_brush;
 
@@ -91,8 +91,8 @@ void CM_InitOctagonHull( cmodel_state_t *cms ) {
 	cms->oct_brush->brushsides = cms->oct_brushsides;
 	cms->oct_brush->contents = CONTENTS_BODY;
 	// Make sure CM_CollideBox() will not reject the brush by its bounds
-	VectorCopy( cms->world_mins, cms->oct_brush->mins );
-	VectorCopy( cms->world_maxs, cms->oct_brush->maxs );
+	VectorCopy( cms->entity_brush_mins, cms->oct_brush->mins );
+	VectorCopy( cms->entity_brush_maxs, cms->oct_brush->maxs );
 
 	cms->oct_markbrushes[0] = cms->oct_brush;
 


### PR DESCRIPTION
While `cms->world_mins`, `cms->world_maxs` values seem to be valid to the time of these calls (as the CM initialization calls order points. Also I have printed these values to console for various maps), they are not really sufficient leading to weapons malfunction on regular DM maps. This glitch has not been noticed because I have been using only bomb maps for bots testing during recent months of development. You have suggested using «world bounds» instead of introducing huge numeric constants in discussion about the CM patch merging. In order to avoid introduction of ones I rely on `ClearBounds()` call for obtaining some huge components magnitude.