### PR TITLE
Fix few AI assertions revealed

### DIFF
--- a/source/game/ai/bot_movement.cpp
+++ b/source/game/ai/bot_movement.cpp
@@ -1307,7 +1307,7 @@ inline void BotBaseMovementAction::Assert( bool condition, const char *message )
 #ifdef ENABLE_MOVEMENT_ASSERTIONS
 	if( !condition ) {
 		if( message ) {
-			AI_FailWith("BotBaseMovementAction::Assert()", "An assertion has failed\n", message );
+			AI_FailWith("BotBaseMovementAction::Assert()", "An assertion has failed: %s\n", message );
 		} else {
 			AI_FailWith("BotBaseMovementAction::Assert()", "An assertion has failed\n");
 		}
@@ -1743,7 +1743,7 @@ void BotDummyMovementAction::PlanPredictionStep( BotMovementPredictionContext *c
 				if( entityPhysicsState.Speed2D() > context->GetRunSpeed() ) {
 					// If there is a substantial 2D speed, looks like the bot is jumping over a gap
 					Vec3 intendedLookDir( entityPhysicsState.Velocity() );
-					intendedLookDir *= 1.0f / entityPhysicsState.Speed2D();
+					intendedLookDir *= 1.0f / entityPhysicsState.Speed();
 					botInput->SetIntendedLookDir( intendedLookDir, true );
 				} else {
 					// Force falling down

--- a/source/game/ai/bot_movement.h
+++ b/source/game/ai/bot_movement.h
@@ -205,11 +205,6 @@ public:
 	}
 
 	inline const Vec3 &AlreadyComputedAngles() const {
-#ifndef PUBLIC_BUILD
-		if( !hasAlreadyComputedAngles ) {
-			AI_FailWith( "BotInput::AlreadyComputedAngles()", "The angles have not been computed yet\n" );
-		}
-#endif
 		return alreadyComputedAngles;
 	}
 
@@ -231,11 +226,6 @@ public:
 	}
 
 	inline const Vec3 &IntendedLookDir() const {
-#ifndef PUBLIC_BUILD
-		if( isLookDirSet ) {
-			AI_FailWith( "BotInput::IntendedLookDir()", "The intended look dir has not been set yet\n" );
-		}
-#endif
 		return intendedLookDir;
 	}
 };


### PR DESCRIPTION
1) I tbh rarely tested non-PUBLIC builds because they spam a lot in the console. Access to these fields is perfectly valid and is usually performed in combat when the "keep xhair on enemy flag" is set (a movement action does not set the "intended look dir" intentionally in this case"). These fields are overwritten by values required for crosshair tracking in this case. Another assertion on normalization is kept as being useful, and a minor glitch confusing `speed` and `speed2D` has been revealed and fixed.
I have tested the `rekt` gametype for half of a hour on various maps and has not managed to trigger any assertion anymore.

2) There is another branch https://github.com/dnk777/qfusion/tree/ai-major-patch-1 that is compatible with the current repo and fixes some long-term issues I have used to turn blind eyes on thinking it's a goal jitter, namely loops in default AAS-driven movement that occur even at 100ups walking. A new almost mathematically proven approach is proposed and implemented showing great results (https://webmshare.com/AdoQd, pink lines are drawn if the newly introduced kind of movement action is activated), but it should be extracted in a separated patch along with recommended AAS subsystem improvement (floor and stairs floodfill clusters should be precomputed at start).