### PR TITLE
Address movement assertions reported in #408

### DIFF
--- a/source/game/ai/bot_movement.h
+++ b/source/game/ai/bot_movement.h
@@ -1437,12 +1437,12 @@ public:
 	}
 
 	inline void MarkAsVisited( int areaNum ) {
-		assert( (unsigned)areaNum < AiAasWorld::Instance()->NumAreas() );
+		assert( areaNum < AiAasWorld::Instance()->NumAreas() );
 		millisSinceLastVisited[areaNum] = 0;
 	}
 
 	inline unsigned MillisSinceLastVisited( int areaNum ) const {
-		assert( (unsigned)areaNum < AiAasWorld::Instance()->NumAreas() );
+		assert( areaNum < AiAasWorld::Instance()->NumAreas() );
 		return millisSinceLastVisited[areaNum];
 	}
 


### PR DESCRIPTION
The patch has been tested by playing rekt using (no-public + debug + address-sanitizer) build on various maps (including wda5). I'm unsure though has the planner malfunction on MSVC been fixed by the previous PR.

The jumppad issue is still questionable as I have never managed to catch it triggered during the entire bot development (make sure please you use an AAS file produced by the BSPC version i have linked).