### PR TITLE
Make rgbgen and tcmod behave like Q3A

### DIFF
--- a/source/ref_gl/r_backend_program.c
+++ b/source/ref_gl/r_backend_program.c
@@ -335,7 +335,7 @@ void RB_GetShaderpassColor( const shaderpass_t *pass, byte_vec4_t rgba_, float *
 					temp = rb.currentShaderTime * rgbgenfunc->args[3] + rgbgenfunc->args[2];
 					temp = FTABLE_EVALUATE( table, temp ) * rgbgenfunc->args[1] + rgbgenfunc->args[0];
 				}
-				temp = temp * rgbgenfunc->args[1] + rgbgenfunc->args[0];
+				temp = temp * ((rgbgenfunc->args[1] + rgbgenfunc->args[0])-0.5)*2;
 			}
 
 			if( pass->rgbgen.type == RGB_GEN_ENTITYWAVE ) {


### PR DESCRIPTION
QFusion's rgbgen makes Q3 bouncepads look funny, so here's a fix