### PR TITLE
Re-add blocking areas(regions) by enemies

### DIFF
--- a/source/game/ai/ai_aas_route_cache.h
+++ b/source/game/ai/ai_aas_route_cache.h
@@ -444,8 +444,12 @@ public:
 		return false;
 	}
 
-	inline bool AreaDisabled( int areaNum ) {
+	inline bool AreaDisabled( int areaNum ) const {
 		return areasDisabledStatus[areaNum].CurrStatus() || ( aasWorld.AreaSettings()[areaNum].areaflags & AREA_DISABLED );
+	}
+
+	inline bool AreaTemporarilyDisabled( int areaNum ) const {
+		return areasDisabledStatus[areaNum].CurrStatus();
 	}
 
 	struct DisableZoneRequest {

--- a/source/game/ai/ai_aas_world.h
+++ b/source/game/ai/ai_aas_world.h
@@ -259,6 +259,9 @@ class AiAasWorld
 
 	int *face2DProjVertexNums;     // Elements #i*2, #i*2+1 contain numbers of vertices of a 2d face proj for face #i
 
+	int *areaMapLeafListOffsets;    // An element #i contains an offset of leafs list data in the joint data
+	int *areaMapLeafsData;          // Contains area map (collision/vis) leafs lists, each one is prepended by the length
+
 	static AiAasWorld *instance;
 
 	AiAasWorld() {
@@ -283,6 +286,8 @@ class AiAasWorld
 	void ComputeLogicalAreaClusters();
     // Computes vertices of top 2D face projections
 	void ComputeFace2DProjVertices();
+	// Computes map (collision/vis) leafs for areas
+	void ComputeAreasLeafsLists();
 
 	void TrySetAreaLedgeFlags( int areaNum );
 	void TrySetAreaWallFlags( int areaNum );
@@ -462,6 +467,11 @@ public:
 	}
 
 	inline int *Face2DProjVertexNums() const { return face2DProjVertexNums; }
+
+	inline const int *AreaMapLeafsList( int areaNum ) const {
+		assert( areaNum >= 0 && areaNum < numareas );
+		return areaMapLeafsData + areaMapLeafListOffsets[areaNum];
+	}
 };
 
 #endif

--- a/source/game/ai/ai_local.h
+++ b/source/game/ai/ai_local.h
@@ -279,4 +279,20 @@ public:
 	const T *end() const { return end_; }
 };
 
+// This is a compact storage for 64-bit values.
+// If an int64_t field is used in an array of tiny structs,
+// a substantial amount of space can be lost for alignment.
+class alignas ( 4 )Int64Align4 {
+	uint32_t parts[2];
+public:
+	operator int64_t() const {
+		return (int64_t)( ( (uint64_t)parts[0] << 32 ) | parts[1] );
+	}
+	Int64Align4 operator=( int64_t value ) {
+		parts[0] = (uint32_t)( ( (uint64_t)value >> 32 ) & 0xFFFFFFFFu );
+		parts[1] = (uint32_t)( ( (uint64_t)value >> 00 ) & 0xFFFFFFFFu );
+		return *this;
+	}
+};
+
 #endif

--- a/source/game/ai/ai_squad_based_team_brain.h
+++ b/source/game/ai/ai_squad_based_team_brain.h
@@ -112,7 +112,6 @@ protected:
 		virtual bool CheckHasShell() const override;
 		virtual float ComputeDamageToBeKilled() const override;
 		virtual void OnEnemyRemoved( const Enemy *enemy ) override;
-		virtual void TryPushNewEnemy( const edict_t *enemy, const float *suggestedOrigin ) override;
 
 		void SetBotRoleWeight( const edict_t *bot, float weight ) override;
 		float GetAdditionalEnemyWeight( const edict_t *bot, const edict_t *enemy ) const override;

--- a/source/game/ai/bot.cpp
+++ b/source/game/ai/bot.cpp
@@ -382,7 +382,7 @@ void Bot::UpdateKeptInFovPoint() {
 			lastChosenLostOrHiddenEnemyInstanceId++;
 		}
 
