### PR TITLE
Do not force team models to the local player

### DIFF
--- a/source/cgame/cg_teams.cpp
+++ b/source/cgame/cg_teams.cpp
@@ -159,10 +159,10 @@ bool CG_PModelForCentity( centity_t *cent, pmodelinfo_t **pmodelinfo, struct ski
 	}
 
 	if( GS_CanForceModels() && ( ownerNum < ( unsigned )( gs.maxclients + 1 ) ) ) {
-		if( ( team == TEAM_ALPHA ) || ( team == TEAM_BETA ) ||
+		if( ( ( team == TEAM_ALPHA ) || ( team == TEAM_BETA ) || ( team == TEAM_PLAYERS ) ) &&
 
-		    // Don't force the model for the local player in non-team modes to distinguish the sounds from enemies'
-			( ( team == TEAM_PLAYERS ) && ( ( ownerNum != cgs.playerNum + 1 ) ) ) ) {
+		    // Don't force the model for the local player
+			( ( ownerNum != cgs.playerNum + 1 ) ) ) {
 			if( cgs.teamModelInfo[team] ) {
 				// There is a force model for this team
 				if( pmodelinfo ) {


### PR DESCRIPTION
This commit extends Triang3l's commit - https://github.com/Qfusion/qfusion/commit/b63aab3a5270280eced973b7e5fcfbc5ae576340#diff-d4dd3494cfffd8f5ed55135306b1174d, and disables forcing model for local player for Alpha/Beta teams too.

Before:
- Local player has Viciious
- Alpha/Beta have forced Padpork
- In result local player gets Padpork

After:
- Local player has Vicious
- Alpha/Beta have forced Padpork
- In result local player gets Viciious, only color is applied from Alpha/Beta