-		Vec3 origin( lostOrHiddenEnemy->LastSeenPosition() );
+		Vec3 origin( lostOrHiddenEnemy->LastSeenOrigin() );
 		if( !GetMiscTactics().shouldKeepXhairOnEnemy ) {
 			float distanceThreshold = 384.0f;
 			if( lostOrHiddenEnemy->ent ) {

--- a/source/game/ai/bot.h
+++ b/source/game/ai/bot.h
@@ -619,6 +619,8 @@ public:
 	SelectedMiscTactics &GetMiscTactics() { return botBrain.selectedTactics; }
 	const SelectedMiscTactics &GetMiscTactics() const { return botBrain.selectedTactics; }
 
+	const Danger *PrimaryDanger() const { return perceptionManager.PrimaryDanger(); }
+
 	inline bool WillAdvance() const { return botBrain.WillAdvance(); }
 	inline bool WillRetreat() const { return botBrain.WillRetreat(); }
 

--- a/source/game/ai/bot_brain.cpp
+++ b/source/game/ai/bot_brain.cpp
@@ -181,8 +181,9 @@ void BotBrain::UpdateSelectedEnemies() {
 	lostEnemies.Invalidate();
 	float visibleEnemyWeight = 0.0f;
 	if( const Enemy *visibleEnemy = activeEnemyPool->ChooseVisibleEnemy( self ) ) {
-		const auto &activeEnemies = activeEnemyPool->ActiveEnemies();
-		selectedEnemies.Set( visibleEnemy, targetChoicePeriod, activeEnemies.begin(), activeEnemies.end() );
+		// A compiler prefers a non-const version here, and therefore fails on non-const version of method being private
+		const auto *activeEnemiesHead = ( (const AiBaseEnemyPool *)activeEnemyPool )->ActiveEnemiesHead();
+		selectedEnemies.Set( visibleEnemy, targetChoicePeriod, activeEnemiesHead );
 		visibleEnemyWeight = 0.5f * ( visibleEnemy->AvgWeight() + visibleEnemy->MaxWeight() );
 	}
 	if( const Enemy *lostEnemy = activeEnemyPool->ChooseLostOrHiddenEnemy( self ) ) {

--- a/source/game/ai/bot_brain.h
+++ b/source/game/ai/bot_brain.h
@@ -141,6 +141,8 @@ class BotBrain : public AiBaseBrain
 		return true;
 	}
 
+	float ComputeEnemyAreasBlockingFactor( const Enemy *enemy, float damageToKillBot, int botBestWeaponTier );
+
 	void UpdateBlockedAreasStatus();
 
 	bool FindDodgeDangerSpot( const Danger &danger, vec3_t spotOrigin );

--- a/source/game/ai/bot_brain.h
+++ b/source/game/ai/bot_brain.h
@@ -185,9 +185,6 @@ protected:
 		bool CheckHasShell() const override { return ::HasShell( bot ); }
 		float ComputeDamageToBeKilled() const override { return DamageToKill( bot ); }
 		void OnEnemyRemoved( const Enemy *enemy ) override;
-		void TryPushNewEnemy( const edict_t *enemy, const float *suggestedOrigin ) override {
-			TryPushEnemyOfSingleBot( bot, enemy, suggestedOrigin );
-		}
 		void SetBotRoleWeight( const edict_t *bot_, float weight ) override {}
 		float GetAdditionalEnemyWeight( const edict_t *bot_, const edict_t *enemy ) const override { return 0; }
 		void OnBotEnemyAssigned( const edict_t *bot_, const Enemy *enemy ) override {}
@@ -233,8 +230,6 @@ public:
 	void OnNewThreat( const edict_t *newThreat, const AiFrameAwareUpdatable *threatDetector );
 	void OnEnemyRemoved( const Enemy *enemy );
 
-	inline unsigned MaxTrackedEnemies() const { return botEnemyPool.MaxTrackedEnemies(); }
-
 	void OnEnemyViewed( const edict_t *enemy );
 	void OnEnemyOriginGuessed( const edict_t *enemy, unsigned minMillisSinceLastSeen, const float *guessedOrigin = nullptr );
 
@@ -246,10 +241,10 @@ public:
 
 	// In these calls use not active but bot's own enemy pool
 	// (this behaviour is expected by callers, otherwise referring to a squad enemy pool is enough)
-	inline unsigned LastAttackedByTime( const edict_t *attacker ) const {
+	inline int64_t LastAttackedByTime( const edict_t *attacker ) const {
 		return botEnemyPool.LastAttackedByTime( attacker );
 	}
-	inline unsigned LastTargetTime( const edict_t *target ) const {
+	inline int64_t LastTargetTime( const edict_t *target ) const {
 		return botEnemyPool.LastTargetTime( target );
 	}
 

--- a/source/game/ai/bot_fire_target_cache.cpp
+++ b/source/game/ai/bot_fire_target_cache.cpp
@@ -433,7 +433,7 @@ void BotFireTargetCache::SetupCoarseFireTarget( const SelectedEnemies &selectedE
 		float weightsSum = 1.0f;
 		for( auto iter = snapshots.begin(), end = snapshots.end(); iter != end; ++iter ) {
 			const auto &snapshot = *iter;
-			unsigned timeDelta = (unsigned)( levelTime - snapshot.timestamp );
+			unsigned timeDelta = (unsigned)( levelTime - snapshot.Timestamp() );
 			// If snapshot is too outdated, stop accumulation
 			if( timeDelta > maxTimeDelta ) {
 				break;
@@ -441,12 +441,13 @@ void BotFireTargetCache::SetupCoarseFireTarget( const SelectedEnemies &selectedE
 
 			// Recent snapshots have greater weight
 			float weight = 1.0f - timeDelta * weightTimeDeltaScale;
-			const float *originData = snapshot.origin.Data();
-			const float *velocityData = snapshot.velocity.Data();
+			// We have to store these temporarily unpacked values in locals
+			Vec3 snapshotOrigin( snapshot.Origin() );
+			Vec3 snapshotVelocity( snapshot.Velocity() );
 			// Accumulate snapshot target origin using the weight
-			VectorMA( target, weight, originData, target );
+			VectorMA( target, weight, snapshotOrigin.Data(), target );
 			// Accumulate snapshot target velocity using the weight
-			VectorMA( velocity, weight, velocityData, velocity );
+			VectorMA( velocity, weight, snapshotVelocity.Data(), velocity );
 			weightsSum += weight;
 		}
 		float invWeightsSum = 1.0f / weightsSum;

--- a/source/game/ai/bot_items_selector.cpp
+++ b/source/game/ai/bot_items_selector.cpp
@@ -46,6 +46,17 @@ BotItemsSelector::ItemAndGoalWeights BotItemsSelector::ComputeItemWeights( const
 		case IT_ARMOR: return ComputeArmorWeights( item );
 		case IT_POWERUP: return ComputePowerupWeights( item );
 	}
+
+	// Collect ammo packs too.
+	// Checking an actual pack contents might sound better, but:
+	// 1) It complicates the item selection code that is likely to be reworked anyway.
+	// 2) It adds some degree of cheating (a bot knows exact pack contents in this case)
+	if( item->tag == AMMO_PACK || item->tag == AMMO_PACK_STRONG || item->tag == AMMO_PACK_WEAK ) {
+		// These weights are relatively large for this kind of item,
+		// but we guess ammo packs are valuable in gametypes where they might be dropped.
+		return ItemAndGoalWeights( 0.75f, 0.75f );
+	}
+
 	return ItemAndGoalWeights( 0, 0 );
 }
 

--- a/source/game/ai/bot_movement.cpp
+++ b/source/game/ai/bot_movement.cpp
@@ -6,6 +6,9 @@
 #ifndef PUBLIC_BUILD
 #define CHECK_ACTION_SUGGESTION_LOOPS
 #define ENABLE_MOVEMENT_ASSERTIONS
+#define CHECK_INFINITE_NEXT_STEP_LOOPS
+static int nextStepIterationsCounter = 0;
+static constexpr int NEXT_STEP_INFINITE_LOOP_THRESHOLD = 10000;
 #endif
 
 // Useful for debugging but freezes even Release version
@@ -223,8 +226,16 @@ bool BotMovementState::TestActualStatesForExpectedMask( unsigned expectedStatesM
 	// Might be set to null if verbose logging is not needed
 #ifdef ENABLE_MOVEMENT_DEBUG_OUTPUT
 	void ( *logFunc )( const char *format, ... ) = G_Printf;
+#elif defined( CHECK_INFINITE_NEXT_STEP_LOOPS )
+	void ( *logFunc )( const char *format, ... );
+	// Suppress output if the iterations counter is within a feasible range
+	if( ::nextStepIterationsCounter < NEXT_STEP_INFINITE_LOOP_THRESHOLD ) {
+		logFunc = nullptr;
+	} else {
+		logFunc = G_Printf;
+	}
 #else
-	void ( *logFunc )( const char *format, ... ) = nullptr;
+	void ( logFunc )( const char *format, ... ) = nullptr;
 #endif
 	constexpr const char *format = "BotMovementState(%s): %s %d has mismatch with the mask value\n";
 
@@ -1082,11 +1093,34 @@ void BotMovementPredictionContext::BuildPlan() {
 	this->sequenceStopReason = UNSPECIFIED;
 	this->isCompleted = false;
 	this->shouldRollback = false;
+
+#ifndef CHECK_INFINITE_NEXT_STEP_LOOPS
 	for(;; ) {
 		if( !NextPredictionStep() ) {
 			break;
 		}
 	}
+#else
+	::nextStepIterationsCounter = 0;
+	for(;; ) {
+		if( !NextPredictionStep() ) {
+			break;
+		}
+		++nextStepIterationsCounter;
+		if( nextStepIterationsCounter < NEXT_STEP_INFINITE_LOOP_THRESHOLD ) {
+			continue;
+		}
+		// An verbose output has been enabled at this stage
+		if( nextStepIterationsCounter < NEXT_STEP_INFINITE_LOOP_THRESHOLD + 200 ) {
+			continue;
+		}
+		constexpr const char *message =
+			"BotMovementPredictionContext::BuildPlan(): "
+			"an infinite NextPredictionStep() loop has been detected. "
+			"Check the server console output of last 200 steps\n";
+		G_Error( "%s", message );
+	}
+#endif
 
 	// The entity might be linked for some predicted state by Intercepted_PMoveTouchTriggers()
 	GClip_UnlinkEntity( self );
@@ -1209,7 +1243,14 @@ void BotMovementPredictionContext::NextMovementStep() {
 }
 
 void BotMovementPredictionContext::Debug( const char *format, ... ) const {
-#ifdef ENABLE_MOVEMENT_DEBUG_OUTPUT
+#if ( defined( ENABLE_MOVEMENT_DEBUG_OUTPUT ) || defined( CHECK_INFINITE_NEXT_STEP_LOOPS ) )
+// Check if there is an already detected error in this case and perform output only it the condition passes
+#if !defined( ENABLE_MOVEMENT_DEBUG_OUTPUT )
+	if( ::nextStepIterationsCounter < NEXT_STEP_INFINITE_LOOP_THRESHOLD ) {
+		return;
+	}
+#endif
+
 	char tag[64];
 	Q_snprintfz( tag, 64, "^6MovementPredictionContext(%s)", Nick( self ) );
 
@@ -1350,7 +1391,14 @@ inline BotLandOnSavedAreasMovementAction &BotBaseMovementAction::LandOnSavedArea
 }
 
 void BotBaseMovementAction::Debug( const char *format, ... ) const {
-#ifdef ENABLE_MOVEMENT_DEBUG_OUTPUT
+#if ( defined( ENABLE_MOVEMENT_DEBUG_OUTPUT ) || defined( CHECK_INFINITE_NEXT_STEP_LOOPS ) )
+// Check if there is an already detected error in this case and perform output only it the condition passes
+#if !defined( ENABLE_MOVEMENT_DEBUG_OUTPUT )
+	if( ::nextStepIterationsCounter < NEXT_STEP_INFINITE_LOOP_THRESHOLD ) {
+		return;
+	}
+#endif
+
 	char tag[128];
 	Q_snprintfz( tag, 128, "^5%s(%s)", this->Name(), Nick( self ) );
 

--- a/source/game/ai/bot_movement.cpp
+++ b/source/game/ai/bot_movement.cpp
@@ -4988,6 +4988,19 @@ void BotWalkCarefullyMovementAction::PlanPredictionStep( BotMovementPredictionCo
 	}
 }
 
+void BotWalkCarefullyMovementAction::CheckPredictionStepResults( BotMovementPredictionContext *context ) {
+	BotBaseMovementAction::CheckPredictionStepResults( context );
+	if( context->isCompleted ) {
+		return;
+	}
+
+	if( context->cannotApplyAction && context->shouldRollback ) {
+		Debug( "A prediction step has lead to rolling back, the action will be disabled for planning\n" );
+		this->isDisabledForPlanning = true;
+		return;
+	}
+}
+
 bool BotGenericRunBunnyingMovementAction::GenericCheckIsActionEnabled( BotMovementPredictionContext *context,
 																	   BotBaseMovementAction *suggestedAction ) {
 	if( !BotBaseMovementAction::GenericCheckIsActionEnabled( context, suggestedAction ) ) {

--- a/source/game/ai/bot_movement.h
+++ b/source/game/ai/bot_movement.h
@@ -1665,6 +1665,7 @@ class BotWalkCarefullyMovementAction : public BotBaseMovementAction
 public:
 	DECLARE_MOVEMENT_ACTION_CONSTRUCTOR( BotWalkCarefullyMovementAction, COLOR_RGB( 128, 0, 255 ) ) {}
 	void PlanPredictionStep( BotMovementPredictionContext *context ) override;
+	void CheckPredictionStepResults( BotMovementPredictionContext *context ) override;
 };
 
 class BotGenericRunBunnyingMovementAction : public BotBaseMovementAction

--- a/source/game/ai/bot_perception_manager.cpp
+++ b/source/game/ai/bot_perception_manager.cpp
@@ -929,9 +929,7 @@ void BotPerceptionManager::RegisterVisibleEnemies() {
 	}
 
 	StaticVector<uint16_t, MAX_CLIENTS> visibleTargets;
-	static_assert( AiBaseEnemyPool::MAX_TRACKED_ENEMIES <= MAX_CLIENTS, "targetsInPVS capacity may be exceeded" );
-
-	entitiesDetector.FilterRawEntitiesWithDistances( candidateTargets, visibleTargets, botBrain->MaxTrackedEnemies(),
+	entitiesDetector.FilterRawEntitiesWithDistances( candidateTargets, visibleTargets, MAX_CLIENTS,
 													 IsGenericEntityInPvs, IsEnemyVisible );
 
 	for( auto entNum: visibleTargets )
@@ -1179,22 +1177,6 @@ void BotPerceptionManager::HandleGenericPlayerEntityEvent( const edict_t *player
 		PushEnemyEventOrigin( player, player->s.origin );
 	}
 }
-
-// This is a compact storage for 64-bit values.
-// If an int64_t field is used in an array of tiny structs,
-// a substantial amount of space can be lost for alignment.
-class alignas ( 4 )Int64Align4 {
-	uint32_t parts[2];
-public:
-	operator int64_t() const {
-		return (int64_t)( ( (uint64_t)parts[0] << 32 ) | parts[1] );
-	}
-	Int64Align4 operator=( int64_t value ) {
-		parts[0] = (uint32_t)( ( (uint64_t)value >> 32 ) & 0xFFFFFFFFu );
-		parts[1] = (uint32_t)( ( (uint64_t)value >> 00 ) & 0xFFFFFFFFu );
-		return *this;
-	}
-};
 
 class CachedEventsToPlayersMap {
 	struct alignas ( 4 )Entry {

--- a/source/game/ai/bot_weapon_selector.cpp
+++ b/source/game/ai/bot_weapon_selector.cpp
@@ -172,7 +172,7 @@ float SelectedEnemies::ComputeThreatFactor( const edict_t *ent, int enemyNum ) c
 	// Try cutting off further expensive calls by doing this cheap test first
 	if( const auto *client = ent->r.client ) {
 		// Can't shoot soon.
-		if( client->ps.stats[STAT_WEAPON_TIME] > 500 ) {
+		if( client->ps.stats[STAT_WEAPON_TIME] > 800 ) {
 			return 0.0f;
 		}
 	}
@@ -204,6 +204,12 @@ float SelectedEnemies::ComputeThreatFactor( const edict_t *ent, int enemyNum ) c
 
 	if( ent->s.effects & ( EF_QUAD | EF_CARRIER ) ) {
 		return 1.0f;
+	}
+
+	if( const auto *danger = self->ai->botRef->PrimaryDanger() ) {
+		if( danger->attacker == ent ) {
+			return 0.5f + 0.5f * BoundedFraction( danger->damage, 75 );
+		}
 	}
 
 	// Its guaranteed that the enemy cannot hit

--- a/source/game/ai/bot_weapon_selector.h
+++ b/source/game/ai/bot_weapon_selector.h
@@ -157,8 +157,12 @@ public:
 
 	void Set( const Enemy *primaryEnemy_,
 			  unsigned timeoutPeriod,
-			  const Enemy *const *activeEnemiesBegin,
-			  const Enemy *const *activeEnemiesEnd );
+			  const Enemy **activeEnemiesBegin,
+			  const Enemy **activeEnemiesEnd );
+
+	void Set( const Enemy *primaryEnemy_,
+			  unsigned timeoutPeriod,
+			  const Enemy *firstActiveEnemy );
 
 	inline unsigned InstanceId() const { return instanceId; }
 
@@ -172,7 +176,7 @@ public:
 
 	Vec3 LastSeenOrigin() const {
 		CheckValid( __FUNCTION__ );
-		return primaryEnemy->LastSeenPosition();
+		return primaryEnemy->LastSeenOrigin();
 	}
 
 	Vec3 ActualOrigin() const {


### PR DESCRIPTION
1) This patch re-adds blocking regions occupied by enemies, so bots should no longer try rush through enemies. The newly added approach should cause much less goal jitter compared to the old temporarily disabled one. This is an example: https://webmshare.com/z4Bxz, areas around me became disabled for a bot after getting a quad (these areas are updated since a bot can guess enemy origin from incoming projectiles). **WARNING:** This patch has not been launched/tested within the upstream code. Also I have witnessed another "denormalized dir" assertion triggering while testing it, but have not managed to reproduce it.

2) Currently bots stop moving if predictable/a-priori feasible movement actions fail, and there is no fallback (I have disabled following a nearest AAS reachability as it leads to infinite looping sometimes even while walking on 100ups). Thats why I have investigated using Recast/Detour (rather small but truly high-tech navigation library distributed under zlib license terms) for fallback movement (yes, it is not volumetric and usable only for walking) when AAS environment around a bot is a junk. These AAS faces https://webmshare.com/3Xy53 are ready to be fed as input to this library (though supplying an actual collision geometry would be better, but it requires its reconstruction). Moreover I have already managed to build Detour data from AAS faces and run queries for nearest polys/polys in radius/paths from poly to an arbitrary poly successfully (that code is in my local repo), and will try using that for the actual fallback movement.